### PR TITLE
feat(theme): render @example JSDoc tags in member bodies

### DIFF
--- a/plugins/theme/helpers/index.mjs
+++ b/plugins/theme/helpers/index.mjs
@@ -31,6 +31,22 @@ export default (ctx) => ({
     return entries.map(ctx.helpers.typedListItem).join("\n");
   },
 
+  renderExamples(comment, headingLevel) {
+    const examples =
+      comment?.blockTags?.filter((t) => t.tag === "@example") ?? [];
+    if (!examples.length) return null;
+
+    const prefix = "#".repeat(headingLevel + 1);
+    return examples
+      .map((tag, index) => {
+        const heading = `${prefix} Example${examples.length > 1 ? ` ${index + 1}` : ""}`;
+        const body = ctx.helpers.getCommentParts(tag.content).trim();
+        return body ? `${heading}\n\n${body}` : null;
+      })
+      .filter(Boolean)
+      .join("\n\n");
+  },
+
   stabilityBlockquote(comment) {
     if (!comment) return null;
 

--- a/plugins/theme/partials/index.mjs
+++ b/plugins/theme/partials/index.mjs
@@ -60,6 +60,7 @@ export default (ctx) => ({
           headingLevel: options.headingLevel,
           showTags: false,
         }),
+      ctx.helpers.renderExamples(comment, options.headingLevel),
     ]
       .filter((x) => typeof x === "string" || Boolean(x))
       .join("\n");


### PR DESCRIPTION
Summary
Adds support for rendering @example JSDoc tags in generated member bodies and previously these tags were silently dropped. As of now they appear as headed sections after the member description, following the same patterns already used for @deprecated and @returns.

Closes #5.

What kind of change does this PR introduce?
Feature - which renders @example JSDoc tags in generated member bodies.

Did you add tests for your changes?
No. But verified manually by adding an @example tag to webpack/types.d.ts, running npm run generate-docs, and confirming the output in pages/v5.x.

Does this PR introduce a breaking change?
No only members with @example tags are affected rest all existing output is unchanged.

If relevant, what needs to be documented once your changes are merged or what have you already documented?
No documentation needed.

Use of AI
No