### PR TITLE
feat: generate YAML metadata blocks for deprecated APIs

### DIFF
--- a/pages/v5.x/globals.md
+++ b/pages/v5.x/globals.md
@@ -320,6 +320,10 @@ After this method has succeeded the cache can only be restored when build depend
 
 #### `getChunkMaps(realHash)`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `realHash` {boolean}
@@ -915,6 +919,10 @@ After this method has succeeded the cache can only be restored when build depend
 
 #### Static method: `clearChunkGraphForChunk(chunk)`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `chunk` {Chunk}
@@ -922,12 +930,20 @@ After this method has succeeded the cache can only be restored when build depend
 
 #### Static method: `clearChunkGraphForModule(module)`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `module` {Module}
 * Returns: {void}
 
 #### Static method: `getChunkGraphForChunk(chunk, deprecateMessage, deprecationCode)`
+
+<!-- YAML
+deprecated: true
+-->
 
 > Stability: 0 - Deprecated
 
@@ -938,6 +954,10 @@ After this method has succeeded the cache can only be restored when build depend
 
 #### Static method: `getChunkGraphForModule(module, deprecateMessage, deprecationCode)`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `module` {Module}
@@ -947,6 +967,10 @@ After this method has succeeded the cache can only be restored when build depend
 
 #### Static method: `setChunkGraphForChunk(chunk, chunkGraph)`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `chunk` {Chunk}
@@ -954,6 +978,10 @@ After this method has succeeded the cache can only be restored when build depend
 * Returns: {void}
 
 #### Static method: `setChunkGraphForModule(module, chunkGraph)`
+
+<!-- YAML
+deprecated: true
+-->
 
 > Stability: 0 - Deprecated
 
@@ -1439,6 +1467,10 @@ If `module` is passed, `loc` and `request` must also be passed.
 * Returns: {void}
 
 #### `assignDepth(module)`
+
+<!-- YAML
+deprecated: true
+-->
 
 > Stability: 0 - Deprecated
 
@@ -2140,6 +2172,10 @@ Returns the exported names
 implement this method to allow the occurrence order plugin to count correctly
 
 #### `getReference(moduleGraph)`
+
+<!-- YAML
+deprecated: true
+-->
 
 > Stability: 0 - Deprecated
 
@@ -2975,6 +3011,10 @@ This data will be passed to restoreFromUnsafeCache later.
 
 #### `needRebuild(fileTimestamps, contextTimestamps)`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `fileTimestamps` {Map}
@@ -3022,6 +3062,10 @@ restore unsafe cache data
 
 #### `source(dependencyTemplates, runtimeTemplate[, type])`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `dependencyTemplates` {DependencyTemplates}
@@ -3046,7 +3090,16 @@ and properties.
 * `context` {UpdateHashContextDependency}
 * Returns: {void}
 
+#### Static method: `getCompilationHooks(compilation)`
+
+* `compilation` {Compilation}
+* Returns: {ExternalModuleHooks}
+
 #### Static method: `getSourceBasicTypes(module)`
+
+<!-- YAML
+deprecated: true
+-->
 
 > Stability: 0 - Deprecated
 
@@ -3259,6 +3312,10 @@ Apply the plugin
 * Returns: {ChunkChildOfTypeInOrder[]}
 
 #### `getChunkMaps(realHash)`
+
+<!-- YAML
+deprecated: true
+-->
 
 > Stability: 0 - Deprecated
 
@@ -3970,6 +4027,10 @@ This data will be passed to restoreFromUnsafeCache later.
 
 #### `needRebuild(fileTimestamps, contextTimestamps)`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `fileTimestamps` {Map}
@@ -4009,6 +4070,10 @@ Use needBuild instead
 
 #### `source(dependencyTemplates, runtimeTemplate[, type])`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `dependencyTemplates` {DependencyTemplates}
@@ -4034,6 +4099,10 @@ and properties.
 * Returns: {void}
 
 #### Static method: `getSourceBasicTypes(module)`
+
+<!-- YAML
+deprecated: true
+-->
 
 > Stability: 0 - Deprecated
 
@@ -4409,12 +4478,20 @@ In webpack 6, call getSourceBasicTypes() directly on the module instance instead
 
 #### Static method: `clearModuleGraphForModule(module)`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `module` {Module}
 * Returns: {void}
 
 #### Static method: `getModuleGraphForModule(module, deprecateMessage, deprecationCode)`
+
+<!-- YAML
+deprecated: true
+-->
 
 > Stability: 0 - Deprecated
 
@@ -4424,6 +4501,10 @@ In webpack 6, call getSourceBasicTypes() directly on the module instance instead
 * Returns: {ModuleGraph}
 
 #### Static method: `setModuleGraphForModule(module, moduleGraph)`
+
+<!-- YAML
+deprecated: true
+-->
 
 > Stability: 0 - Deprecated
 
@@ -4546,6 +4627,10 @@ In webpack 6, call getSourceBasicTypes() directly on the module instance instead
 * Returns: {void}
 
 #### `runWithDependencies(compilers, fn, callback)`
+
+<!-- YAML
+deprecated: true
+-->
 
 > Stability: 0 - Deprecated
 
@@ -4964,6 +5049,10 @@ This data will be passed to restoreFromUnsafeCache later.
 
 #### `needRebuild(fileTimestamps, contextTimestamps)`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `fileTimestamps` {Map}
@@ -5017,6 +5106,10 @@ restore unsafe cache data
 
 #### `source(dependencyTemplates, runtimeTemplate[, type])`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `dependencyTemplates` {DependencyTemplates}
@@ -5052,6 +5145,10 @@ and properties.
 * Returns: {NormalModuleCompilationHooks}
 
 #### Static method: `getSourceBasicTypes(module)`
+
+<!-- YAML
+deprecated: true
+-->
 
 > Stability: 0 - Deprecated
 
@@ -5625,6 +5722,10 @@ This data will be passed to restoreFromUnsafeCache later.
 
 #### `needRebuild(fileTimestamps, contextTimestamps)`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `fileTimestamps` {Map}
@@ -5668,6 +5769,10 @@ Use needBuild instead
 
 #### `source(dependencyTemplates, runtimeTemplate[, type])`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `dependencyTemplates` {DependencyTemplates}
@@ -5693,6 +5798,10 @@ and properties.
 * Returns: {void}
 
 #### Static method: `getSourceBasicTypes(module)`
+
+<!-- YAML
+deprecated: true
+-->
 
 > Stability: 0 - Deprecated
 

--- a/pages/v5.x/webpack/namespaces/dependencies.md
+++ b/pages/v5.x/webpack/namespaces/dependencies.md
@@ -84,6 +84,10 @@ implement this method to allow the occurrence order plugin to count correctly
 
 #### `getReference(moduleGraph)`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `moduleGraph` {ModuleGraph}
@@ -251,6 +255,10 @@ implement this method to allow the occurrence order plugin to count correctly
 
 #### `getReference(moduleGraph)`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `moduleGraph` {ModuleGraph}
@@ -393,6 +401,10 @@ implement this method to allow the occurrence order plugin to count correctly
 
 #### `getReference(moduleGraph)`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `moduleGraph` {ModuleGraph}
@@ -528,6 +540,10 @@ Returns the exported names
 implement this method to allow the occurrence order plugin to count correctly
 
 #### `getReference(moduleGraph)`
+
+<!-- YAML
+deprecated: true
+-->
 
 > Stability: 0 - Deprecated
 

--- a/pages/v5.x/webpack/namespaces/esm.md
+++ b/pages/v5.x/webpack/namespaces/esm.md
@@ -309,6 +309,10 @@ This data will be passed to restoreFromUnsafeCache later.
 
 #### `needRebuild(fileTimestamps, contextTimestamps)`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `fileTimestamps` {Map}
@@ -352,6 +356,10 @@ Use needBuild instead
 
 #### `source(dependencyTemplates, runtimeTemplate[, type])`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `dependencyTemplates` {DependencyTemplates}
@@ -382,6 +390,10 @@ and properties.
 * Returns: {JsonpCompilationPluginHooks}
 
 #### Static method: `getSourceBasicTypes(module)`
+
+<!-- YAML
+deprecated: true
+-->
 
 > Stability: 0 - Deprecated
 

--- a/pages/v5.x/webpack/namespaces/javascript.md
+++ b/pages/v5.x/webpack/namespaces/javascript.md
@@ -353,6 +353,10 @@ Block pre walking iterates the scope for block variable declarations
 
 #### `inScope(params, fn)`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `params` {string|Identifier|Property|MemberExpression|ObjectPattern|ArrayPattern|RestElement|AssignmentPattern[]}

--- a/pages/v5.x/webpack/namespaces/runtime.md
+++ b/pages/v5.x/webpack/namespaces/runtime.md
@@ -317,6 +317,10 @@ This data will be passed to restoreFromUnsafeCache later.
 
 #### `needRebuild(fileTimestamps, contextTimestamps)`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `fileTimestamps` {Map}
@@ -360,6 +364,10 @@ Use needBuild instead
 
 #### `source(dependencyTemplates, runtimeTemplate[, type])`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `dependencyTemplates` {DependencyTemplates}
@@ -385,6 +393,10 @@ and properties.
 * Returns: {void}
 
 #### Static method: `getSourceBasicTypes(module)`
+
+<!-- YAML
+deprecated: true
+-->
 
 > Stability: 0 - Deprecated
 
@@ -705,6 +717,10 @@ This data will be passed to restoreFromUnsafeCache later.
 
 #### `needRebuild(fileTimestamps, contextTimestamps)`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `fileTimestamps` {Map}
@@ -748,6 +764,10 @@ Use needBuild instead
 
 #### `source(dependencyTemplates, runtimeTemplate[, type])`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `dependencyTemplates` {DependencyTemplates}
@@ -778,6 +798,10 @@ and properties.
 * Returns: {LoadScriptCompilationHooks}
 
 #### Static method: `getSourceBasicTypes(module)`
+
+<!-- YAML
+deprecated: true
+-->
 
 > Stability: 0 - Deprecated
 

--- a/pages/v5.x/webpack/namespaces/web.md
+++ b/pages/v5.x/webpack/namespaces/web.md
@@ -309,6 +309,10 @@ This data will be passed to restoreFromUnsafeCache later.
 
 #### `needRebuild(fileTimestamps, contextTimestamps)`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `fileTimestamps` {Map}
@@ -352,6 +356,10 @@ Use needBuild instead
 
 #### `source(dependencyTemplates, runtimeTemplate[, type])`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `dependencyTemplates` {DependencyTemplates}
@@ -382,6 +390,10 @@ and properties.
 * Returns: {CssLoadingRuntimeModulePluginHooks}
 
 #### Static method: `getSourceBasicTypes(module)`
+
+<!-- YAML
+deprecated: true
+-->
 
 > Stability: 0 - Deprecated
 
@@ -744,6 +756,10 @@ This data will be passed to restoreFromUnsafeCache later.
 
 #### `needRebuild(fileTimestamps, contextTimestamps)`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `fileTimestamps` {Map}
@@ -787,6 +803,10 @@ Use needBuild instead
 
 #### `source(dependencyTemplates, runtimeTemplate[, type])`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `dependencyTemplates` {DependencyTemplates}
@@ -818,6 +838,10 @@ and properties.
 
 #### Static method: `getSourceBasicTypes(module)`
 
+<!-- YAML
+deprecated: true
+-->
+
 > Stability: 0 - Deprecated
 
 * `module` {Module}
@@ -845,6 +869,10 @@ In webpack 6, call getSourceBasicTypes() directly on the module instance instead
 Apply the plugin
 
 #### Static method: `getCompilationHooks(compilation)`
+
+<!-- YAML
+deprecated: true
+-->
 
 > Stability: 0 - Deprecated
 

--- a/plugins/theme/helpers/index.mjs
+++ b/plugins/theme/helpers/index.mjs
@@ -64,4 +64,13 @@ export default (ctx) => ({
 
     return null;
   },
+  yamlBlock(comment) {
+    if (!comment) return null;
+    const lines = [];
+    if (comment.blockTags?.find((t) => t.tag === "@deprecated")) {
+      lines.push("deprecated: true");
+    }
+    if (!lines.length) return null;
+    return `<!-- YAML\n${lines.join("\n")}\n-->`;
+  },
 });

--- a/plugins/theme/partials/index.mjs
+++ b/plugins/theme/partials/index.mjs
@@ -36,9 +36,12 @@ export default (ctx) => ({
       ? model.comment
       : model.comment || model.parent?.comment;
 
+    const yaml = ctx.helpers.yamlBlock(comment);
     const stability = ctx.helpers.stabilityBlockquote(comment);
 
     return [
+      yaml,
+      yaml && "",
       stability,
       stability && "",
       model.typeParameters?.length &&


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
Closes: #4 

**Summary**
This PR adds YAML metadata block generation to the custom TypeDoc theme for APIs marked with `@deprecated` in webpack's `types.d.ts`.

**What's not included**
- `added`/`since` — webpack types don't have `@since` annotations
- `changes` — no changelog annotations in webpack types
- Properties — YAML blocks only apply to methods/functions since properties are rendered as a flat list with no per-item headings


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feat

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**
no

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**
no

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**
used sonet 4.6 for discussing

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->