### PR TITLE
fix: add stability blockquotes for @deprecated/@experimental/@legacy tags

### DIFF
--- a/plugins/theme/helpers/index.mjs
+++ b/plugins/theme/helpers/index.mjs
@@ -30,4 +30,33 @@ export default (ctx) => ({
   typedList(entries) {
     return entries.map(ctx.helpers.typedListItem).join("\n");
   },
+  stabilityBlockquote(comment) {
+    if (!comment) return null;
+    const deprecated = comment.blockTags?.find((t) => t.tag === "@deprecated");
+    const isExperimental =
+      comment.modifierTags?.has("@experimental") ||
+      comment.modifierTags?.has("@beta");
+    const legacy = comment.blockTags?.find((t) => t.tag === "@legacy");
+
+    if (deprecated) {
+      const message = deprecated.content?.length
+        ? ctx.helpers.getCommentParts(deprecated.content).trim()
+        : "";
+      return message
+        ? `> Stability: 0 - Deprecated: ${message}`
+        : `> Stability: 0 - Deprecated`;
+    }
+    if (isExperimental) {
+      return `> Stability: 1 - Experimental`;
+    }
+    if (legacy) {
+      const message = legacy.content?.length
+        ? ctx.helpers.getCommentParts(legacy.content).trim()
+        : "";
+      return message
+        ? `> Stability: 3 - Legacy: ${message}`
+        : `> Stability: 3 - Legacy`;
+    }
+    return null;
+  },
 });

--- a/plugins/theme/partials/index.mjs
+++ b/plugins/theme/partials/index.mjs
@@ -36,35 +36,7 @@ export default (ctx) => ({
       ? model.comment
       : model.comment || model.parent?.comment;
 
-    // Stability blockquote
-    const stability = (() => {
-      if (!comment) return null;
-      const deprecated = comment.blockTags?.find((t) => t.tag === "@deprecated");
-      const experimental =
-        comment.blockTags?.find((t) => t.tag === "@experimental") ??
-        comment.blockTags?.find((t) => t.tag === "@beta");
-      const legacy = comment.blockTags?.find((t) => t.tag === "@legacy");
-
-      if (deprecated) {
-        const desc = deprecated.content?.length
-          ? ctx.helpers.getCommentParts(deprecated.content)
-          : "Deprecated";
-        return `> Stability: 0 - Deprecated: ${desc}`;
-      }
-      if (experimental) {
-        const desc = experimental.content?.length
-          ? `: ${ctx.helpers.getCommentParts(experimental.content)}`
-          : "";
-        return `> Stability: 1 - Experimental${desc}`;
-      }
-      if (legacy) {
-        const desc = legacy.content?.length
-          ? `: ${ctx.helpers.getCommentParts(legacy.content)}`
-          : "";
-        return `> Stability: 3 - Legacy${desc}`;
-      }
-      return null;
-    })();
+    const stability = ctx.helpers.stabilityBlockquote(comment);
 
     return [
       stability,
@@ -85,6 +57,7 @@ export default (ctx) => ({
       comment &&
         ctx.partials.comment(comment, {
           headingLevel: options.headingLevel,
+          showTags: false,  // ← prevents duplicate ###### Deprecated
         }),
     ]
       .filter((x) => (typeof x === "string" ? x : Boolean(x)))


### PR DESCRIPTION
Closes #8

## What this does
Adds Node.js-style stability blockquotes for JSDoc stability tags in the theme's `signature` partial.

| Tag | Output |
|-----|--------|
| `@deprecated` | `> Stability: 0 - Deprecated[: message]` |
| `@experimental` / `@beta` | `> Stability: 1 - Experimental` |
| `@legacy` | `> Stability: 3 - Legacy[: message]` |
| (no tag) | nothing emitted |

## Changes
- `helpers/index.mjs` — adds `stabilityBlockquote(comment)` helper that inspects a TypeDoc `Comment` and returns the appropriate blockquote or `null`
- `partials/index.mjs` — updates `signature()` to call the helper and adds `showTags: false` to prevent TypeDoc from also rendering a duplicate `###### Deprecated` heading

## Before / After

**Before:**
`clearChunkGraphForChunk(chunk)`
 - `chunk `{Chunk}
 - Returns: {void}
 - 
**After:**
`clearChunkGraphForChunk(chunk)`

Stability: 0 - Deprecated

`chunk `{Chunk}
 - Returns: {void}
 
**Use of AI:** Parts of this implementation were developed with Claude (AI assistant) as a coding tool. Every line was personally reviewed, tested, and understood before committing. Complies with the [webpack AI policy](https://github.com/webpack/governance/blob/main/AI_POLICY.md).