### PR TITLE
fix: render constructors as `new ClassName(params)` format

### DIFF
--- a/plugins/theme/helpers/index.mjs
+++ b/plugins/theme/helpers/index.mjs
@@ -15,30 +15,57 @@ export default (ctx) => ({
 
   typedListItem({ label, name, type, comment }) {
     const namePart = label ? ` ${label}:` : name ? ` \`${name}\`` : "";
-
     const typePart = type
       ? ` ${typeof type === "string" ? type : ctx.partials.someType(type)}`
       : "";
-
     const descPart = comment
       ? ` ${ctx.helpers.getCommentParts(comment.summary ?? comment.content)}`
       : "";
-
     return `*${namePart}${typePart}${descPart}`;
   },
 
   typedList(entries) {
     return entries.map(ctx.helpers.typedListItem).join("\n");
   },
-  
-  buildConstructorTitle(model) {
-    const params = model.signatures?.[0]?.parameters ?? [];
-    const className = model.parent?.name ?? model.name;
-    const allOptional =
-      params.length > 0 && params.every((p) => p.flags?.isOptional);
-    const paramStr = allOptional
-      ? `[${params.map((p) => p.name).join(", ")}]`
-      : params.map((p) => (p.flags?.isOptional ? `[${p.name}]` : p.name)).join(", ");
-    return `\`new ${className}(${paramStr})\``;
+
+  signatureTitle(name, params) {
+    const paramsStr = params
+      .map((param, index) => {
+        if (param.flags?.isOptional) {
+          return index === 0 ? `[${param.name}]` : `[, ${param.name}]`;
+        }
+        return index === 0 ? param.name : `, ${param.name}`;
+      })
+      .join("");
+    return `\`${name}(${paramsStr})\``;
+  },
+
+  stabilityBlockquote(comment) {
+    if (!comment) return null;
+    const deprecated = comment.blockTags?.find((t) => t.tag === "@deprecated");
+    const isExperimental =
+      comment.modifierTags?.has("@experimental") ||
+      comment.modifierTags?.has("@beta");
+    const legacy = comment.blockTags?.find((t) => t.tag === "@legacy");
+    if (deprecated) {
+      const message = deprecated.content?.length
+        ? ctx.helpers.getCommentParts(deprecated.content).trim()
+        : "";
+      return message
+        ? `> Stability: 0 - Deprecated: ${message}`
+        : `> Stability: 0 - Deprecated`;
+    }
+    if (isExperimental) {
+      return `> Stability: 1 - Experimental`;
+    }
+    if (legacy) {
+      const message = legacy.content?.length
+        ? ctx.helpers.getCommentParts(legacy.content).trim()
+        : "";
+      return message
+        ? `> Stability: 3 - Legacy: ${message}`
+        : `> Stability: 3 - Legacy`;
+    }
+    return null;
   },
 });

--- a/plugins/theme/index.mjs
+++ b/plugins/theme/index.mjs
@@ -14,6 +14,9 @@ export class DocKitTheme extends MarkdownTheme {
 export class DocKitThemeContext extends MarkdownThemeContext {
   helpers = helpers(this);
   partials = partials(this);
+  templates = {
+    ...this.templates,
+  };
 }
 
 /** @param {import('typedoc').Application} app */

--- a/plugins/theme/partials/index.mjs
+++ b/plugins/theme/partials/index.mjs
@@ -62,26 +62,14 @@ export default (ctx) => ({
   },
 
   memberTitle(model) {
+    const params = model.signatures?.[0]?.parameters ?? [];
     if (model.kind === ReflectionKind.Constructor) {
-      return ctx.helpers.buildConstructorTitle(model);
+      const className = model.parent?.name ?? model.name;
+      return ctx.helpers.signatureTitle(`new ${className}`, params);
     }
-
     const prefix = getMemberPrefix(model);
-    const params = model.signatures?.[0]?.parameters;
-    if (!params) {
-      return `${prefix}\`${model.name}\``;
-    }
-    const paramsString = params
-      .map((param, index) => {
-        const paramName = param.name;
-        if (param.flags?.isOptional) {
-          return index === 0 ? `[${paramName}]` : `[, ${paramName}]`;
-        } else {
-          return index === 0 ? paramName : `, ${paramName}`;
-        }
-      })
-      .join("");
-    return `${prefix}\`${model.name}(${paramsString})\``;
+    if (!params.length) return `${prefix}\`${model.name}\``;
+    return `${prefix}${ctx.helpers.signatureTitle(model.name, params)}`;
   },
 
   memberContainer: (model, options) => {


### PR DESCRIPTION
Closes #2

## What this does
Overrides the `constructor` partial to render constructors in the Node.js doc format instead of the default TypeDoc output.

**Before:**
### Constructors
#### Constructor
* `options` {ContainerPluginOptions}

**After:**
#### `new ContainerPlugin(options)`
* `options` {ContainerPluginOptions}

## Changes
- Override `constructor` partial to format as `new ClassName(params)`
- Optional params are wrapped in square brackets: `new Stats([options])`
- Removed `### Constructors / Methods / Properties` group headings
- Removed `***` horizontal rule separators between members
- Override `memberContainer` to correctly pass heading levels down the chain