### PR TITLE
fix: exit with code 1 when TypeDoc fails to convert project

### DIFF
--- a/generate-md.mjs
+++ b/generate-md.mjs
@@ -28,6 +28,9 @@ const app = await Application.bootstrapWithPlugins({
 
 const project = await app.convert();
 
-if (project) {
-  await app.generateOutputs(project);
+if (!project) {
+  app.logger.error("TypeDoc failed to convert the project. See errors above.");
+  process.exit(1);
 }
+
+await app.generateOutputs(project);


### PR DESCRIPTION

**Summary**

When `app.convert()` fails, `generate-md.mjs` exits with code 0 instead of 1. 
This means CI passes and the build pipeline continues silently even though no 
docs were generated.

Fixes this by checking if `project` is null and calling `process.exit(1)` with 
an error message through `TypeDoc's` own logger.

Closes #36 

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

No tests added. The change is a single condition check — if a test suite exists 
for generate-md.mjs I'm happy to add one.

**Does this PR introduce a breaking change?**

No. Scripts that were succeeding before will continue to succeed. Scripts that 
were silently failing will now correctly exit with code 1.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No documentation changes needed.

**Use of AI**

I used AI to help structure the issue report and PR description. The bug 
discovery, local reproduction, and fix were done by me. I verified the 
exit code behavior before and after the change on my local machine.