### PR TITLE
fix: resolve Windows path separator compatibility

### DIFF
--- a/generate-md.mjs
+++ b/generate-md.mjs
@@ -7,10 +7,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 // Define all paths relative to the current file
-const entryPointsPath = resolve(__dirname, "./webpack/types.d.ts");
-const tsconfigPath = resolve(__dirname, "./tsconfig.json");
-const dockitTheme = resolve(__dirname, "./plugins/theme/index.mjs");
-const consolidationPlugin = resolve(__dirname, "./plugins/consolidation.mjs");
+const entryPointsPath = resolve(__dirname, "./webpack/types.d.ts").replace(/\\/g, '/');
+const tsconfigPath = resolve(__dirname, "./tsconfig.json").replace(/\\/g, '/');
+const dockitTheme = resolve(__dirname, "./plugins/theme/index.mjs").replace(/\\/g, '/');
+const consolidationPlugin = resolve(__dirname, "./plugins/consolidation.mjs").replace(/\\/g, '/');
 
 Application.bootstrapWithPlugins({
   entryPoints: [entryPointsPath],


### PR DESCRIPTION
TypeDoc does not support **Windows-style backslash path separators** in glob patterns. This fix adds `.replace(/\\/g, '/') `to all resolved paths in `generate-md.mjs`, converting them to forward slashes before being passed to TypeDoc.
This fix is cross-platform safe — on Mac/Linux no backslashes exist so the replace does nothing. 
**Tested and working on Windows 11**.