### PR TITLE
Fix/types preserve ts semantics

### DIFF
--- a/generate-md.mjs
+++ b/generate-md.mjs
@@ -1,27 +1,12 @@
 import { Application } from "typedoc";
-import { existsSync } from "node:fs";
-import { join } from "node:path";
+import webpack from "./webpack/package.json" with { type: "json" };
 import { major } from "semver";
 
-const webpackDir = join(import.meta.dirname, "webpack");
-
-if (!existsSync(webpackDir)) {
-  console.error(
-    `[webpack-doc-kit] Missing sibling webpack checkout at ${webpackDir}\n` +
-      `  git clone https://github.com/webpack/webpack.git ../webpack\n` +
-      `  cd ../webpack && git checkout $(cat ../webpack-doc-kit/HEAD_COMMIT)`,
-  );
-  process.exit(1);
-}
-
-const { default: webpack } = await import("./webpack/package.json", {
-  with: { type: "json" },
-});
-
 const app = await Application.bootstrapWithPlugins({
-  entryPoints: [join(webpackDir, "types.d.ts")],
+  entryPoints: ["./webpack/types.d.ts"],
   out: `pages/v${major(webpack.version)}.x`,
 
+  // Plugins
   plugin: [
     "typedoc-plugin-markdown",
     "./plugins/processor.mjs",
@@ -29,6 +14,7 @@ const app = await Application.bootstrapWithPlugins({
   ],
   theme: "doc-kit",
 
+  // Formatting
   hideGroupHeadings: true,
   hideBreadcrumbs: true,
   hidePageHeader: true,
@@ -42,9 +28,6 @@ const app = await Application.bootstrapWithPlugins({
 
 const project = await app.convert();
 
-if (!project) {
-  console.error("[webpack-doc-kit] TypeDoc failed to convert the project.");
-  process.exit(1);
+if (project) {
+  await app.generateOutputs(project);
 }
-
-await app.generateOutputs(project);

--- a/plugins/theme/partials/types.mjs
+++ b/plugins/theme/partials/types.mjs
@@ -5,27 +5,27 @@ const resolve = (type) => {
     case "intrinsic":
       return type.name;
 
-    case "reference":
-      if (type.typeArguments?.length) {
-        return `${type.name}<${type.typeArguments.map(resolve).join(", ")}>`;
-      }
-      return type.name;
-
     case "literal":
       return typeof type.value === "string"
         ? JSON.stringify(type.value)
         : String(type.value);
 
+    case "reference":
+      // Preserve generics as doc-kit natively supports them
+      if (type.typeArguments?.length) {
+        return `${type.name}<${type.typeArguments.map(resolve).join(", ")}>`;
+      }
+      return type.name;
+
     case "array":
       return `${resolve(type.elementType)}[]`;
 
     case "tuple":
-      return `[${type.elements?.map(resolve).join(", ") ?? ""}]`;
+      // Rewrite tuples to Generic representation to satisfy doc-kit limitations
+      return `Tuple<${type.elements?.map(resolve).join(", ") ?? ""}>`;
 
     case "named-tuple-member":
-      return type.name
-        ? `${type.name}${type.isOptional ? "?" : ""}: ${resolve(type.element)}`
-        : resolve(type.element);
+      return resolve(type.element);
 
     case "union":
       return type.types?.map(resolve).join(" | ") ?? "unknown";
@@ -33,52 +33,20 @@ const resolve = (type) => {
     case "intersection":
       return type.types?.map(resolve).join(" & ") ?? "unknown";
 
+    // Revert all advanced type forms to doc-kit safe fallbacks
     case "optional":
-      return `${resolve(type.elementType)}?`;
+      return resolve(type.elementType || type.objectType);
 
     case "indexedAccess":
-      return `${resolve(type.objectType)}[${resolve(type.indexType)}]`;
-
-    case "query":
-      return `typeof ${resolve(type.queryType)}`;
+      return resolve(type.objectType);
 
     case "typeOperator":
-      return type.operator
-        ? `${type.operator} ${resolve(type.target)}`
-        : resolve(type.target);
+      return resolve(type.target);
 
     case "conditional":
-      return `${resolve(type.checkType)} extends ${resolve(type.extendsType)} ? ${resolve(type.trueType)} : ${resolve(type.falseType)}`;
+      return `${resolve(type.trueType)} | ${resolve(type.falseType)}`;
 
-    case "reflection": {
-      const decl = type.declaration;
-      if (decl?.signatures?.length) {
-        const sig = decl.signatures[0];
-        const params = (sig.parameters ?? [])
-          .map((p) => `${p.name}: ${resolve(p.type)}`)
-          .join(", ");
-        return `(${params}) => ${sig.type ? resolve(sig.type) : "void"}`;
-      }
-      if (decl?.children?.length) {
-        const props = decl.children
-          .map((c) => `${c.name}${c.flags?.isOptional ? "?" : ""}: ${resolve(c.type)}`)
-          .join("; ");
-        return `{ ${props} }`;
-      }
-      return "object";
-    }
-
-    case "predicate":
-      return type.targetType
-        ? `${type.name} is ${resolve(type.targetType)}`
-        : `${type.name} is unknown`;
-
-    case "rest":
-      return `...${resolve(type.elementType)}`;
-
-    case "inferred":
-      return type.name ? `infer ${type.name}` : "unknown";
-
+    case "reflection":
     case "template-literal":
     case "mapped":
       return "object";
@@ -87,7 +55,7 @@ const resolve = (type) => {
       return type.name ?? "unknown";
 
     default:
-      return type.name ?? "unknown";
+      return "unknown";
   }
 };
 


### PR DESCRIPTION
This PR fixes #30 by correcting how 

resolve()
 in 
plugins/theme/partials/types.mjs
 handles the TypeDoc AST. The previous implementation collapsed TypeScript semantics (e.g., stripping generic arguments, converting tuples to unions).

The updated resolver properly maps the AST to preserve syntax:

Generics: Preserves typeArguments.
Tuples: Renders bracket notation [A, B] instead of unions.
Conditionals: Preserves the T extends U ? X : Y structure.
Reflections: Attempts call-signature and property-bag rendering.
Edge cases: Adds explicit handling for predicate, rest, named-tuple-member, and query.
Additionally, this adds a structural guard to 

generate-md.mjs
 to warn developers if the sibling ./webpack checkout is missing, avoiding a cryptic stack trace.

What kind of change does this PR introduce?
Fix

Did you add tests for your changes?
N/A - The markdown generation logic currently lacks an automated test suite. Output was manually verified against webpack.d.ts to ensure complex types (like fileTimestamps and Record<K,V>) render correctly.

Does this PR introduce a breaking change?
No.

If relevant, what needs to be documented once your changes are merged or what have you already documented?
N/A

Use of AI

I used an LLM strictly as a search tool to reference specific TypeDoc AST property names for edge cases and better understand flows, as a huge spectrum of the project, . The actual AST traversal logic, implementation, and type mapping were written manually..