### PR TITLE
improve documentation readability with section dividers and headings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2560,18 +2560,6 @@
         "hast-util-to-html": "^9.0.5"
       }
     },
-    "node_modules/@shikijs/engine-javascript": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
-      "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "oniguruma-to-es": "^4.3.4"
-      }
-    },
     "node_modules/@shikijs/engine-oniguruma": {
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",

--- a/pages/v5.x/globals.md
+++ b/pages/v5.x/globals.md
@@ -29,7 +29,8 @@
 - [web](webpack/namespaces/web.md)
 - [webworker](webpack/namespaces/webworker.md)
 
-## Class: `AsyncDependenciesBlock`
+## 
+### Class: `AsyncDependenciesBlock`
 
 ### Extends
 
@@ -39,10 +40,14 @@
 
 #### `new AsyncDependenciesBlock(groupOptions[, loc][, request])`
 
+---
+### AsyncDependenciesBlock
+
 * `groupOptions` {string|GroupOptionsAsyncDependenciesBlock}
 * `loc` {SyntheticDependencyLocation|RealDependencyLocation}
 * `request` {string}
-* Returns: {AsyncDependenciesBlock}
+
+* ###Returns: {AsyncDependenciesBlock}
 
 ### Properties
 
@@ -60,77 +65,120 @@
 
 #### `addBlock(block)`
 
+---
+### addBlock
+
 * `block` {AsyncDependenciesBlock}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Adds a DependencyBlock to DependencyBlock relationship.
 This is used for when a Module has a AsyncDependencyBlock tie (for code-splitting)
 
 #### `addDependency(dependency)`
 
+---
+### addDependency
+
 * `dependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `clearDependenciesAndBlocks()`
 
-* Returns: {void}
+---
+### clearDependenciesAndBlocks
+
+* ###Returns: {void}
 
 Removes all dependencies and blocks
 
 #### `deserialize(__namedParameters)`
 
+---
+### deserialize
+
 * `__namedParameters` {ObjectDeserializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `getRootBlock()`
 
-* Returns: {DependenciesBlock}
+---
+### getRootBlock
+
+* ###Returns: {DependenciesBlock}
 
 #### `removeDependency(dependency)`
 
+---
+### removeDependency
+
 * `dependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `serialize(__namedParameters)`
 
+---
+### serialize
+
 * `__namedParameters` {ObjectSerializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `updateHash(hash, context)`
 
+---
+### updateHash
+
 * `hash` {Hash}
 * `context` {UpdateHashContextDependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## Class: `AutomaticPrefetchPlugin`
+## 
+### Class: `AutomaticPrefetchPlugin`
 
 ### Constructors
 
 #### `new AutomaticPrefetchPlugin()`
 
-* Returns: {AutomaticPrefetchPlugin}
+---
+### AutomaticPrefetchPlugin
+
+* ###Returns: {AutomaticPrefetchPlugin}
 
 ### Methods
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `BannerPlugin`
+## 
+### Class: `BannerPlugin`
 
 ### Constructors
 
 #### `new BannerPlugin(options)`
 
+---
+### BannerPlugin
+
 * `options` {BannerPluginArgument}
-* Returns: {BannerPlugin}
+
+* ###Returns: {BannerPlugin}
 
 ### Properties
 
@@ -141,20 +189,28 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `Cache`
+## 
+### Class: `Cache`
 
 ### Constructors
 
 #### `new Cache()`
 
-* Returns: {CacheClass}
+---
+### Cache
+
+* ###Returns: {CacheClass}
 
 ### Properties
 
@@ -168,50 +224,76 @@ Apply the plugin
 
 #### `beginIdle()`
 
-* Returns: {void}
+---
+### beginIdle
+
+* ###Returns: {void}
 
 #### `endIdle(callback)`
 
+---
+### endIdle
+
 * `callback` {CallbackCacheCache<void>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `get(identifier, etag, callback)`
 
+---
+### get
+
 ###### T
 
 `T`
+
 * `identifier` {string}
 * `etag` {Etag}
 * `callback` {CallbackCacheCache<T>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `shutdown(callback)`
 
+---
+### shutdown
+
 * `callback` {CallbackCacheCache<void>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `store(identifier, etag, data, callback)`
+
+---
+### store
 
 ###### T
 
 `T`
+
 * `identifier` {string}
 * `etag` {Etag}
 * `data` {T}
 * `callback` {CallbackCacheCache<void>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `storeBuildDependencies(dependencies, callback)`
 
+---
+### storeBuildDependencies
+
 * `dependencies` {Iterable<string>}
 * `callback` {CallbackCacheCache<void>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 After this method has succeeded the cache can only be restored when build dependencies are
 
 ***
 
-## Class: `Chunk`
+## 
+### Class: `Chunk`
 
 ### Extended by
 
@@ -221,9 +303,13 @@ After this method has succeeded the cache can only be restored when build depend
 
 #### `new Chunk([name][, backCompat])`
 
+---
+### Chunk
+
 * `name` {string}
 * `backCompat` {boolean}
-* Returns: {Chunk}
+
+* ###Returns: {Chunk}
 
 ### Properties
 
@@ -252,201 +338,341 @@ After this method has succeeded the cache can only be restored when build depend
 
 #### `addGroup(chunkGroup)`
 
+---
+### addGroup
+
 * `chunkGroup` {ChunkGroup}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addModule(module)`
 
+---
+### addModule
+
 * `module` {Module}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `canBeInitial()`
 
-* Returns: {boolean}
+---
+### canBeInitial
+
+* ###Returns: {boolean}
 
 #### `canBeIntegrated(otherChunk)`
 
+---
+### canBeIntegrated
+
 * `otherChunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `compareTo(otherChunk)`
 
+---
+### compareTo
+
 * `otherChunk` {Chunk}
-* Returns: {-1|0|1}
+
+* ###Returns: {-1|0|1}
 
 #### `containsModule(module)`
 
+---
+### containsModule
+
 * `module` {Module}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `disconnectFromGroups()`
 
-* Returns: {void}
+---
+### disconnectFromGroups
+
+* ###Returns: {void}
 
 #### `getAllAsyncChunks()`
 
-* Returns: {Set<Chunk>}
+---
+### getAllAsyncChunks
+
+* ###Returns: {Set<Chunk>}
 
 #### `getAllInitialChunks()`
 
-* Returns: {Set<Chunk>}
+---
+### getAllInitialChunks
+
+* ###Returns: {Set<Chunk>}
 
 #### `getAllReferencedAsyncEntrypoints()`
 
-* Returns: {Set<Entrypoint>}
+---
+### getAllReferencedAsyncEntrypoints
+
+* ###Returns: {Set<Entrypoint>}
 
 #### `getAllReferencedChunks()`
 
-* Returns: {Set<Chunk>}
+---
+### getAllReferencedChunks
+
+* ###Returns: {Set<Chunk>}
 
 #### `getChildIdsByOrders(chunkGraph[, filterFn])`
 
+---
+### getChildIdsByOrders
+
 * `chunkGraph` {ChunkGraph}
 * `filterFn` {object}
-* Returns: {Record<string, ChunkId[]>}
+
+* ###Returns: {Record<string, ChunkId[]>}
 
 #### `getChildIdsByOrdersMap(chunkGraph[, includeDirectChildren][, filterFn])`
+
+---
+### getChildIdsByOrdersMap
 
 * `chunkGraph` {ChunkGraph}
 * `includeDirectChildren` {boolean}
 * `filterFn` {object}
-* Returns: {ChunkChildIdsByOrdersMapByData}
+
+* ###Returns: {ChunkChildIdsByOrdersMapByData}
 
 #### `getChildrenOfTypeInOrder(chunkGraph, type)`
 
+---
+### getChildrenOfTypeInOrder
+
 * `chunkGraph` {ChunkGraph}
 * `type` {string}
-* Returns: {ChunkChildOfTypeInOrder[]}
+
+* ###Returns: {ChunkChildOfTypeInOrder[]}
 
 #### `getChunkMaps(realHash)`
+
+---
+### getChunkMaps
 
 > Stability: 0 - Deprecated
 
 * `realHash` {boolean}
-* Returns: {ChunkMaps}
+
+* ###Returns: {ChunkMaps}
 
 #### `getChunkModuleMaps(filterFn)`
 
+---
+### getChunkModuleMaps
+
 * `filterFn` {object}
-* Returns: {ChunkModuleMaps}
+
+* ###Returns: {ChunkModuleMaps}
 
 #### `getEntryOptions()`
 
-* Returns: {EntryOptions}
+---
+### getEntryOptions
+
+* ###Returns: {EntryOptions}
 
 #### `getModules()`
 
-* Returns: {Module[]}
+---
+### getModules
+
+* ###Returns: {Module[]}
 
 #### `getNumberOfGroups()`
 
-* Returns: {number}
+---
+### getNumberOfGroups
+
+* ###Returns: {number}
 
 #### `getNumberOfModules()`
 
-* Returns: {number}
+---
+### getNumberOfModules
+
+* ###Returns: {number}
 
 #### `hasAsyncChunks()`
 
-* Returns: {boolean}
+---
+### hasAsyncChunks
+
+* ###Returns: {boolean}
 
 #### `hasChildByOrder(chunkGraph, type[, includeDirectChildren][, filterFn])`
+
+---
+### hasChildByOrder
 
 * `chunkGraph` {ChunkGraph}
 * `type` {string}
 * `includeDirectChildren` {boolean}
 * `filterFn` {object}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `hasEntryModule()`
 
-* Returns: {boolean}
+---
+### hasEntryModule
+
+* ###Returns: {boolean}
 
 #### `hasModuleInGraph(filterFn[, filterChunkFn])`
 
+---
+### hasModuleInGraph
+
 * `filterFn` {object}
 * `filterChunkFn` {object}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `hasRuntime()`
 
-* Returns: {boolean}
+---
+### hasRuntime
+
+* ###Returns: {boolean}
 
 #### `integrate(otherChunk)`
 
+---
+### integrate
+
 * `otherChunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `integratedSize(otherChunk, options)`
 
+---
+### integratedSize
+
 * `otherChunk` {Chunk}
 * `options` {ChunkSizeOptions}
-* Returns: {number}
+
+* ###Returns: {number}
 
 #### `isEmpty()`
 
-* Returns: {boolean}
+---
+### isEmpty
+
+* ###Returns: {boolean}
 
 #### `isInGroup(chunkGroup)`
 
+---
+### isInGroup
+
 * `chunkGroup` {ChunkGroup}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isOnlyInitial()`
 
-* Returns: {boolean}
+---
+### isOnlyInitial
+
+* ###Returns: {boolean}
 
 #### `modulesSize()`
 
-* Returns: {number}
+---
+### modulesSize
+
+* ###Returns: {number}
 
 #### `moveModule(module, otherChunk)`
 
+---
+### moveModule
+
 * `module` {Module}
 * `otherChunk` {Chunk}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `remove()`
 
-* Returns: {void}
+---
+### remove
+
+* ###Returns: {void}
 
 #### `removeGroup(chunkGroup)`
 
+---
+### removeGroup
+
 * `chunkGroup` {ChunkGroup}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `removeModule(module)`
 
+---
+### removeModule
+
 * `module` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `size([options])`
 
+---
+### size
+
 * `options` {ChunkSizeOptions}
-* Returns: {number}
+
+* ###Returns: {number}
 
 #### `split(newChunk)`
 
+---
+### split
+
 * `newChunk` {Chunk}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `updateHash(hash, chunkGraph)`
 
+---
+### updateHash
+
 * `hash` {Hash}
 * `chunkGraph` {ChunkGraph}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## Class: `ChunkGraph`
+## 
+### Class: `ChunkGraph`
 
 ### Constructors
 
 #### `new ChunkGraph(moduleGraph[, hashFunction])`
 
+---
+### ChunkGraph
+
 * `moduleGraph` {ModuleGraph}
 * `hashFunction` {HashFunction}
-* Returns: {ChunkGraph}
+
+* ###Returns: {ChunkGraph}
 
 ### Properties
 
@@ -456,514 +682,859 @@ After this method has succeeded the cache can only be restored when build depend
 
 #### `addChunkRuntimeRequirements(chunk, items)`
 
+---
+### addChunkRuntimeRequirements
+
 * `chunk` {Chunk}
 * `items` {Set<string>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addDependentHashModuleToChunk(chunk, module)`
 
+---
+### addDependentHashModuleToChunk
+
 * `chunk` {Chunk}
 * `module` {RuntimeModule}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addFullHashModuleToChunk(chunk, module)`
 
+---
+### addFullHashModuleToChunk
+
 * `chunk` {Chunk}
 * `module` {RuntimeModule}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addModuleRuntimeRequirements(module, runtime, items[, transferOwnership])`
+
+---
+### addModuleRuntimeRequirements
 
 * `module` {Module}
 * `runtime` {RuntimeSpec}
 * `items` {Set<string>}
 * `transferOwnership` {boolean}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addTreeRuntimeRequirements(chunk, items)`
 
+---
+### addTreeRuntimeRequirements
+
 * `chunk` {Chunk}
 * `items` {Iterable<string>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `attachDependentHashModules(chunk, modules)`
 
+---
+### attachDependentHashModules
+
 * `chunk` {Chunk}
 * `modules` {Iterable<RuntimeModule>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `attachFullHashModules(chunk, modules)`
 
+---
+### attachFullHashModules
+
 * `chunk` {Chunk}
 * `modules` {Iterable<RuntimeModule>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `attachModules(chunk, modules)`
 
+---
+### attachModules
+
 * `chunk` {Chunk}
 * `modules` {Iterable<Module>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `attachRuntimeModules(chunk, modules)`
 
+---
+### attachRuntimeModules
+
 * `chunk` {Chunk}
 * `modules` {Iterable<RuntimeModule>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `canChunksBeIntegrated(chunkA, chunkB)`
 
+---
+### canChunksBeIntegrated
+
 * `chunkA` {Chunk}
 * `chunkB` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `compareChunks(chunkA, chunkB)`
 
+---
+### compareChunks
+
 * `chunkA` {Chunk}
 * `chunkB` {Chunk}
-* Returns: {-1|0|1}
+
+* ###Returns: {-1|0|1}
 
 #### `connectBlockAndChunkGroup(depBlock, chunkGroup)`
 
+---
+### connectBlockAndChunkGroup
+
 * `depBlock` {AsyncDependenciesBlock}
 * `chunkGroup` {ChunkGroup}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `connectChunkAndEntryModule(chunk, module, entrypoint)`
+
+---
+### connectChunkAndEntryModule
 
 * `chunk` {Chunk}
 * `module` {Module}
 * `entrypoint` {Entrypoint}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `connectChunkAndModule(chunk, module)`
 
+---
+### connectChunkAndModule
+
 * `chunk` {Chunk}
 * `module` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `connectChunkAndRuntimeModule(chunk, module)`
 
+---
+### connectChunkAndRuntimeModule
+
 * `chunk` {Chunk}
 * `module` {RuntimeModule}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `disconnectChunk(chunk)`
 
+---
+### disconnectChunk
+
 * `chunk` {Chunk}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `disconnectChunkAndEntryModule(chunk, module)`
 
+---
+### disconnectChunkAndEntryModule
+
 * `chunk` {Chunk}
 * `module` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `disconnectChunkAndModule(chunk, module)`
 
+---
+### disconnectChunkAndModule
+
 * `chunk` {Chunk}
 * `module` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `disconnectChunkAndRuntimeModule(chunk, module)`
 
+---
+### disconnectChunkAndRuntimeModule
+
 * `chunk` {Chunk}
 * `module` {RuntimeModule}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `disconnectChunkGroup(chunkGroup)`
 
+---
+### disconnectChunkGroup
+
 * `chunkGroup` {ChunkGroup}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `disconnectEntries(chunk)`
 
+---
+### disconnectEntries
+
 * `chunk` {Chunk}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `disconnectEntryModule(module)`
 
+---
+### disconnectEntryModule
+
 * `module` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `getBlockChunkGroup(depBlock)`
 
+---
+### getBlockChunkGroup
+
 * `depBlock` {AsyncDependenciesBlock}
-* Returns: {ChunkGroup}
+
+* ###Returns: {ChunkGroup}
 
 #### `getChunkConditionMap(chunk, filterFn)`
 
+---
+### getChunkConditionMap
+
 * `chunk` {Chunk}
 * `filterFn` {object}
-* Returns: {ChunkConditionMap}
+
+* ###Returns: {ChunkConditionMap}
 
 #### `getChunkDependentHashModulesIterable(chunk)`
 
+---
+### getChunkDependentHashModulesIterable
+
 * `chunk` {Chunk}
-* Returns: {Iterable<RuntimeModule, any, any>}
+
+* ###Returns: {Iterable<RuntimeModule, any, any>}
 
 #### `getChunkEntryDependentChunksIterable(chunk)`
 
+---
+### getChunkEntryDependentChunksIterable
+
 * `chunk` {Chunk}
-* Returns: {Iterable<Chunk>}
+
+* ###Returns: {Iterable<Chunk>}
 
 #### `getChunkEntryModulesIterable(chunk)`
 
+---
+### getChunkEntryModulesIterable
+
 * `chunk` {Chunk}
-* Returns: {Iterable<Module>}
+
+* ###Returns: {Iterable<Module>}
 
 #### `getChunkEntryModulesWithChunkGroupIterable(chunk)`
 
+---
+### getChunkEntryModulesWithChunkGroupIterable
+
 * `chunk` {Chunk}
-* Returns: {Iterable<Tuple<Module, Entrypoint>>}
+
+* ###Returns: {Iterable<Tuple<Module, Entrypoint>>}
 
 #### `getChunkFullHashModulesIterable(chunk)`
 
+---
+### getChunkFullHashModulesIterable
+
 * `chunk` {Chunk}
-* Returns: {Iterable<RuntimeModule, any, any>}
+
+* ###Returns: {Iterable<RuntimeModule, any, any>}
 
 #### `getChunkFullHashModulesSet(chunk)`
 
+---
+### getChunkFullHashModulesSet
+
 * `chunk` {Chunk}
-* Returns: {ReadonlySet<RuntimeModule>}
+
+* ###Returns: {ReadonlySet<RuntimeModule>}
 
 #### `getChunkModuleIdMap(chunk, filterFn[, includeAllChunks])`
+
+---
+### getChunkModuleIdMap
 
 * `chunk` {Chunk}
 * `filterFn` {object}
 * `includeAllChunks` {boolean}
-* Returns: {ChunkModuleIdMapEs5Alias_2}
+
+* ###Returns: {ChunkModuleIdMapEs5Alias_2}
 
 #### `getChunkModuleRenderedHashMap(chunk, filterFn[, hashLength][, includeAllChunks])`
+
+---
+### getChunkModuleRenderedHashMap
 
 * `chunk` {Chunk}
 * `filterFn` {object}
 * `hashLength` {number}
 * `includeAllChunks` {boolean}
-* Returns: {ChunkModuleHashMap}
+
+* ###Returns: {ChunkModuleHashMap}
 
 #### `getChunkModules(chunk)`
 
+---
+### getChunkModules
+
 * `chunk` {Chunk}
-* Returns: {Module[]}
+
+* ###Returns: {Module[]}
 
 #### `getChunkModulesIterable(chunk)`
 
+---
+### getChunkModulesIterable
+
 * `chunk` {Chunk}
-* Returns: {Iterable<Module>}
+
+* ###Returns: {Iterable<Module>}
 
 #### `getChunkModulesIterableBySourceType(chunk, sourceType)`
 
+---
+### getChunkModulesIterableBySourceType
+
 * `chunk` {Chunk}
 * `sourceType` {string}
-* Returns: {Iterable<Module, any, any>}
+
+* ###Returns: {Iterable<Module, any, any>}
 
 #### `getChunkModuleSourceTypes(chunk, module)`
 
+---
+### getChunkModuleSourceTypes
+
 * `chunk` {Chunk}
 * `module` {Module}
-* Returns: {ReadonlySet<string>}
+
+* ###Returns: {ReadonlySet<string>}
 
 #### `getChunkModulesSize(chunk)`
 
+---
+### getChunkModulesSize
+
 * `chunk` {Chunk}
-* Returns: {number}
+
+* ###Returns: {number}
 
 #### `getChunkModulesSizes(chunk)`
 
+---
+### getChunkModulesSizes
+
 * `chunk` {Chunk}
-* Returns: {Record<string, number>}
+
+* ###Returns: {Record<string, number>}
 
 #### `getChunkRootModules(chunk)`
 
+---
+### getChunkRootModules
+
 * `chunk` {Chunk}
-* Returns: {Module[]}
+
+* ###Returns: {Module[]}
 
 #### `getChunkRuntimeModulesInOrder(chunk)`
 
+---
+### getChunkRuntimeModulesInOrder
+
 * `chunk` {Chunk}
-* Returns: {RuntimeModule[]}
+
+* ###Returns: {RuntimeModule[]}
 
 #### `getChunkRuntimeModulesIterable(chunk)`
 
+---
+### getChunkRuntimeModulesIterable
+
 * `chunk` {Chunk}
-* Returns: {Iterable<RuntimeModule>}
+
+* ###Returns: {Iterable<RuntimeModule>}
 
 #### `getChunkRuntimeRequirements(chunk)`
 
+---
+### getChunkRuntimeRequirements
+
 * `chunk` {Chunk}
-* Returns: {ReadonlySet<string>}
+
+* ###Returns: {ReadonlySet<string>}
 
 #### `getChunkSize(chunk[, options])`
 
+---
+### getChunkSize
+
 * `chunk` {Chunk}
 * `options` {ChunkSizeOptions}
-* Returns: {number}
+
+* ###Returns: {number}
 
 #### `getIntegratedChunksSize(chunkA, chunkB[, options])`
+
+---
+### getIntegratedChunksSize
 
 * `chunkA` {Chunk}
 * `chunkB` {Chunk}
 * `options` {ChunkSizeOptions}
-* Returns: {number}
+
+* ###Returns: {number}
 
 #### `getModuleChunks(module)`
 
+---
+### getModuleChunks
+
 * `module` {Module}
-* Returns: {Chunk[]}
+
+* ###Returns: {Chunk[]}
 
 #### `getModuleChunksIterable(module)`
 
+---
+### getModuleChunksIterable
+
 * `module` {Module}
-* Returns: {Iterable<Chunk>}
+
+* ###Returns: {Iterable<Chunk>}
 
 #### `getModuleGraphHash(module, runtime[, withConnections])`
 
+---
+### getModuleGraphHash
+
 * `module` {Module}
 * `runtime` {RuntimeSpec}
 * `withConnections` {boolean}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `getModuleGraphHashBigInt(module, runtime[, withConnections])`
 
+---
+### getModuleGraphHashBigInt
+
 * `module` {Module}
 * `runtime` {RuntimeSpec}
 * `withConnections` {boolean}
-* Returns: {bigint}
+
+* ###Returns: {bigint}
 
 #### `getModuleHash(module, runtime)`
 
+---
+### getModuleHash
+
 * `module` {Module}
 * `runtime` {RuntimeSpec}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `getModuleId(module)`
 
+---
+### getModuleId
+
 * `module` {Module}
-* Returns: {string|number}
+
+* ###Returns: {string|number}
 
 #### `getModuleRuntimeRequirements(module, runtime)`
 
+---
+### getModuleRuntimeRequirements
+
 * `module` {Module}
 * `runtime` {RuntimeSpec}
-* Returns: {ReadonlySet<string>}
+
+* ###Returns: {ReadonlySet<string>}
 
 #### `getModuleRuntimes(module)`
 
+---
+### getModuleRuntimes
+
 * `module` {Module}
-* Returns: {RuntimeSpecSet}
+
+* ###Returns: {RuntimeSpecSet}
 
 #### `getModuleSourceTypes(module)`
 
+---
+### getModuleSourceTypes
+
 * `module` {Module}
-* Returns: {ReadonlySet<string>}
+
+* ###Returns: {ReadonlySet<string>}
 
 #### `getNumberOfChunkFullHashModules(chunk)`
 
+---
+### getNumberOfChunkFullHashModules
+
 * `chunk` {Chunk}
-* Returns: {number}
+
+* ###Returns: {number}
 
 #### `getNumberOfChunkModules(chunk)`
 
+---
+### getNumberOfChunkModules
+
 * `chunk` {Chunk}
-* Returns: {number}
+
+* ###Returns: {number}
 
 #### `getNumberOfEntryModules(chunk)`
 
+---
+### getNumberOfEntryModules
+
 * `chunk` {Chunk}
-* Returns: {number}
+
+* ###Returns: {number}
 
 #### `getNumberOfModuleChunks(module)`
 
+---
+### getNumberOfModuleChunks
+
 * `module` {Module}
-* Returns: {number}
+
+* ###Returns: {number}
 
 #### `getNumberOfRuntimeModules(chunk)`
 
+---
+### getNumberOfRuntimeModules
+
 * `chunk` {Chunk}
-* Returns: {number}
+
+* ###Returns: {number}
 
 #### `getOrderedChunkModules(chunk, comparator)`
 
+---
+### getOrderedChunkModules
+
 * `chunk` {Chunk}
 * `comparator` {object}
-* Returns: {Module[]}
+
+* ###Returns: {Module[]}
 
 #### `getOrderedChunkModulesIterable(chunk, comparator)`
 
+---
+### getOrderedChunkModulesIterable
+
 * `chunk` {Chunk}
 * `comparator` {object}
-* Returns: {Iterable<Module>}
+
+* ###Returns: {Iterable<Module>}
 
 #### `getOrderedChunkModulesIterableBySourceType(chunk, sourceType, comparator)`
+
+---
+### getOrderedChunkModulesIterableBySourceType
 
 * `chunk` {Chunk}
 * `sourceType` {string}
 * `comparator` {object}
-* Returns: {Iterable<Module, any, any>}
+
+* ###Returns: {Iterable<Module, any, any>}
 
 #### `getOrderedModuleChunksIterable(module, sortFn)`
 
+---
+### getOrderedModuleChunksIterable
+
 * `module` {Module}
 * `sortFn` {object}
-* Returns: {Iterable<Chunk>}
+
+* ###Returns: {Iterable<Chunk>}
 
 #### `getRenderedModuleHash(module, runtime)`
 
+---
+### getRenderedModuleHash
+
 * `module` {Module}
 * `runtime` {RuntimeSpec}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `getRuntimeChunkDependentChunksIterable(chunk)`
 
+---
+### getRuntimeChunkDependentChunksIterable
+
 * `chunk` {Chunk}
-* Returns: {Iterable<Chunk>}
+
+* ###Returns: {Iterable<Chunk>}
 
 #### `getRuntimeId(runtime)`
 
+---
+### getRuntimeId
+
 * `runtime` {string}
-* Returns: {RuntimeId}
+
+* ###Returns: {RuntimeId}
 
 #### `getTreeRuntimeRequirements(chunk)`
 
+---
+### getTreeRuntimeRequirements
+
 * `chunk` {Chunk}
-* Returns: {ReadonlySet<string>}
+
+* ###Returns: {ReadonlySet<string>}
 
 #### `hasChunkEntryDependentChunks(chunk)`
 
+---
+### hasChunkEntryDependentChunks
+
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `hasModuleHashes(module, runtime)`
 
+---
+### hasModuleHashes
+
 * `module` {Module}
 * `runtime` {RuntimeSpec}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `hasModuleInGraph(chunk, filterFn[, filterChunkFn])`
+
+---
+### hasModuleInGraph
 
 * `chunk` {Chunk}
 * `filterFn` {object}
 * `filterChunkFn` {object}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `integrateChunks(chunkA, chunkB)`
 
+---
+### integrateChunks
+
 * `chunkA` {Chunk}
 * `chunkB` {Chunk}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `isEntryModule(module)`
 
+---
+### isEntryModule
+
 * `module` {Module}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isEntryModuleInChunk(module, chunk)`
 
+---
+### isEntryModuleInChunk
+
 * `module` {Module}
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isModuleInChunk(module, chunk)`
 
+---
+### isModuleInChunk
+
 * `module` {Module}
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isModuleInChunkGroup(module, chunkGroup)`
 
+---
+### isModuleInChunkGroup
+
 * `module` {Module}
 * `chunkGroup` {ChunkGroup}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `replaceModule(oldModule, newModule)`
 
+---
+### replaceModule
+
 * `oldModule` {Module}
 * `newModule` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `setChunkModuleSourceTypes(chunk, module, sourceTypes)`
+
+---
+### setChunkModuleSourceTypes
 
 * `chunk` {Chunk}
 * `module` {Module}
 * `sourceTypes` {ReadonlySet<string>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `setModuleHashes(module, runtime, hash, renderedHash)`
+
+---
+### setModuleHashes
 
 * `module` {Module}
 * `runtime` {RuntimeSpec}
 * `hash` {string}
 * `renderedHash` {string}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `setModuleId(module, id)`
 
+---
+### setModuleId
+
 * `module` {Module}
 * `id` {ModuleId}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `setRuntimeId(runtime, id)`
 
+---
+### setRuntimeId
+
 * `runtime` {string}
 * `id` {RuntimeId}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `upgradeDependentToFullHashModules(chunk)`
 
+---
+### upgradeDependentToFullHashModules
+
 * `chunk` {Chunk}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `clearChunkGraphForChunk(chunk)`
 
+---
+### clearChunkGraphForChunk
+
 > Stability: 0 - Deprecated
 
 * `chunk` {Chunk}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `clearChunkGraphForModule(module)`
 
+---
+### clearChunkGraphForModule
+
 > Stability: 0 - Deprecated
 
 * `module` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `getChunkGraphForChunk(chunk, deprecateMessage, deprecationCode)`
 
+---
+### getChunkGraphForChunk
+
 > Stability: 0 - Deprecated
 
 * `chunk` {Chunk}
 * `deprecateMessage` {string}
 * `deprecationCode` {string}
-* Returns: {ChunkGraph}
+
+* ###Returns: {ChunkGraph}
 
 #### Static method: `getChunkGraphForModule(module, deprecateMessage, deprecationCode)`
 
+---
+### getChunkGraphForModule
+
 > Stability: 0 - Deprecated
 
 * `module` {Module}
 * `deprecateMessage` {string}
 * `deprecationCode` {string}
-* Returns: {ChunkGraph}
+
+* ###Returns: {ChunkGraph}
 
 #### Static method: `setChunkGraphForChunk(chunk, chunkGraph)`
+
+---
+### setChunkGraphForChunk
 
 > Stability: 0 - Deprecated
 
 * `chunk` {Chunk}
 * `chunkGraph` {ChunkGraph}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `setChunkGraphForModule(module, chunkGraph)`
+
+---
+### setChunkGraphForModule
 
 > Stability: 0 - Deprecated
 
 * `module` {Module}
 * `chunkGraph` {ChunkGraph}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## Class: `ChunkGroup`
+## 
+### Class: `ChunkGroup`
 
 ### Extended by
 
@@ -973,7 +1544,10 @@ After this method has succeeded the cache can only be restored when build depend
 
 #### `new ChunkGroup()`
 
-* Returns: {ChunkGroup}
+---
+### ChunkGroup
+
+* ###Returns: {ChunkGroup}
 
 ### Properties
 
@@ -997,190 +1571,312 @@ sets a new name for current ChunkGroup
 
 #### `addAsyncEntrypoint(entrypoint)`
 
+---
+### addAsyncEntrypoint
+
 * `entrypoint` {Entrypoint}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `addBlock(block)`
 
+---
+### addBlock
+
 * `block` {AsyncDependenciesBlock}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `addChild(group)`
 
+---
+### addChild
+
 * `group` {ChunkGroup}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `addOptions(options)`
 
+---
+### addOptions
+
 * `options` {ChunkGroupOptions}
-* Returns: {void}
+
+* ###Returns: {void}
 
 when a new chunk is added to a chunkGroup, addingOptions will occur.
 
 #### `addOrigin(module, loc, request)`
 
+---
+### addOrigin
+
 * `module` {Module}
 * `loc` {DependencyLocation}
 * `request` {string}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addParent(parentChunk)`
 
+---
+### addParent
+
 * `parentChunk` {ChunkGroup}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `checkConstraints()`
 
-* Returns: {void}
+---
+### checkConstraints
+
+* ###Returns: {void}
 
 #### `compareTo(chunkGraph, otherGroup)`
 
+---
+### compareTo
+
 * `chunkGraph` {ChunkGraph}
 * `otherGroup` {ChunkGroup}
-* Returns: {-1|0|1}
+
+* ###Returns: {-1|0|1}
 
 Sorting predicate which allows current ChunkGroup to be compared against another.
 Sorting values are based off of number of chunks in ChunkGroup.
 
 #### `getBlocks()`
 
-* Returns: {AsyncDependenciesBlock[]}
+---
+### getBlocks
+
+* ###Returns: {AsyncDependenciesBlock[]}
 
 #### `getChildren()`
 
-* Returns: {ChunkGroup[]}
+---
+### getChildren
+
+* ###Returns: {ChunkGroup[]}
 
 #### `getChildrenByOrders(moduleGraph, chunkGraph)`
 
+---
+### getChildrenByOrders
+
 * `moduleGraph` {ModuleGraph}
 * `chunkGraph` {ChunkGraph}
-* Returns: {Record<string, ChunkGroup[]>}
+
+* ###Returns: {Record<string, ChunkGroup[]>}
 
 #### `getFiles()`
 
-* Returns: {string[]}
+---
+### getFiles
+
+* ###Returns: {string[]}
 
 #### `getModulePostOrderIndex(module)`
 
+---
+### getModulePostOrderIndex
+
 * `module` {Module}
-* Returns: {number}
+
+* ###Returns: {number}
 
 Gets the bottom-up index of a module in this ChunkGroup
 
 #### `getModulePreOrderIndex(module)`
 
+---
+### getModulePreOrderIndex
+
 * `module` {Module}
-* Returns: {number}
+
+* ###Returns: {number}
 
 Gets the top-down index of a module in this ChunkGroup
 
 #### `getNumberOfBlocks()`
 
-* Returns: {number}
+---
+### getNumberOfBlocks
+
+* ###Returns: {number}
 
 #### `getNumberOfChildren()`
 
-* Returns: {number}
+---
+### getNumberOfChildren
+
+* ###Returns: {number}
 
 #### `getNumberOfParents()`
 
-* Returns: {number}
+---
+### getNumberOfParents
+
+* ###Returns: {number}
 
 #### `getParents()`
 
-* Returns: {ChunkGroup[]}
+---
+### getParents
+
+* ###Returns: {ChunkGroup[]}
 
 #### `hasBlock(block)`
 
+---
+### hasBlock
+
 * `block` {AsyncDependenciesBlock}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `hasParent(parent)`
 
+---
+### hasParent
+
 * `parent` {ChunkGroup}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `insertChunk(chunk, before)`
 
+---
+### insertChunk
+
 * `chunk` {Chunk}
 * `before` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 inserts a chunk before another existing chunk in group
 
 #### `isInitial()`
 
-* Returns: {boolean}
+---
+### isInitial
+
+* ###Returns: {boolean}
 
 #### `pushChunk(chunk)`
 
+---
+### pushChunk
+
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 add a chunk into ChunkGroup. Is pushed on or prepended
 
 #### `remove()`
 
-* Returns: {void}
+---
+### remove
+
+* ###Returns: {void}
 
 #### `removeChild(group)`
 
+---
+### removeChild
+
 * `group` {ChunkGroup}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `removeChunk(chunk)`
 
+---
+### removeChunk
+
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `removeParent(chunkGroup)`
 
+---
+### removeParent
+
 * `chunkGroup` {ChunkGroup}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `replaceChunk(oldChunk, newChunk)`
 
+---
+### replaceChunk
+
 * `oldChunk` {Chunk}
 * `newChunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `setModulePostOrderIndex(module, index)`
 
+---
+### setModulePostOrderIndex
+
 * `module` {Module}
 * `index` {number}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Sets the bottom-up index of a module in this ChunkGroup
 
 #### `setModulePreOrderIndex(module, index)`
 
+---
+### setModulePreOrderIndex
+
 * `module` {Module}
 * `index` {number}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Sets the top-down index of a module in this ChunkGroup
 
 #### `sortItems()`
 
-* Returns: {void}
+---
+### sortItems
+
+* ###Returns: {void}
 
 #### `unshiftChunk(chunk)`
 
+---
+### unshiftChunk
+
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 Performs an unshift of a specific chunk
 
 ***
 
-## Class: `CleanPlugin`
+## 
+### Class: `CleanPlugin`
 
 ### Constructors
 
 #### `new CleanPlugin([options])`
 
+---
+### CleanPlugin
+
 * `options` {CleanOptions}
-* Returns: {CleanPlugin}
+
+* ###Returns: {CleanPlugin}
 
 ### Properties
 
@@ -1190,25 +1886,37 @@ Performs an unshift of a specific chunk
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 #### Static method: `getCompilationHooks(compilation)`
 
+---
+### getCompilationHooks
+
 * `compilation` {Compilation}
-* Returns: {CleanPluginCompilationHooks}
+
+* ###Returns: {CleanPluginCompilationHooks}
 
 ***
 
-## Class: `CodeGenerationResults`
+## 
+### Class: `CodeGenerationResults`
 
 ### Constructors
 
 #### `new CodeGenerationResults()`
 
-* Returns: {CodeGenerationResults}
+---
+### CodeGenerationResults
+
+* ###Returns: {CodeGenerationResults}
 
 ### Properties
 
@@ -1218,60 +1926,93 @@ Apply the plugin
 
 #### `add(module, runtime, result)`
 
+---
+### add
+
 * `module` {Module}
 * `runtime` {RuntimeSpec}
 * `result` {CodeGenerationResult}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `get(module, runtime)`
 
+---
+### get
+
 * `module` {Module}
 * `runtime` {RuntimeSpec}
-* Returns: {CodeGenerationResult}
+
+* ###Returns: {CodeGenerationResult}
 
 #### `getData(module, runtime, key)`
+
+---
+### getData
 
 * `module` {Module}
 * `runtime` {RuntimeSpec}
 * `key` {string}
-* Returns: {any}
+
+* ###Returns: {any}
 
 #### `getHash(module, runtime)`
 
+---
+### getHash
+
 * `module` {Module}
 * `runtime` {RuntimeSpec}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `getRuntimeRequirements(module, runtime)`
 
+---
+### getRuntimeRequirements
+
 * `module` {Module}
 * `runtime` {RuntimeSpec}
-* Returns: {ReadonlySet<string>}
+
+* ###Returns: {ReadonlySet<string>}
 
 #### `getSource(module, runtime, sourceType)`
+
+---
+### getSource
 
 * `module` {Module}
 * `runtime` {RuntimeSpec}
 * `sourceType` {string}
-* Returns: {Source}
+
+* ###Returns: {Source}
 
 #### `has(module, runtime)`
 
+---
+### has
+
 * `module` {Module}
 * `runtime` {RuntimeSpec}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 ***
 
-## Class: `Compilation`
+## 
+### Class: `Compilation`
 
 ### Constructors
 
 #### `new Compilation(compiler, params)`
 
+---
+### Compilation
+
 * `compiler` {Compiler}
 * `params` {CompilationParams}
-* Returns: {Compilation}
+
+* ###Returns: {Compilation}
 
 Creates an instance of Compilation.
 
@@ -1372,115 +2113,180 @@ e. g. creating an assets manifest of Service Workers.
 
 #### `addAsyncEntrypoint(options, module, loc, request)`
 
+---
+### addAsyncEntrypoint
+
 * `options` {EntryOptions}
 * `module` {Module}
 * `loc` {DependencyLocation}
 * `request` {string}
-* Returns: {Entrypoint}
+
+* ###Returns: {Entrypoint}
 
 #### `addChunk([name])`
 
+---
+### addChunk
+
 * `name` {string}
-* Returns: {Chunk}
+
+* ###Returns: {Chunk}
 
 This method first looks to see if a name is provided for a new chunk,
 and first looks to see if any named chunks already exist and reuse that chunk instead.
 
 #### `addChunkInGroup(groupOptions[, module][, loc][, request])`
 
+---
+### addChunkInGroup
+
 * `groupOptions` {string|ChunkGroupOptions}
 * `module` {Module}
 * `loc` {SyntheticDependencyLocation|RealDependencyLocation}
 * `request` {string}
-* Returns: {ChunkGroup}
+
+* ###Returns: {ChunkGroup}
 
 If `module` is passed, `loc` and `request` must also be passed.
 
 #### `addEntry(context, entry, optionsOrName, callback)`
 
+---
+### addEntry
+
 * `context` {string}
 * `entry` {Dependency}
 * `optionsOrName` {string|EntryOptions}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addInclude(context, dependency, options, callback)`
+
+---
+### addInclude
 
 * `context` {string}
 * `dependency` {Dependency}
 * `options` {EntryOptions}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addModule(module, callback)`
 
+---
+### addModule
+
 * `module` {Module}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addModuleChain(context, dependency, callback)`
+
+---
+### addModuleChain
 
 * `context` {string}
 * `dependency` {Dependency}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addModuleTree(__namedParameters, callback)`
 
+---
+### addModuleTree
+
 * `__namedParameters` {object}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addRuntimeModule(chunk, module[, chunkGraph])`
+
+---
+### addRuntimeModule
 
 * `chunk` {Chunk}
 * `module` {RuntimeModule}
 * `chunkGraph` {ChunkGraph}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `assignDepth(module)`
+
+---
+### assignDepth
 
 > Stability: 0 - Deprecated
 
 * `module` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `assignDepths(modules)`
 
+---
+### assignDepths
+
 * `modules` {Set<Module>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `assignRuntimeIds()`
 
-* Returns: {void}
+---
+### assignRuntimeIds
+
+* ###Returns: {void}
 
 #### `buildModule(module, callback)`
 
+---
+### buildModule
+
 * `module` {Module}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Schedules a build of the module object
 
 #### `checkConstraints()`
 
-* Returns: {void}
+---
+### checkConstraints
+
+* ###Returns: {void}
 
 #### `clearAssets()`
 
-* Returns: {void}
+---
+### clearAssets
+
+* ###Returns: {void}
 
 #### `codeGeneration(callback)`
 
+---
+### codeGeneration
+
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `createChildCompiler(name[, outputOptions][, plugins])`
+
+---
+### createChildCompiler
 
 * `name` {string}
 * `outputOptions` {Partial<OutputNormalized>}
 * `plugins` {false|""|0|object|WebpackPluginInstance[]}
-* Returns: {Compiler}
+
+* ###Returns: {Compiler}
 
 This function allows you to run another instance of webpack inside of webpack however as
 a child with different settings and configurations (if desired) applied. It copies all hooks, plugins
@@ -1488,248 +2294,415 @@ from parent (or top level compiler) and creates a child Compilation
 
 #### `createChunkAssets(callback)`
 
+---
+### createChunkAssets
+
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `createHash()`
 
-* Returns: {CodeGenerationJob[]}
+---
+### createHash
+
+* ###Returns: {CodeGenerationJob[]}
 
 #### `createModuleAssets()`
 
-* Returns: {void}
+---
+### createModuleAssets
+
+* ###Returns: {void}
 
 #### `createModuleHashes()`
 
-* Returns: {void}
+---
+### createModuleHashes
+
+* ###Returns: {void}
 
 #### `createStatsFactory(options)`
 
+---
+### createStatsFactory
+
 * `options` {NormalizedStatsOptions}
-* Returns: {StatsFactory}
+
+* ###Returns: {StatsFactory}
 
 #### `createStatsOptions([optionsOrPreset][, context])`
 
+---
+### createStatsOptions
+
 * `optionsOrPreset` {string|boolean|StatsOptions}
 * `context` {CreateStatsOptionsContext}
-* Returns: {NormalizedStatsOptions}
+
+* ###Returns: {NormalizedStatsOptions}
 
 #### `createStatsPrinter(options)`
 
+---
+### createStatsPrinter
+
 * `options` {NormalizedStatsOptions}
-* Returns: {StatsPrinter}
+
+* ###Returns: {StatsPrinter}
 
 #### `deleteAsset(file)`
 
+---
+### deleteAsset
+
 * `file` {string}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `emitAsset(file, source[, assetInfo])`
+
+---
+### emitAsset
 
 * `file` {string}
 * `source` {Source}
 * `assetInfo` {AssetInfo}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `executeModule(module, options, callback)`
+
+---
+### executeModule
 
 * `module` {Module}
 * `options` {ExecuteModuleOptions}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `factorizeModule(options, callback)`
 
 ##### Call Signature
 
+---
+### factorizeModule
+
 * `options` {FactorizeModuleOptions|object}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ##### Call Signature
 
+---
+### factorizeModule
+
 * `options` {FactorizeModuleOptions|object}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `findModule(identifier)`
 
+---
+### findModule
+
 * `identifier` {string}
-* Returns: {Module}
+
+* ###Returns: {Module}
 
 Attempts to search for a module by its identifier
 
 #### `finish(callback)`
 
+---
+### finish
+
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `getAsset(name)`
 
+---
+### getAsset
+
 * `name` {string}
-* Returns: {Readonly<Asset>}
+
+* ###Returns: {Readonly<Asset>}
 
 #### `getAssetPath(filename, data)`
 
+---
+### getAssetPath
+
 * `filename` {TemplatePath}
 * `data` {PathData}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `getAssetPathWithInfo(filename, data)`
 
+---
+### getAssetPathWithInfo
+
 * `filename` {TemplatePath}
 * `data` {PathData}
-* Returns: {InterpolatedPathAndAssetInfo}
+
+* ###Returns: {InterpolatedPathAndAssetInfo}
 
 #### `getAssets()`
 
-* Returns: {Readonly<Asset>[]}
+---
+### getAssets
+
+* ###Returns: {Readonly<Asset>[]}
 
 #### `getCache(name)`
 
+---
+### getCache
+
 * `name` {string}
-* Returns: {CacheFacade}
+
+* ###Returns: {CacheFacade}
 
 #### `getDependencyReferencedExports(dependency, runtime)`
 
+---
+### getDependencyReferencedExports
+
 * `dependency` {Dependency}
 * `runtime` {RuntimeSpec}
-* Returns: {string[]|ReferencedExport[]}
+
+* ###Returns: {string[]|ReferencedExport[]}
 
 #### `getErrors()`
 
-* Returns: {Error[]}
+---
+### getErrors
+
+* ###Returns: {Error[]}
 
 #### `getLogger(name)`
 
+---
+### getLogger
+
 * `name` {string|object}
-* Returns: {WebpackLogger}
+
+* ###Returns: {WebpackLogger}
 
 #### `getModule(module)`
 
+---
+### getModule
+
 * `module` {Module}
-* Returns: {Module}
+
+* ###Returns: {Module}
 
 Fetches a module from a compilation by its identifier
 
 #### `getPath(filename[, data])`
 
+---
+### getPath
+
 * `filename` {TemplatePath}
 * `data` {PathData}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `getPathWithInfo(filename[, data])`
 
+---
+### getPathWithInfo
+
 * `filename` {TemplatePath}
 * `data` {PathData}
-* Returns: {InterpolatedPathAndAssetInfo}
+
+* ###Returns: {InterpolatedPathAndAssetInfo}
 
 #### `getRenderManifest(options)`
 
+---
+### getRenderManifest
+
 * `options` {RenderManifestOptions}
-* Returns: {RenderManifestEntry[]}
+
+* ###Returns: {RenderManifestEntry[]}
 
 #### `getStats()`
 
-* Returns: {Stats}
+---
+### getStats
+
+* ###Returns: {Stats}
 
 #### `getWarnings()`
 
-* Returns: {Error[]}
+---
+### getWarnings
+
+* ###Returns: {Error[]}
 
 #### `handleModuleCreation(__namedParameters, callback)`
 
+---
+### handleModuleCreation
+
 * `__namedParameters` {HandleModuleCreationOptions}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `patchChunksAfterReasonRemoval(module, chunk)`
 
+---
+### patchChunksAfterReasonRemoval
+
 * `module` {Module}
 * `chunk` {Chunk}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `processModuleDependencies(module, callback)`
 
+---
+### processModuleDependencies
+
 * `module` {Module}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `processModuleDependenciesNonRecursive(module)`
 
+---
+### processModuleDependenciesNonRecursive
+
 * `module` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `processRuntimeRequirements([__namedParameters])`
 
+---
+### processRuntimeRequirements
+
 * `__namedParameters` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `rebuildModule(module, callback)`
 
+---
+### rebuildModule
+
 * `module` {Module}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `removeChunkFromDependencies(block, chunk)`
 
+---
+### removeChunkFromDependencies
+
 * `block` {DependenciesBlock}
 * `chunk` {Chunk}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `removeReasonsOfDependencyBlock(module, block)`
 
+---
+### removeReasonsOfDependencyBlock
+
 * `module` {Module}
 * `block` {DependenciesBlockLike}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `renameAsset(file, newFile)`
 
+---
+### renameAsset
+
 * `file` {string}
 * `newFile` {string}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `reportDependencyErrorsAndWarnings(module, blocks)`
 
+---
+### reportDependencyErrorsAndWarnings
+
 * `module` {Module}
 * `blocks` {DependenciesBlock[]}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `seal(callback)`
 
+---
+### seal
+
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `sortItemsWithChunkIds()`
 
-* Returns: {void}
+---
+### sortItemsWithChunkIds
+
+* ###Returns: {void}
 
 #### `summarizeDependencies()`
 
-* Returns: {void}
+---
+### summarizeDependencies
+
+* ###Returns: {void}
 
 #### `unseal()`
 
-* Returns: {void}
+---
+### unseal
+
+* ###Returns: {void}
 
 #### `updateAsset(file, newSourceOrFunction[, assetInfoUpdateOrFunction])`
+
+---
+### updateAsset
 
 * `file` {string}
 * `newSourceOrFunction` {Source|object}
 * `assetInfoUpdateOrFunction` {AssetInfo|object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## Class: `Compiler`
+## 
+### Class: `Compiler`
 
 ### Constructors
 
 #### `new Compiler(context[, options])`
 
+---
+### Compiler
+
 * `context` {string}
 * `options` {WebpackOptionsNormalized}
-* Returns: {Compiler}
+
+* ###Returns: {Compiler}
 
 ### Properties
 
@@ -1772,120 +2745,197 @@ Fetches a module from a compilation by its identifier
 
 #### `close(callback)`
 
+---
+### close
+
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `compile(callback)`
 
+---
+### compile
+
 * `callback` {CallbackWebpackFunction_2<Compilation, void>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `createChildCompiler(compilation, compilerName, compilerIndex[, outputOptions][, plugins])`
+
+---
+### createChildCompiler
 
 * `compilation` {Compilation}
 * `compilerName` {string}
 * `compilerIndex` {number}
 * `outputOptions` {Partial<OutputNormalized>}
 * `plugins` {false|""|0|WebpackPluginInstance|object[]}
-* Returns: {Compiler}
+
+* ###Returns: {Compiler}
 
 #### `createCompilation(params)`
 
+---
+### createCompilation
+
 * `params` {CompilationParams}
-* Returns: {Compilation}
+
+* ###Returns: {Compilation}
 
 #### `createContextModuleFactory()`
 
-* Returns: {ContextModuleFactory}
+---
+### createContextModuleFactory
+
+* ###Returns: {ContextModuleFactory}
 
 #### `createNormalModuleFactory()`
 
-* Returns: {NormalModuleFactory}
+---
+### createNormalModuleFactory
+
+* ###Returns: {NormalModuleFactory}
 
 #### `emitAssets(compilation, callback)`
 
+---
+### emitAssets
+
 * `compilation` {Compilation}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `emitRecords(callback)`
 
+---
+### emitRecords
+
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `getCache(name)`
 
+---
+### getCache
+
 * `name` {string}
-* Returns: {CacheFacade}
+
+* ###Returns: {CacheFacade}
 
 #### `getInfrastructureLogger(name)`
 
+---
+### getInfrastructureLogger
+
 * `name` {string|object}
-* Returns: {WebpackLogger}
+
+* ###Returns: {WebpackLogger}
 
 #### `isChild()`
 
-* Returns: {boolean}
+---
+### isChild
+
+* ###Returns: {boolean}
 
 #### `newCompilation(params)`
 
+---
+### newCompilation
+
 * `params` {CompilationParams}
-* Returns: {Compilation}
+
+* ###Returns: {Compilation}
 
 #### `newCompilationParams()`
 
-* Returns: {object}
+---
+### newCompilationParams
+
+* ###Returns: {object}
 
 #### `purgeInputFileSystem()`
 
-* Returns: {void}
+---
+### purgeInputFileSystem
+
+* ###Returns: {void}
 
 #### `readRecords(callback)`
 
+---
+### readRecords
+
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `run(callback)`
 
+---
+### run
+
 * `callback` {CallbackWebpackFunction_2<Stats, void>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `runAsChild(callback)`
 
+---
+### runAsChild
+
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `validate(schema, value[, options][, check])`
+
+---
+### validate
 
 ###### T
 
 `T` *extends* {object|object[]} = {object}
+
 * `schema` {JSONSchema4|ExtendedSchema|JSONSchema6|ExtendedSchema|JSONSchema7|ExtendedSchema|object}
 * `value` {T}
 * `options` {ValidationErrorConfiguration}
 * `check` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Schema validation function with optional pre-compiled check
 
 #### `watch(watchOptions, handler)`
 
+---
+### watch
+
 * `watchOptions` {WatchOptions}
 * `handler` {CallbackWebpackFunction_2<Stats, void>}
-* Returns: {Watching}
+
+* ###Returns: {Watching}
 
 ***
 
-## Class: `ConcatenationScope`
+## 
+### Class: `ConcatenationScope`
 
 ### Constructors
 
 #### `new ConcatenationScope(modulesMap, currentModule, usedNames)`
 
+---
+### ConcatenationScope
+
 * `modulesMap` {ModuleInfo[]|Map<Module, ModuleInfo>}
 * `currentModule` {ConcatenatedModuleInfo}
 * `usedNames` {Set<string>}
-* Returns: {ConcatenationScope}
+
+* ###Returns: {ConcatenationScope}
 
 ### Properties
 
@@ -1897,63 +2947,104 @@ Schema validation function with optional pre-compiled check
 
 #### `createModuleReference(module, __namedParameters)`
 
+---
+### createModuleReference
+
 * `module` {Module}
 * `__namedParameters` {Partial<ModuleReferenceOptions>}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `getRawExport(exportName)`
 
+---
+### getRawExport
+
 * `exportName` {string}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `isModuleInScope(module)`
 
+---
+### isModuleInScope
+
 * `module` {Module}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `registerExport(exportName, symbol)`
 
+---
+### registerExport
+
 * `exportName` {string}
 * `symbol` {string}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `registerNamespaceExport(symbol)`
 
+---
+### registerNamespaceExport
+
 * `symbol` {string}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `registerRawExport(exportName, expression)`
 
+---
+### registerRawExport
+
 * `exportName` {string}
 * `expression` {string}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `setRawExportMap(exportName, expression)`
 
+---
+### setRawExportMap
+
 * `exportName` {string}
 * `expression` {string}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `isModuleReference(name)`
 
+---
+### isModuleReference
+
 * `name` {string}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### Static method: `matchModuleReference(name)`
 
+---
+### matchModuleReference
+
 * `name` {string}
-* Returns: {ModuleReferenceOptions|object}
+
+* ###Returns: {ModuleReferenceOptions|object}
 
 ***
 
-## Class: `ContextExclusionPlugin`
+## 
+### Class: `ContextExclusionPlugin`
 
 ### Constructors
 
 #### `new ContextExclusionPlugin(negativeMatcher)`
 
+---
+### ContextExclusionPlugin
+
 * `negativeMatcher` {RegExp}
-* Returns: {ContextExclusionPlugin}
+
+* ###Returns: {ContextExclusionPlugin}
 
 ### Properties
 
@@ -1963,24 +3054,33 @@ Schema validation function with optional pre-compiled check
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `ContextReplacementPlugin`
+## 
+### Class: `ContextReplacementPlugin`
 
 ### Constructors
 
 #### `new ContextReplacementPlugin(resourceRegExp[, newContentResource][, newContentRecursive][, newContentRegExp])`
 
+---
+### ContextReplacementPlugin
+
 * `resourceRegExp` {RegExp}
 * `newContentResource` {string|boolean|RegExp|object}
 * `newContentRecursive` {boolean|RegExp|NewContentCreateContextMap}
 * `newContentRegExp` {RegExp}
-* Returns: {ContextReplacementPlugin}
+
+* ###Returns: {ContextReplacementPlugin}
 
 ### Properties
 
@@ -1995,21 +3095,30 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `DefinePlugin`
+## 
+### Class: `DefinePlugin`
 
 ### Constructors
 
 #### `new DefinePlugin(definitions)`
 
+---
+### DefinePlugin
+
 * `definitions` {Definitions}
-* Returns: {DefinePlugin}
+
+* ###Returns: {DefinePlugin}
 
 Create a new define plugin
 
@@ -2021,32 +3130,49 @@ Create a new define plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 #### Static method: `getCompilationHooks(compilation)`
 
+---
+### getCompilationHooks
+
 * `compilation` {Compilation}
-* Returns: {DefinePluginHooks}
+
+* ###Returns: {DefinePluginHooks}
 
 #### Static method: `runtimeValue(fn[, options])`
 
+---
+### runtimeValue
+
 * `fn` {object}
 * `options` {true|string[]|RuntimeValueOptions}
-* Returns: {RuntimeValue}
+
+* ###Returns: {RuntimeValue}
 
 ***
 
-## Class: `DelegatedPlugin`
+## 
+### Class: `DelegatedPlugin`
 
 ### Constructors
 
 #### `new DelegatedPlugin(options)`
 
+---
+### DelegatedPlugin
+
 * `options` {Options}
-* Returns: {DelegatedPlugin}
+
+* ###Returns: {DelegatedPlugin}
 
 ### Properties
 
@@ -2056,14 +3182,19 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `Dependency`
+## 
+### Class: `Dependency`
 
 ### Extended by
 
@@ -2074,7 +3205,10 @@ Apply the plugin
 
 #### `new Dependency()`
 
-* Returns: {Dependency}
+---
+### Dependency
+
+* ###Returns: {Dependency}
 
 ### Properties
 
@@ -2093,116 +3227,185 @@ Apply the plugin
 
 #### `couldAffectReferencingModule()`
 
-* Returns: {boolean|TRANSITIVE}
+---
+### couldAffectReferencingModule
+
+* ###Returns: {boolean|TRANSITIVE}
 
 #### `createIgnoredModule(context)`
 
+---
+### createIgnoredModule
+
 * `context` {string}
-* Returns: {Module}
+
+* ###Returns: {Module}
 
 #### `deserialize(__namedParameters)`
 
+---
+### deserialize
+
 * `__namedParameters` {ObjectDeserializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `getCondition(moduleGraph)`
 
+---
+### getCondition
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {false|object}
+
+* ###Returns: {false|object}
 
 #### `getContext()`
 
-* Returns: {string}
+---
+### getContext
+
+* ###Returns: {string}
 
 #### `getErrors(moduleGraph)`
 
+---
+### getErrors
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {WebpackError[]}
+
+* ###Returns: {WebpackError[]}
 
 Returns errors
 
 #### `getExports(moduleGraph)`
 
+---
+### getExports
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {ExportsSpec}
+
+* ###Returns: {ExportsSpec}
 
 Returns the exported names
 
 #### `getModuleEvaluationSideEffectsState(moduleGraph)`
 
+---
+### getModuleEvaluationSideEffectsState
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {ConnectionState}
+
+* ###Returns: {ConnectionState}
 
 #### `getNumberOfIdOccurrences()`
 
-* Returns: {number}
+---
+### getNumberOfIdOccurrences
+
+* ###Returns: {number}
 
 implement this method to allow the occurrence order plugin to count correctly
 
 #### `getReference(moduleGraph)`
 
+---
+### getReference
+
 > Stability: 0 - Deprecated
 
 * `moduleGraph` {ModuleGraph}
-* Returns: {never}
+
+* ###Returns: {never}
 
 Returns the referenced module and export
 
 #### `getReferencedExports(moduleGraph, runtime)`
 
+---
+### getReferencedExports
+
 * `moduleGraph` {ModuleGraph}
 * `runtime` {RuntimeSpec}
-* Returns: {string[]|ReferencedExport[]}
+
+* ###Returns: {string[]|ReferencedExport[]}
 
 Returns list of exports referenced by this dependency
 
 #### `getResourceIdentifier()`
 
-* Returns: {string}
+---
+### getResourceIdentifier
+
+* ###Returns: {string}
 
 #### `getWarnings(moduleGraph)`
 
+---
+### getWarnings
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {WebpackError[]}
+
+* ###Returns: {WebpackError[]}
 
 Returns warnings
 
 #### `serialize(__namedParameters)`
 
+---
+### serialize
+
 * `__namedParameters` {ObjectSerializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `setLoc(startLine, startColumn, endLine, endColumn)`
+
+---
+### setLoc
 
 * `startLine` {number}
 * `startColumn` {number}
 * `endLine` {number}
 * `endColumn` {number}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `updateHash(hash, context)`
 
+---
+### updateHash
+
 * `hash` {Hash}
 * `context` {UpdateHashContextDependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Update the hash
 
 #### Static method: `isLowPriorityDependency(dependency)`
 
+---
+### isLowPriorityDependency
+
 * `dependency` {Dependency}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 ***
 
-## Class: `DllPlugin`
+## 
+### Class: `DllPlugin`
 
 ### Constructors
 
 #### `new DllPlugin(options)`
 
+---
+### DllPlugin
+
 * `options` {DllPluginOptions}
-* Returns: {DllPlugin}
+
+* ###Returns: {DllPlugin}
 
 ### Properties
 
@@ -2212,21 +3415,30 @@ Update the hash
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `DllReferencePlugin`
+## 
+### Class: `DllReferencePlugin`
 
 ### Constructors
 
 #### `new DllReferencePlugin(options)`
 
+---
+### DllReferencePlugin
+
 * `options` {DllReferencePluginOptions}
-* Returns: {DllReferencePlugin}
+
+* ###Returns: {DllReferencePlugin}
 
 ### Properties
 
@@ -2236,21 +3448,30 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `DotenvPlugin`
+## 
+### Class: `DotenvPlugin`
 
 ### Constructors
 
 #### `new DotenvPlugin([options])`
 
+---
+### DotenvPlugin
+
 * `options` {DotenvPluginOptions}
-* Returns: {DotenvPlugin}
+
+* ###Returns: {DotenvPlugin}
 
 ### Properties
 
@@ -2260,20 +3481,29 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## Class: `DynamicEntryPlugin`
+## 
+### Class: `DynamicEntryPlugin`
 
 ### Constructors
 
 #### `new DynamicEntryPlugin(context, entry)`
 
+---
+### DynamicEntryPlugin
+
 * `context` {string}
 * `entry` {object}
-* Returns: {DynamicEntryPlugin}
+
+* ###Returns: {DynamicEntryPlugin}
 
 ### Properties
 
@@ -2284,54 +3514,79 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `EntryOptionPlugin`
+## 
+### Class: `EntryOptionPlugin`
 
 ### Constructors
 
 #### `new EntryOptionPlugin()`
 
-* Returns: {EntryOptionPlugin}
+---
+### EntryOptionPlugin
+
+* ###Returns: {EntryOptionPlugin}
 
 ### Methods
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `applyEntryOption(compiler, context, entry)`
+
+---
+### applyEntryOption
 
 * `compiler` {Compiler}
 * `context` {string}
 * `entry` {EntryNormalized}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `entryDescriptionToOptions(compiler, name, desc)`
+
+---
+### entryDescriptionToOptions
 
 * `compiler` {Compiler}
 * `name` {string}
 * `desc` {EntryDescriptionNormalized}
-* Returns: {EntryOptions}
+
+* ###Returns: {EntryOptions}
 
 ***
 
-## Class: `EntryPlugin`
+## 
+### Class: `EntryPlugin`
 
 ### Constructors
 
 #### `new EntryPlugin(context, entry[, options])`
 
+---
+### EntryPlugin
+
 * `context` {string}
 * `entry` {string}
 * `options` {string|EntryOptions}
-* Returns: {EntryPlugin}
+
+* ###Returns: {EntryPlugin}
 
 An entry plugin which will handle creation of the EntryDependency
 
@@ -2345,20 +3600,29 @@ An entry plugin which will handle creation of the EntryDependency
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 #### Static method: `createDependency(entry, options)`
 
+---
+### createDependency
+
 * `entry` {string}
 * `options` {string|EntryOptions}
-* Returns: {EntryDependency}
+
+* ###Returns: {EntryDependency}
 
 ***
 
-## Class: `Entrypoint`
+## 
+### Class: `Entrypoint`
 
 ### Extends
 
@@ -2368,7 +3632,10 @@ Apply the plugin
 
 #### `new Entrypoint()`
 
-* Returns: {Entrypoint}
+---
+### Entrypoint
+
+* ###Returns: {Entrypoint}
 
 ### Properties
 
@@ -2392,227 +3659,371 @@ sets a new name for current ChunkGroup
 
 #### `addAsyncEntrypoint(entrypoint)`
 
+---
+### addAsyncEntrypoint
+
 * `entrypoint` {Entrypoint}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `addBlock(block)`
 
+---
+### addBlock
+
 * `block` {AsyncDependenciesBlock}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `addChild(group)`
 
+---
+### addChild
+
 * `group` {ChunkGroup}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `addDependOn(entrypoint)`
 
+---
+### addDependOn
+
 * `entrypoint` {Entrypoint}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addOptions(options)`
 
+---
+### addOptions
+
 * `options` {ChunkGroupOptions}
-* Returns: {void}
+
+* ###Returns: {void}
 
 when a new chunk is added to a chunkGroup, addingOptions will occur.
 
 #### `addOrigin(module, loc, request)`
 
+---
+### addOrigin
+
 * `module` {Module}
 * `loc` {DependencyLocation}
 * `request` {string}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addParent(parentChunk)`
 
+---
+### addParent
+
 * `parentChunk` {ChunkGroup}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `checkConstraints()`
 
-* Returns: {void}
+---
+### checkConstraints
+
+* ###Returns: {void}
 
 #### `compareTo(chunkGraph, otherGroup)`
 
+---
+### compareTo
+
 * `chunkGraph` {ChunkGraph}
 * `otherGroup` {ChunkGroup}
-* Returns: {-1|0|1}
+
+* ###Returns: {-1|0|1}
 
 Sorting predicate which allows current ChunkGroup to be compared against another.
 Sorting values are based off of number of chunks in ChunkGroup.
 
 #### `dependOn(entrypoint)`
 
+---
+### dependOn
+
 * `entrypoint` {Entrypoint}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `getBlocks()`
 
-* Returns: {AsyncDependenciesBlock[]}
+---
+### getBlocks
+
+* ###Returns: {AsyncDependenciesBlock[]}
 
 #### `getChildren()`
 
-* Returns: {ChunkGroup[]}
+---
+### getChildren
+
+* ###Returns: {ChunkGroup[]}
 
 #### `getChildrenByOrders(moduleGraph, chunkGraph)`
 
+---
+### getChildrenByOrders
+
 * `moduleGraph` {ModuleGraph}
 * `chunkGraph` {ChunkGraph}
-* Returns: {Record<string, ChunkGroup[]>}
+
+* ###Returns: {Record<string, ChunkGroup[]>}
 
 #### `getEntrypointChunk()`
 
-* Returns: {Chunk}
+---
+### getEntrypointChunk
+
+* ###Returns: {Chunk}
 
 Returns the chunk which contains the entrypoint modules
 (or at least the execution of them)
 
 #### `getFiles()`
 
-* Returns: {string[]}
+---
+### getFiles
+
+* ###Returns: {string[]}
 
 #### `getModulePostOrderIndex(module)`
 
+---
+### getModulePostOrderIndex
+
 * `module` {Module}
-* Returns: {number}
+
+* ###Returns: {number}
 
 Gets the bottom-up index of a module in this ChunkGroup
 
 #### `getModulePreOrderIndex(module)`
 
+---
+### getModulePreOrderIndex
+
 * `module` {Module}
-* Returns: {number}
+
+* ###Returns: {number}
 
 Gets the top-down index of a module in this ChunkGroup
 
 #### `getNumberOfBlocks()`
 
-* Returns: {number}
+---
+### getNumberOfBlocks
+
+* ###Returns: {number}
 
 #### `getNumberOfChildren()`
 
-* Returns: {number}
+---
+### getNumberOfChildren
+
+* ###Returns: {number}
 
 #### `getNumberOfParents()`
 
-* Returns: {number}
+---
+### getNumberOfParents
+
+* ###Returns: {number}
 
 #### `getParents()`
 
-* Returns: {ChunkGroup[]}
+---
+### getParents
+
+* ###Returns: {ChunkGroup[]}
 
 #### `getRuntimeChunk()`
 
-* Returns: {Chunk}
+---
+### getRuntimeChunk
+
+* ###Returns: {Chunk}
 
 Fetches the chunk reference containing the webpack bootstrap code
 
 #### `hasBlock(block)`
 
+---
+### hasBlock
+
 * `block` {AsyncDependenciesBlock}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `hasParent(parent)`
 
+---
+### hasParent
+
 * `parent` {ChunkGroup}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `insertChunk(chunk, before)`
 
+---
+### insertChunk
+
 * `chunk` {Chunk}
 * `before` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 inserts a chunk before another existing chunk in group
 
 #### `isInitial()`
 
-* Returns: {boolean}
+---
+### isInitial
+
+* ###Returns: {boolean}
 
 #### `pushChunk(chunk)`
 
+---
+### pushChunk
+
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 add a chunk into ChunkGroup. Is pushed on or prepended
 
 #### `remove()`
 
-* Returns: {void}
+---
+### remove
+
+* ###Returns: {void}
 
 #### `removeChild(group)`
 
+---
+### removeChild
+
 * `group` {ChunkGroup}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `removeChunk(chunk)`
 
+---
+### removeChunk
+
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `removeParent(chunkGroup)`
 
+---
+### removeParent
+
 * `chunkGroup` {ChunkGroup}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `replaceChunk(oldChunk, newChunk)`
 
+---
+### replaceChunk
+
 * `oldChunk` {Chunk}
 * `newChunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `setEntrypointChunk(chunk)`
 
+---
+### setEntrypointChunk
+
 * `chunk` {Chunk}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Sets the chunk with the entrypoint modules for an entrypoint.
 
 #### `setModulePostOrderIndex(module, index)`
 
+---
+### setModulePostOrderIndex
+
 * `module` {Module}
 * `index` {number}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Sets the bottom-up index of a module in this ChunkGroup
 
 #### `setModulePreOrderIndex(module, index)`
 
+---
+### setModulePreOrderIndex
+
 * `module` {Module}
 * `index` {number}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Sets the top-down index of a module in this ChunkGroup
 
 #### `setRuntimeChunk(chunk)`
 
+---
+### setRuntimeChunk
+
 * `chunk` {Chunk}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Sets the runtimeChunk for an entrypoint.
 
 #### `sortItems()`
 
-* Returns: {void}
+---
+### sortItems
+
+* ###Returns: {void}
 
 #### `unshiftChunk(chunk)`
 
+---
+### unshiftChunk
+
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 Performs an unshift of a specific chunk
 
 ***
 
-## Class: `EnvironmentPlugin`
+## 
+### Class: `EnvironmentPlugin`
 
 ### Constructors
 
 #### `new EnvironmentPlugin(keys)`
 
+---
+### EnvironmentPlugin
+
 * `keys` {string|string[]|Record<string, any>[]}
-* Returns: {EnvironmentPlugin}
+
+* ###Returns: {EnvironmentPlugin}
 
 ### Properties
 
@@ -2623,21 +4034,30 @@ Performs an unshift of a specific chunk
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `EvalDevToolModulePlugin`
+## 
+### Class: `EvalDevToolModulePlugin`
 
 ### Constructors
 
 #### `new EvalDevToolModulePlugin([options])`
 
+---
+### EvalDevToolModulePlugin
+
 * `options` {EvalDevToolModulePluginOptions}
-* Returns: {EvalDevToolModulePlugin}
+
+* ###Returns: {EvalDevToolModulePlugin}
 
 ### Properties
 
@@ -2649,21 +4069,30 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `EvalSourceMapDevToolPlugin`
+## 
+### Class: `EvalSourceMapDevToolPlugin`
 
 ### Constructors
 
 #### `new EvalSourceMapDevToolPlugin([inputOptions])`
 
+---
+### EvalSourceMapDevToolPlugin
+
 * `inputOptions` {string|SourceMapDevToolPluginOptions}
-* Returns: {EvalSourceMapDevToolPlugin}
+
+* ###Returns: {EvalSourceMapDevToolPlugin}
 
 ### Properties
 
@@ -2676,14 +4105,19 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `ExternalModule`
+## 
+### Class: `ExternalModule`
 
 ### Extends
 
@@ -2693,11 +4127,15 @@ Apply the plugin
 
 #### `new ExternalModule(request, type, userRequest[, dependencyMeta])`
 
+---
+### ExternalModule
+
 * `request` {ExternalModuleRequest}
 * `type` {ExternalsType}
 * `userRequest` {string}
 * `dependencyMeta` {ImportDependencyMeta|CssImportDependencyMeta|AssetDependencyMeta}
-* Returns: {ExternalModule}
+
+* ###Returns: {ExternalModule}
 
 ### Properties
 
@@ -2748,136 +4186,226 @@ Apply the plugin
 
 #### `addBlock(block)`
 
+---
+### addBlock
+
 * `block` {AsyncDependenciesBlock}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Adds a DependencyBlock to DependencyBlock relationship.
 This is used for when a Module has a AsyncDependencyBlock tie (for code-splitting)
 
 #### `addCacheDependencies(fileDependencies, contextDependencies, missingDependencies, buildDependencies)`
 
+---
+### addCacheDependencies
+
 * `fileDependencies` {LazySet<string>}
 * `contextDependencies` {LazySet<string>}
 * `missingDependencies` {LazySet<string>}
 * `buildDependencies` {LazySet<string>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addChunk(chunk)`
 
+---
+### addChunk
+
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `addCodeGenerationDependency(codeGenerationDependency)`
 
+---
+### addCodeGenerationDependency
+
 * `codeGenerationDependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addDependency(dependency)`
 
+---
+### addDependency
+
 * `dependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addError(error)`
 
+---
+### addError
+
 * `error` {WebpackError}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addPresentationalDependency(presentationalDependency)`
 
+---
+### addPresentationalDependency
+
 * `presentationalDependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addWarning(warning)`
 
+---
+### addWarning
+
 * `warning` {WebpackError}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `build(options, compilation, resolver, fs, callback)`
+
+---
+### build
 
 * `options` {WebpackOptionsNormalizedWithDefaults}
 * `compilation` {Compilation}
 * `resolver` {ResolverWithOptions}
 * `fs` {InputFileSystem}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `chunkCondition(chunk, compilation)`
 
+---
+### chunkCondition
+
 * `chunk` {Chunk}
 * `compilation` {Compilation}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `cleanupForCache()`
 
-* Returns: {void}
+---
+### cleanupForCache
+
+* ###Returns: {void}
 
 Assuming this module is in the cache. Remove internal references to allow freeing some memory.
 
 #### `clearDependenciesAndBlocks()`
 
-* Returns: {void}
+---
+### clearDependenciesAndBlocks
+
+* ###Returns: {void}
 
 Removes all dependencies and blocks
 
 #### `clearWarningsAndErrors()`
 
-* Returns: {void}
+---
+### clearWarningsAndErrors
+
+* ###Returns: {void}
 
 removes all warnings and errors
 
 #### `codeGeneration(context)`
 
+---
+### codeGeneration
+
 * `context` {CodeGenerationContext}
-* Returns: {CodeGenerationResult}
+
+* ###Returns: {CodeGenerationResult}
 
 #### `deserialize(__namedParameters)`
 
+---
+### deserialize
+
 * `__namedParameters` {ObjectDeserializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `getChunks()`
 
-* Returns: {Chunk[]}
+---
+### getChunks
+
+* ###Returns: {Chunk[]}
 
 #### `getConcatenationBailoutReason(context)`
 
+---
+### getConcatenationBailoutReason
+
 * `context` {ConcatenationBailoutReasonContext}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `getErrors()`
 
-* Returns: {Iterable<WebpackError, any, any>}
+---
+### getErrors
+
+* ###Returns: {Iterable<WebpackError, any, any>}
 
 #### `getExportsType(moduleGraph[, strict])`
 
+---
+### getExportsType
+
 * `moduleGraph` {ModuleGraph}
 * `strict` {boolean}
-* Returns: {ExportsType}
+
+* ###Returns: {ExportsType}
 
 #### `getNumberOfChunks()`
 
-* Returns: {number}
+---
+### getNumberOfChunks
+
+* ###Returns: {number}
 
 #### `getNumberOfErrors()`
 
-* Returns: {number}
+---
+### getNumberOfErrors
+
+* ###Returns: {number}
 
 #### `getNumberOfWarnings()`
 
-* Returns: {number}
+---
+### getNumberOfWarnings
+
+* ###Returns: {number}
 
 #### `getRootBlock()`
 
-* Returns: {DependenciesBlock}
+---
+### getRootBlock
+
+* ###Returns: {DependenciesBlock}
 
 #### `getSideEffectsConnectionState(moduleGraph)`
 
+---
+### getSideEffectsConnectionState
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {ConnectionState}
+
+* ###Returns: {ConnectionState}
 
 #### `getSourceBasicTypes()`
 
-* Returns: {ReadonlySet<string>}
+---
+### getSourceBasicTypes
+
+* ###Returns: {ReadonlySet<string>}
 
 Basic source types are high-level categories like javascript, css, webassembly, etc.
 We only have built-in knowledge about the javascript basic type here; other basic types may be
@@ -2887,154 +4415,253 @@ from getSourceTypes(), but their generated output is still JavaScript, i.e. thei
 
 #### `getSourceTypes()`
 
-* Returns: {ReadonlySet<string>}
+---
+### getSourceTypes
+
+* ###Returns: {ReadonlySet<string>}
 
 #### `getUnsafeCacheData()`
 
-* Returns: {UnsafeCacheData}
+---
+### getUnsafeCacheData
+
+* ###Returns: {UnsafeCacheData}
 
 Module should be unsafe cached. Get data that's needed for that.
 This data will be passed to restoreFromUnsafeCache later.
 
 #### `getWarnings()`
 
-* Returns: {Iterable<WebpackError, any, any>}
+---
+### getWarnings
+
+* ###Returns: {Iterable<WebpackError, any, any>}
 
 #### `hasChunkCondition()`
 
-* Returns: {boolean}
+---
+### hasChunkCondition
+
+* ###Returns: {boolean}
 
 #### `hasReasonForChunk(chunk, moduleGraph, chunkGraph)`
+
+---
+### hasReasonForChunk
 
 * `chunk` {Chunk}
 * `moduleGraph` {ModuleGraph}
 * `chunkGraph` {ChunkGraph}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `hasReasons(moduleGraph, runtime)`
 
+---
+### hasReasons
+
 * `moduleGraph` {ModuleGraph}
 * `runtime` {RuntimeSpec}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `identifier()`
 
-* Returns: {string}
+---
+### identifier
+
+* ###Returns: {string}
 
 #### `invalidateBuild()`
 
-* Returns: {void}
+---
+### invalidateBuild
+
+* ###Returns: {void}
 
 #### `isAccessibleInChunk(chunkGraph, chunk[, ignoreChunk])`
+
+---
+### isAccessibleInChunk
 
 * `chunkGraph` {ChunkGraph}
 * `chunk` {Chunk}
 * `ignoreChunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isAccessibleInChunkGroup(chunkGraph, chunkGroup[, ignoreChunk])`
+
+---
+### isAccessibleInChunkGroup
 
 * `chunkGraph` {ChunkGraph}
 * `chunkGroup` {ChunkGroup}
 * `ignoreChunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isEntryModule()`
 
-* Returns: {boolean}
+---
+### isEntryModule
+
+* ###Returns: {boolean}
 
 #### `isInChunk(chunk)`
 
+---
+### isInChunk
+
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isOptional(moduleGraph)`
 
+---
+### isOptional
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isProvided(exportName)`
 
+---
+### isProvided
+
 * `exportName` {string}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `libIdent(options)`
 
+---
+### libIdent
+
 * `options` {LibIdentOptions}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `nameForCondition()`
 
-* Returns: {string}
+---
+### nameForCondition
+
+* ###Returns: {string}
 
 #### `needBuild(context, callback)`
 
+---
+### needBuild
+
 * `context` {NeedBuildContext}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `needRebuild(fileTimestamps, contextTimestamps)`
+
+---
+### needRebuild
 
 > Stability: 0 - Deprecated
 
 * `fileTimestamps` {Map<string, number>}
 * `contextTimestamps` {Map<string, number>}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 Use needBuild instead
 
 #### `originalSource()`
 
-* Returns: {Source}
+---
+### originalSource
+
+* ###Returns: {Source}
 
 #### `readableIdentifier(requestShortener)`
 
+---
+### readableIdentifier
+
 * `requestShortener` {RequestShortener}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `removeChunk(chunk)`
 
+---
+### removeChunk
+
 * `chunk` {Chunk}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `removeDependency(dependency)`
 
+---
+### removeDependency
+
 * `dependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `restoreFromUnsafeCache(unsafeCacheData, normalModuleFactory)`
 
+---
+### restoreFromUnsafeCache
+
 * `unsafeCacheData` {UnsafeCacheData}
 * `normalModuleFactory` {NormalModuleFactory}
-* Returns: {void}
+
+* ###Returns: {void}
 
 restore unsafe cache data
 
 #### `serialize(__namedParameters)`
 
+---
+### serialize
+
 * `__namedParameters` {ObjectSerializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `size([type])`
 
+---
+### size
+
 * `type` {string}
-* Returns: {number}
+
+* ###Returns: {number}
 
 #### `source(dependencyTemplates, runtimeTemplate[, type])`
+
+---
+### source
 
 > Stability: 0 - Deprecated
 
 * `dependencyTemplates` {DependencyTemplates}
 * `runtimeTemplate` {RuntimeTemplate}
 * `type` {string}
-* Returns: {Source}
+
+* ###Returns: {Source}
 
 Use codeGeneration() instead
 
 #### `updateCacheModule(module)`
 
+---
+### updateCacheModule
+
 * `module` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Assuming this module is in the cache. Update the (cached) module with
 the fresh module from the factory. Usually updates internal references
@@ -3042,35 +4669,52 @@ and properties.
 
 #### `updateHash(hash, context)`
 
+---
+### updateHash
+
 * `hash` {Hash}
 * `context` {UpdateHashContextDependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `getCompilationHooks(compilation)`
 
+---
+### getCompilationHooks
+
 * `compilation` {Compilation}
-* Returns: {ExternalModuleHooks}
+
+* ###Returns: {ExternalModuleHooks}
 
 #### Static method: `getSourceBasicTypes(module)`
+
+---
+### getSourceBasicTypes
 
 > Stability: 0 - Deprecated
 
 * `module` {Module}
-* Returns: {ReadonlySet<string>}
+
+* ###Returns: {ReadonlySet<string>}
 
 In webpack 6, call getSourceBasicTypes() directly on the module instance instead of using this static method.
 
 ***
 
-## Class: `ExternalsPlugin`
+## 
+### Class: `ExternalsPlugin`
 
 ### Constructors
 
 #### `new ExternalsPlugin(type, externals)`
 
+---
+### ExternalsPlugin
+
 * `type` {"asset"|"module"|"css-import"|"css-url"|"global"|"import"|"commonjs"|"jsonp"|"promise"|"this"|"var"|"assign"|"window"|"self"|"commonjs2"|"commonjs-module"|"commonjs-static"|"amd"|"amd-require"|"umd"|"umd2"|"system"|"module-import"|"script"|"node-commonjs"|object}
 * `externals` {Externals}
-* Returns: {ExternalsPlugin}
+
+* ###Returns: {ExternalsPlugin}
 
 ### Properties
 
@@ -3081,84 +4725,129 @@ In webpack 6, call getSourceBasicTypes() directly on the module instance instead
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `Generator`
+## 
+### Class: `Generator`
 
 ### Constructors
 
 #### `new Generator()`
 
-* Returns: {Generator}
+---
+### Generator
+
+* ###Returns: {Generator}
 
 ### Methods
 
 #### `generate(module, __namedParameters)`
 
+---
+### generate
+
 * `module` {NormalModule}
 * `__namedParameters` {GenerateContext}
-* Returns: {Source}
+
+* ###Returns: {Source}
 
 #### `getConcatenationBailoutReason(module, context)`
 
+---
+### getConcatenationBailoutReason
+
 * `module` {NormalModule}
 * `context` {ConcatenationBailoutReasonContext}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `getSize(module[, type])`
 
+---
+### getSize
+
 * `module` {NormalModule}
 * `type` {string}
-* Returns: {number}
+
+* ###Returns: {number}
 
 #### `getTypes(module)`
 
+---
+### getTypes
+
 * `module` {NormalModule}
-* Returns: {ReadonlySet<string>}
+
+* ###Returns: {ReadonlySet<string>}
 
 #### `updateHash(hash, __namedParameters)`
 
+---
+### updateHash
+
 * `hash` {Hash}
 * `__namedParameters` {UpdateHashContextGenerator}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `byType(map)`
 
+---
+### byType
+
 * `map` {object}
-* Returns: {ByTypeGenerator}
+
+* ###Returns: {ByTypeGenerator}
 
 ***
 
-## Class: `HotModuleReplacementPlugin`
+## 
+### Class: `HotModuleReplacementPlugin`
 
 ### Constructors
 
 #### `new HotModuleReplacementPlugin()`
 
-* Returns: {HotModuleReplacementPlugin}
+---
+### HotModuleReplacementPlugin
+
+* ###Returns: {HotModuleReplacementPlugin}
 
 ### Methods
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 #### Static method: `getParserHooks(parser)`
 
+---
+### getParserHooks
+
 * `parser` {JavascriptParser}
-* Returns: {HMRJavascriptParserHooks}
+
+* ###Returns: {HMRJavascriptParserHooks}
 
 ***
 
-## Class: `HotUpdateChunk`
+## 
+### Class: `HotUpdateChunk`
 
 ### Extends
 
@@ -3168,7 +4857,10 @@ Apply the plugin
 
 #### `new HotUpdateChunk()`
 
-* Returns: {HotUpdateChunk}
+---
+### HotUpdateChunk
+
+* ###Returns: {HotUpdateChunk}
 
 ### Properties
 
@@ -3197,200 +4889,340 @@ Apply the plugin
 
 #### `addGroup(chunkGroup)`
 
+---
+### addGroup
+
 * `chunkGroup` {ChunkGroup}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addModule(module)`
 
+---
+### addModule
+
 * `module` {Module}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `canBeInitial()`
 
-* Returns: {boolean}
+---
+### canBeInitial
+
+* ###Returns: {boolean}
 
 #### `canBeIntegrated(otherChunk)`
 
+---
+### canBeIntegrated
+
 * `otherChunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `compareTo(otherChunk)`
 
+---
+### compareTo
+
 * `otherChunk` {Chunk}
-* Returns: {-1|0|1}
+
+* ###Returns: {-1|0|1}
 
 #### `containsModule(module)`
 
+---
+### containsModule
+
 * `module` {Module}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `disconnectFromGroups()`
 
-* Returns: {void}
+---
+### disconnectFromGroups
+
+* ###Returns: {void}
 
 #### `getAllAsyncChunks()`
 
-* Returns: {Set<Chunk>}
+---
+### getAllAsyncChunks
+
+* ###Returns: {Set<Chunk>}
 
 #### `getAllInitialChunks()`
 
-* Returns: {Set<Chunk>}
+---
+### getAllInitialChunks
+
+* ###Returns: {Set<Chunk>}
 
 #### `getAllReferencedAsyncEntrypoints()`
 
-* Returns: {Set<Entrypoint>}
+---
+### getAllReferencedAsyncEntrypoints
+
+* ###Returns: {Set<Entrypoint>}
 
 #### `getAllReferencedChunks()`
 
-* Returns: {Set<Chunk>}
+---
+### getAllReferencedChunks
+
+* ###Returns: {Set<Chunk>}
 
 #### `getChildIdsByOrders(chunkGraph[, filterFn])`
 
+---
+### getChildIdsByOrders
+
 * `chunkGraph` {ChunkGraph}
 * `filterFn` {object}
-* Returns: {Record<string, ChunkId[]>}
+
+* ###Returns: {Record<string, ChunkId[]>}
 
 #### `getChildIdsByOrdersMap(chunkGraph[, includeDirectChildren][, filterFn])`
+
+---
+### getChildIdsByOrdersMap
 
 * `chunkGraph` {ChunkGraph}
 * `includeDirectChildren` {boolean}
 * `filterFn` {object}
-* Returns: {ChunkChildIdsByOrdersMapByData}
+
+* ###Returns: {ChunkChildIdsByOrdersMapByData}
 
 #### `getChildrenOfTypeInOrder(chunkGraph, type)`
 
+---
+### getChildrenOfTypeInOrder
+
 * `chunkGraph` {ChunkGraph}
 * `type` {string}
-* Returns: {ChunkChildOfTypeInOrder[]}
+
+* ###Returns: {ChunkChildOfTypeInOrder[]}
 
 #### `getChunkMaps(realHash)`
+
+---
+### getChunkMaps
 
 > Stability: 0 - Deprecated
 
 * `realHash` {boolean}
-* Returns: {ChunkMaps}
+
+* ###Returns: {ChunkMaps}
 
 #### `getChunkModuleMaps(filterFn)`
 
+---
+### getChunkModuleMaps
+
 * `filterFn` {object}
-* Returns: {ChunkModuleMaps}
+
+* ###Returns: {ChunkModuleMaps}
 
 #### `getEntryOptions()`
 
-* Returns: {EntryOptions}
+---
+### getEntryOptions
+
+* ###Returns: {EntryOptions}
 
 #### `getModules()`
 
-* Returns: {Module[]}
+---
+### getModules
+
+* ###Returns: {Module[]}
 
 #### `getNumberOfGroups()`
 
-* Returns: {number}
+---
+### getNumberOfGroups
+
+* ###Returns: {number}
 
 #### `getNumberOfModules()`
 
-* Returns: {number}
+---
+### getNumberOfModules
+
+* ###Returns: {number}
 
 #### `hasAsyncChunks()`
 
-* Returns: {boolean}
+---
+### hasAsyncChunks
+
+* ###Returns: {boolean}
 
 #### `hasChildByOrder(chunkGraph, type[, includeDirectChildren][, filterFn])`
+
+---
+### hasChildByOrder
 
 * `chunkGraph` {ChunkGraph}
 * `type` {string}
 * `includeDirectChildren` {boolean}
 * `filterFn` {object}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `hasEntryModule()`
 
-* Returns: {boolean}
+---
+### hasEntryModule
+
+* ###Returns: {boolean}
 
 #### `hasModuleInGraph(filterFn[, filterChunkFn])`
 
+---
+### hasModuleInGraph
+
 * `filterFn` {object}
 * `filterChunkFn` {object}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `hasRuntime()`
 
-* Returns: {boolean}
+---
+### hasRuntime
+
+* ###Returns: {boolean}
 
 #### `integrate(otherChunk)`
 
+---
+### integrate
+
 * `otherChunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `integratedSize(otherChunk, options)`
 
+---
+### integratedSize
+
 * `otherChunk` {Chunk}
 * `options` {ChunkSizeOptions}
-* Returns: {number}
+
+* ###Returns: {number}
 
 #### `isEmpty()`
 
-* Returns: {boolean}
+---
+### isEmpty
+
+* ###Returns: {boolean}
 
 #### `isInGroup(chunkGroup)`
 
+---
+### isInGroup
+
 * `chunkGroup` {ChunkGroup}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isOnlyInitial()`
 
-* Returns: {boolean}
+---
+### isOnlyInitial
+
+* ###Returns: {boolean}
 
 #### `modulesSize()`
 
-* Returns: {number}
+---
+### modulesSize
+
+* ###Returns: {number}
 
 #### `moveModule(module, otherChunk)`
 
+---
+### moveModule
+
 * `module` {Module}
 * `otherChunk` {Chunk}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `remove()`
 
-* Returns: {void}
+---
+### remove
+
+* ###Returns: {void}
 
 #### `removeGroup(chunkGroup)`
 
+---
+### removeGroup
+
 * `chunkGroup` {ChunkGroup}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `removeModule(module)`
 
+---
+### removeModule
+
 * `module` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `size([options])`
 
+---
+### size
+
 * `options` {ChunkSizeOptions}
-* Returns: {number}
+
+* ###Returns: {number}
 
 #### `split(newChunk)`
 
+---
+### split
+
 * `newChunk` {Chunk}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `updateHash(hash, chunkGraph)`
 
+---
+### updateHash
+
 * `hash` {Hash}
 * `chunkGraph` {ChunkGraph}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## Class: `IgnorePlugin`
+## 
+### Class: `IgnorePlugin`
 
 ### Constructors
 
 #### `new IgnorePlugin(options)`
 
+---
+### IgnorePlugin
+
 * `options` {IgnorePluginOptions}
-* Returns: {IgnorePlugin}
+
+* ###Returns: {IgnorePlugin}
 
 ### Properties
 
@@ -3400,21 +5232,30 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 #### `checkIgnore(resolveData)`
 
+---
+### checkIgnore
+
 * `resolveData` {BeforeContextResolveData|ResolveData}
-* Returns: {false}
+
+* ###Returns: {false}
 
 Note that if "contextRegExp" is given, both the "resourceRegExp" and "contextRegExp" have to match.
 
 ***
 
-## Class: `InitFragment`
+## 
+### Class: `InitFragment`
 
 ### Type Parameters
 
@@ -3426,15 +5267,20 @@ Note that if "contextRegExp" is given, both the "resourceRegExp" and "contextReg
 
 #### `new InitFragment(content, stage, position[, key][, endContent])`
 
+---
+### InitFragment
+
 ###### GenerateContext
 
 `GenerateContext`
+
 * `content` {string|Source}
 * `stage` {number}
 * `position` {number}
 * `key` {string}
 * `endContent` {string|Source}
-* Returns: {InitFragment<GenerateContext>}
+
+* ###Returns: {InitFragment<GenerateContext>}
 
 ### Properties
 
@@ -3455,44 +5301,70 @@ Note that if "contextRegExp" is given, both the "resourceRegExp" and "contextReg
 
 #### `deserialize(context)`
 
+---
+### deserialize
+
 * `context` {ObjectDeserializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `getContent(context)`
 
+---
+### getContent
+
 * `context` {GenerateContext}
-* Returns: {string|Source}
+
+* ###Returns: {string|Source}
 
 #### `getEndContent(context)`
 
+---
+### getEndContent
+
 * `context` {GenerateContext}
-* Returns: {string|Source}
+
+* ###Returns: {string|Source}
 
 #### `serialize(context)`
 
+---
+### serialize
+
 * `context` {ObjectSerializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `addToSource(source, initFragments, context)`
+
+---
+### addToSource
 
 ###### Context
 
 `Context`
+
 * `source` {Source}
 * `initFragments` {MaybeMergeableInitFragment<Context>[]}
 * `context` {Context}
-* Returns: {Source}
+
+* ###Returns: {Source}
 
 ***
 
-## Class: `JavascriptModulesPlugin`
+## 
+### Class: `JavascriptModulesPlugin`
 
 ### Constructors
 
 #### `new JavascriptModulesPlugin([options])`
 
+---
+### JavascriptModulesPlugin
+
 * `options` {object}
-* Returns: {JavascriptModulesPlugin}
+
+* ###Returns: {JavascriptModulesPlugin}
 
 ### Properties
 
@@ -3503,71 +5375,112 @@ Note that if "contextRegExp" is given, both the "resourceRegExp" and "contextReg
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 #### `renderBootstrap(renderContext, hooks)`
 
+---
+### renderBootstrap
+
 * `renderContext` {RenderBootstrapContext}
 * `hooks` {CompilationHooksJavascriptModulesPlugin}
-* Returns: {Bootstrap}
+
+* ###Returns: {Bootstrap}
 
 #### `renderChunk(renderContext, hooks)`
 
+---
+### renderChunk
+
 * `renderContext` {RenderContextJavascriptModulesPlugin}
 * `hooks` {CompilationHooksJavascriptModulesPlugin}
-* Returns: {Source}
+
+* ###Returns: {Source}
 
 #### `renderMain(renderContext, hooks, compilation)`
+
+---
+### renderMain
 
 * `renderContext` {MainRenderContext}
 * `hooks` {CompilationHooksJavascriptModulesPlugin}
 * `compilation` {Compilation}
-* Returns: {Source}
+
+* ###Returns: {Source}
 
 #### `renderModule(module, renderContext, hooks)`
+
+---
+### renderModule
 
 * `module` {Module}
 * `renderContext` {ModuleRenderContext}
 * `hooks` {CompilationHooksJavascriptModulesPlugin}
-* Returns: {Source}
+
+* ###Returns: {Source}
 
 #### `renderRequire(renderContext, hooks)`
 
+---
+### renderRequire
+
 * `renderContext` {RenderBootstrapContext}
 * `hooks` {CompilationHooksJavascriptModulesPlugin}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `updateHashWithBootstrap(hash, renderContext, hooks)`
+
+---
+### updateHashWithBootstrap
 
 * `hash` {Hash}
 * `renderContext` {RenderBootstrapContext}
 * `hooks` {CompilationHooksJavascriptModulesPlugin}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `getChunkFilenameTemplate(chunk, outputOptions)`
 
+---
+### getChunkFilenameTemplate
+
 * `chunk` {Chunk}
 * `outputOptions` {OutputNormalizedWithDefaults}
-* Returns: {TemplatePath}
+
+* ###Returns: {TemplatePath}
 
 #### Static method: `getCompilationHooks(compilation)`
 
+---
+### getCompilationHooks
+
 * `compilation` {Compilation}
-* Returns: {CompilationHooksJavascriptModulesPlugin}
+
+* ###Returns: {CompilationHooksJavascriptModulesPlugin}
 
 ***
 
-## Class: `LibManifestPlugin`
+## 
+### Class: `LibManifestPlugin`
 
 ### Constructors
 
 #### `new LibManifestPlugin(options)`
 
+---
+### LibManifestPlugin
+
 * `options` {LibManifestPluginOptions}
-* Returns: {LibManifestPlugin}
+
+* ###Returns: {LibManifestPlugin}
 
 ### Properties
 
@@ -3577,25 +5490,34 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `LibraryTemplatePlugin`
+## 
+### Class: `LibraryTemplatePlugin`
 
 ### Constructors
 
 #### `new LibraryTemplatePlugin(name, target, umdNamedDefine, auxiliaryComment, exportProperty)`
+
+---
+### LibraryTemplatePlugin
 
 * `name` {LibraryName}
 * `target` {string}
 * `umdNamedDefine` {boolean}
 * `auxiliaryComment` {AuxiliaryComment}
 * `exportProperty` {LibraryExport}
-* Returns: {LibraryTemplatePlugin}
+
+* ###Returns: {LibraryTemplatePlugin}
 
 ### Properties
 
@@ -3605,21 +5527,30 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `LoaderOptionsPlugin`
+## 
+### Class: `LoaderOptionsPlugin`
 
 ### Constructors
 
 #### `new LoaderOptionsPlugin([options])`
 
+---
+### LoaderOptionsPlugin
+
 * `options` {LoaderOptionsPluginOptions|MatchObject}
-* Returns: {LoaderOptionsPlugin}
+
+* ###Returns: {LoaderOptionsPlugin}
 
 ### Properties
 
@@ -3629,21 +5560,30 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `LoaderTargetPlugin`
+## 
+### Class: `LoaderTargetPlugin`
 
 ### Constructors
 
 #### `new LoaderTargetPlugin(target)`
 
+---
+### LoaderTargetPlugin
+
 * `target` {string}
-* Returns: {LoaderTargetPlugin}
+
+* ###Returns: {LoaderTargetPlugin}
 
 ### Properties
 
@@ -3653,21 +5593,30 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `ManifestPlugin`
+## 
+### Class: `ManifestPlugin`
 
 ### Constructors
 
 #### `new ManifestPlugin([options])`
 
+---
+### ManifestPlugin
+
 * `options` {ManifestPluginOptions}
-* Returns: {ManifestPlugin}
+
+* ###Returns: {ManifestPlugin}
 
 ### Properties
 
@@ -3677,14 +5626,19 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `Module`
+## 
+### Class: `Module`
 
 ### Extends
 
@@ -3700,10 +5654,14 @@ Apply the plugin
 
 #### `new Module(type[, context][, layer])`
 
+---
+### Module
+
 * `type` {string}
 * `context` {string}
 * `layer` {string}
-* Returns: {Module}
+
+* ###Returns: {Module}
 
 ### Properties
 
@@ -3748,136 +5706,226 @@ Apply the plugin
 
 #### `addBlock(block)`
 
+---
+### addBlock
+
 * `block` {AsyncDependenciesBlock}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Adds a DependencyBlock to DependencyBlock relationship.
 This is used for when a Module has a AsyncDependencyBlock tie (for code-splitting)
 
 #### `addCacheDependencies(fileDependencies, contextDependencies, missingDependencies, buildDependencies)`
 
+---
+### addCacheDependencies
+
 * `fileDependencies` {LazySet<string>}
 * `contextDependencies` {LazySet<string>}
 * `missingDependencies` {LazySet<string>}
 * `buildDependencies` {LazySet<string>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addChunk(chunk)`
 
+---
+### addChunk
+
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `addCodeGenerationDependency(codeGenerationDependency)`
 
+---
+### addCodeGenerationDependency
+
 * `codeGenerationDependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addDependency(dependency)`
 
+---
+### addDependency
+
 * `dependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addError(error)`
 
+---
+### addError
+
 * `error` {WebpackError}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addPresentationalDependency(presentationalDependency)`
 
+---
+### addPresentationalDependency
+
 * `presentationalDependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addWarning(warning)`
 
+---
+### addWarning
+
 * `warning` {WebpackError}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `build(options, compilation, resolver, fs, callback)`
+
+---
+### build
 
 * `options` {WebpackOptionsNormalizedWithDefaults}
 * `compilation` {Compilation}
 * `resolver` {ResolverWithOptions}
 * `fs` {InputFileSystem}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `chunkCondition(chunk, compilation)`
 
+---
+### chunkCondition
+
 * `chunk` {Chunk}
 * `compilation` {Compilation}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `cleanupForCache()`
 
-* Returns: {void}
+---
+### cleanupForCache
+
+* ###Returns: {void}
 
 Assuming this module is in the cache. Remove internal references to allow freeing some memory.
 
 #### `clearDependenciesAndBlocks()`
 
-* Returns: {void}
+---
+### clearDependenciesAndBlocks
+
+* ###Returns: {void}
 
 Removes all dependencies and blocks
 
 #### `clearWarningsAndErrors()`
 
-* Returns: {void}
+---
+### clearWarningsAndErrors
+
+* ###Returns: {void}
 
 removes all warnings and errors
 
 #### `codeGeneration(context)`
 
+---
+### codeGeneration
+
 * `context` {CodeGenerationContext}
-* Returns: {CodeGenerationResult}
+
+* ###Returns: {CodeGenerationResult}
 
 #### `deserialize(__namedParameters)`
 
+---
+### deserialize
+
 * `__namedParameters` {ObjectDeserializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `getChunks()`
 
-* Returns: {Chunk[]}
+---
+### getChunks
+
+* ###Returns: {Chunk[]}
 
 #### `getConcatenationBailoutReason(context)`
 
+---
+### getConcatenationBailoutReason
+
 * `context` {ConcatenationBailoutReasonContext}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `getErrors()`
 
-* Returns: {Iterable<WebpackError, any, any>}
+---
+### getErrors
+
+* ###Returns: {Iterable<WebpackError, any, any>}
 
 #### `getExportsType(moduleGraph[, strict])`
 
+---
+### getExportsType
+
 * `moduleGraph` {ModuleGraph}
 * `strict` {boolean}
-* Returns: {ExportsType}
+
+* ###Returns: {ExportsType}
 
 #### `getNumberOfChunks()`
 
-* Returns: {number}
+---
+### getNumberOfChunks
+
+* ###Returns: {number}
 
 #### `getNumberOfErrors()`
 
-* Returns: {number}
+---
+### getNumberOfErrors
+
+* ###Returns: {number}
 
 #### `getNumberOfWarnings()`
 
-* Returns: {number}
+---
+### getNumberOfWarnings
+
+* ###Returns: {number}
 
 #### `getRootBlock()`
 
-* Returns: {DependenciesBlock}
+---
+### getRootBlock
+
+* ###Returns: {DependenciesBlock}
 
 #### `getSideEffectsConnectionState(moduleGraph)`
 
+---
+### getSideEffectsConnectionState
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {ConnectionState}
+
+* ###Returns: {ConnectionState}
 
 #### `getSourceBasicTypes()`
 
-* Returns: {ReadonlySet<string>}
+---
+### getSourceBasicTypes
+
+* ###Returns: {ReadonlySet<string>}
 
 Basic source types are high-level categories like javascript, css, webassembly, etc.
 We only have built-in knowledge about the javascript basic type here; other basic types may be
@@ -3887,146 +5935,241 @@ from getSourceTypes(), but their generated output is still JavaScript, i.e. thei
 
 #### `getSourceTypes()`
 
-* Returns: {ReadonlySet<string>}
+---
+### getSourceTypes
+
+* ###Returns: {ReadonlySet<string>}
 
 #### `getUnsafeCacheData()`
 
-* Returns: {UnsafeCacheData}
+---
+### getUnsafeCacheData
+
+* ###Returns: {UnsafeCacheData}
 
 Module should be unsafe cached. Get data that's needed for that.
 This data will be passed to restoreFromUnsafeCache later.
 
 #### `getWarnings()`
 
-* Returns: {Iterable<WebpackError, any, any>}
+---
+### getWarnings
+
+* ###Returns: {Iterable<WebpackError, any, any>}
 
 #### `hasChunkCondition()`
 
-* Returns: {boolean}
+---
+### hasChunkCondition
+
+* ###Returns: {boolean}
 
 #### `hasReasonForChunk(chunk, moduleGraph, chunkGraph)`
+
+---
+### hasReasonForChunk
 
 * `chunk` {Chunk}
 * `moduleGraph` {ModuleGraph}
 * `chunkGraph` {ChunkGraph}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `hasReasons(moduleGraph, runtime)`
 
+---
+### hasReasons
+
 * `moduleGraph` {ModuleGraph}
 * `runtime` {RuntimeSpec}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `identifier()`
 
-* Returns: {string}
+---
+### identifier
+
+* ###Returns: {string}
 
 #### `invalidateBuild()`
 
-* Returns: {void}
+---
+### invalidateBuild
+
+* ###Returns: {void}
 
 #### `isAccessibleInChunk(chunkGraph, chunk[, ignoreChunk])`
+
+---
+### isAccessibleInChunk
 
 * `chunkGraph` {ChunkGraph}
 * `chunk` {Chunk}
 * `ignoreChunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isAccessibleInChunkGroup(chunkGraph, chunkGroup[, ignoreChunk])`
+
+---
+### isAccessibleInChunkGroup
 
 * `chunkGraph` {ChunkGraph}
 * `chunkGroup` {ChunkGroup}
 * `ignoreChunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isEntryModule()`
 
-* Returns: {boolean}
+---
+### isEntryModule
+
+* ###Returns: {boolean}
 
 #### `isInChunk(chunk)`
 
+---
+### isInChunk
+
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isOptional(moduleGraph)`
 
+---
+### isOptional
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isProvided(exportName)`
 
+---
+### isProvided
+
 * `exportName` {string}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `libIdent(options)`
 
+---
+### libIdent
+
 * `options` {LibIdentOptions}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `nameForCondition()`
 
-* Returns: {string}
+---
+### nameForCondition
+
+* ###Returns: {string}
 
 #### `needBuild(context, callback)`
 
+---
+### needBuild
+
 * `context` {NeedBuildContext}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `needRebuild(fileTimestamps, contextTimestamps)`
+
+---
+### needRebuild
 
 > Stability: 0 - Deprecated
 
 * `fileTimestamps` {Map<string, number>}
 * `contextTimestamps` {Map<string, number>}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 Use needBuild instead
 
 #### `originalSource()`
 
-* Returns: {Source}
+---
+### originalSource
+
+* ###Returns: {Source}
 
 #### `readableIdentifier(requestShortener)`
 
+---
+### readableIdentifier
+
 * `requestShortener` {RequestShortener}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `removeChunk(chunk)`
 
+---
+### removeChunk
+
 * `chunk` {Chunk}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `removeDependency(dependency)`
 
+---
+### removeDependency
+
 * `dependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `serialize(__namedParameters)`
 
+---
+### serialize
+
 * `__namedParameters` {ObjectSerializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `size([type])`
 
+---
+### size
+
 * `type` {string}
-* Returns: {number}
+
+* ###Returns: {number}
 
 #### `source(dependencyTemplates, runtimeTemplate[, type])`
+
+---
+### source
 
 > Stability: 0 - Deprecated
 
 * `dependencyTemplates` {DependencyTemplates}
 * `runtimeTemplate` {RuntimeTemplate}
 * `type` {string}
-* Returns: {Source}
+
+* ###Returns: {Source}
 
 Use codeGeneration() instead
 
 #### `updateCacheModule(module)`
 
+---
+### updateCacheModule
+
 * `module` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Assuming this module is in the cache. Update the (cached) module with
 the fresh module from the factory. Usually updates internal references
@@ -4034,46 +6177,66 @@ and properties.
 
 #### `updateHash(hash, context)`
 
+---
+### updateHash
+
 * `hash` {Hash}
 * `context` {UpdateHashContextDependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `getSourceBasicTypes(module)`
+
+---
+### getSourceBasicTypes
 
 > Stability: 0 - Deprecated
 
 * `module` {Module}
-* Returns: {ReadonlySet<string>}
+
+* ###Returns: {ReadonlySet<string>}
 
 In webpack 6, call getSourceBasicTypes() directly on the module instance instead of using this static method.
 
 ***
 
-## Class: `ModuleFactory`
+## 
+### Class: `ModuleFactory`
 
 ### Constructors
 
 #### `new ModuleFactory()`
 
-* Returns: {ModuleFactory}
+---
+### ModuleFactory
+
+* ###Returns: {ModuleFactory}
 
 ### Methods
 
 #### `create(data, callback)`
 
+---
+### create
+
 * `data` {ModuleFactoryCreateData}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## Class: `ModuleGraph`
+## 
+### Class: `ModuleGraph`
 
 ### Constructors
 
 #### `new ModuleGraph()`
 
-* Returns: {ModuleGraph}
+---
+### ModuleGraph
+
+* ###Returns: {ModuleGraph}
 
 ### Properties
 
@@ -4083,17 +6246,28 @@ In webpack 6, call getSourceBasicTypes() directly on the module instance instead
 
 #### `addExplanation(dependency, explanation)`
 
+---
+### addExplanation
+
 * `dependency` {Dependency}
 * `explanation` {string}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addExtraReason(module, explanation)`
 
+---
+### addExtraReason
+
 * `module` {Module}
 * `explanation` {string}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `cached(fn, args)`
+
+---
+### cached
 
 ###### T
 
@@ -4102,24 +6276,37 @@ In webpack 6, call getSourceBasicTypes() directly on the module instance instead
 ###### R
 
 `R`
+
 * `fn` {object}
 * `args` {T}
-* Returns: {R}
+
+* ###Returns: {R}
 
 #### `cloneModuleAttributes(sourceModule, targetModule)`
 
+---
+### cloneModuleAttributes
+
 * `sourceModule` {Module}
 * `targetModule` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `copyOutgoingModuleConnections(oldModule, newModule, filterConnection)`
+
+---
+### copyOutgoingModuleConnections
 
 * `oldModule` {Module}
 * `newModule` {Module}
 * `filterConnection` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `dependencyCacheProvide(dependency, args)`
+
+---
+### dependencyCacheProvide
 
 ###### D
 
@@ -4132,317 +6319,536 @@ In webpack 6, call getSourceBasicTypes() directly on the module instance instead
 ###### R
 
 `R`
+
 * `dependency` {D}
 * `args` {Tuple<ARGS, unknown>}
-* Returns: {R}
+
+* ###Returns: {R}
 
 #### `finishUpdateParent()`
 
-* Returns: {void}
+---
+### finishUpdateParent
+
+* ###Returns: {void}
 
 #### `freeze([cacheStage])`
 
+---
+### freeze
+
 * `cacheStage` {string}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `getConnection(dependency)`
 
+---
+### getConnection
+
 * `dependency` {Dependency}
-* Returns: {ModuleGraphConnection}
+
+* ###Returns: {ModuleGraphConnection}
 
 #### `getDepth(module)`
 
+---
+### getDepth
+
 * `module` {Module}
-* Returns: {number}
+
+* ###Returns: {number}
 
 #### `getExportInfo(module, exportName)`
 
+---
+### getExportInfo
+
 * `module` {Module}
 * `exportName` {string}
-* Returns: {ExportInfo}
+
+* ###Returns: {ExportInfo}
 
 #### `getExportsInfo(module)`
 
+---
+### getExportsInfo
+
 * `module` {Module}
-* Returns: {ExportsInfo}
+
+* ###Returns: {ExportsInfo}
 
 #### `getIncomingConnections(module)`
 
+---
+### getIncomingConnections
+
 * `module` {Module}
-* Returns: {Iterable<ModuleGraphConnection>}
+
+* ###Returns: {Iterable<ModuleGraphConnection>}
 
 #### `getIncomingConnectionsByOriginModule(module)`
 
+---
+### getIncomingConnectionsByOriginModule
+
 * `module` {Module}
-* Returns: {ReadonlyMap<Module, ModuleGraphConnection[]>}
+
+* ###Returns: {ReadonlyMap<Module, ModuleGraphConnection[]>}
 
 #### `getIssuer(module)`
 
+---
+### getIssuer
+
 * `module` {Module}
-* Returns: {Module}
+
+* ###Returns: {Module}
 
 #### `getMeta(thing)`
 
+---
+### getMeta
+
 * `thing` {object}
-* Returns: {Meta}
+
+* ###Returns: {Meta}
 
 #### `getMetaIfExisting(thing)`
 
+---
+### getMetaIfExisting
+
 * `thing` {object}
-* Returns: {Meta}
+
+* ###Returns: {Meta}
 
 #### `getModule(dependency)`
 
+---
+### getModule
+
 * `dependency` {Dependency}
-* Returns: {Module}
+
+* ###Returns: {Module}
 
 #### `getOptimizationBailout(module)`
 
+---
+### getOptimizationBailout
+
 * `module` {Module}
-* Returns: {string|object[]}
+
+* ###Returns: {string|object[]}
 
 #### `getOrigin(dependency)`
 
+---
+### getOrigin
+
 * `dependency` {Dependency}
-* Returns: {Module}
+
+* ###Returns: {Module}
 
 #### `getOutgoingConnections(module)`
 
+---
+### getOutgoingConnections
+
 * `module` {Module}
-* Returns: {Iterable<ModuleGraphConnection>}
+
+* ###Returns: {Iterable<ModuleGraphConnection>}
 
 #### `getOutgoingConnectionsByModule(module)`
 
+---
+### getOutgoingConnectionsByModule
+
 * `module` {Module}
-* Returns: {ReadonlyMap<Module, ModuleGraphConnection[]>}
+
+* ###Returns: {ReadonlyMap<Module, ModuleGraphConnection[]>}
 
 #### `getParentBlock(dependency)`
 
+---
+### getParentBlock
+
 * `dependency` {Dependency}
-* Returns: {DependenciesBlock}
+
+* ###Returns: {DependenciesBlock}
 
 #### `getParentBlockIndex(dependency)`
 
+---
+### getParentBlockIndex
+
 * `dependency` {Dependency}
-* Returns: {number}
+
+* ###Returns: {number}
 
 #### `getParentModule(dependency)`
 
+---
+### getParentModule
+
 * `dependency` {Dependency}
-* Returns: {Module}
+
+* ###Returns: {Module}
 
 #### `getPostOrderIndex(module)`
 
+---
+### getPostOrderIndex
+
 * `module` {Module}
-* Returns: {number}
+
+* ###Returns: {number}
 
 #### `getPreOrderIndex(module)`
 
+---
+### getPreOrderIndex
+
 * `module` {Module}
-* Returns: {number}
+
+* ###Returns: {number}
 
 #### `getProfile(module)`
 
+---
+### getProfile
+
 * `module` {Module}
-* Returns: {ModuleProfile}
+
+* ###Returns: {ModuleProfile}
 
 #### `getProvidedExports(module)`
 
+---
+### getProvidedExports
+
 * `module` {Module}
-* Returns: {true|string[]}
+
+* ###Returns: {true|string[]}
 
 #### `getReadOnlyExportInfo(module, exportName)`
 
+---
+### getReadOnlyExportInfo
+
 * `module` {Module}
 * `exportName` {string}
-* Returns: {ExportInfo}
+
+* ###Returns: {ExportInfo}
 
 #### `getResolvedModule(dependency)`
 
+---
+### getResolvedModule
+
 * `dependency` {Dependency}
-* Returns: {Module}
+
+* ###Returns: {Module}
 
 #### `getResolvedOrigin(dependency)`
 
+---
+### getResolvedOrigin
+
 * `dependency` {Dependency}
-* Returns: {Module}
+
+* ###Returns: {Module}
 
 #### `getUsedExports(module, runtime)`
 
+---
+### getUsedExports
+
 * `module` {Module}
 * `runtime` {RuntimeSpec}
-* Returns: {boolean|SortableSet<string>}
+
+* ###Returns: {boolean|SortableSet<string>}
 
 #### `isAsync(module)`
 
+---
+### isAsync
+
 * `module` {Module}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isDeferred(module)`
 
+---
+### isDeferred
+
 * `module` {Module}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isExportProvided(module, exportName)`
 
+---
+### isExportProvided
+
 * `module` {Module}
 * `exportName` {string|string[]}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `moveModuleConnections(oldModule, newModule, filterConnection)`
+
+---
+### moveModuleConnections
 
 * `oldModule` {Module}
 * `newModule` {Module}
 * `filterConnection` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `removeAllModuleAttributes()`
 
-* Returns: {void}
+---
+### removeAllModuleAttributes
+
+* ###Returns: {void}
 
 #### `removeConnection(dependency)`
 
+---
+### removeConnection
+
 * `dependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `removeModuleAttributes(module)`
 
+---
+### removeModuleAttributes
+
 * `module` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `setAsync(module)`
 
+---
+### setAsync
+
 * `module` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `setDepth(module, depth)`
 
+---
+### setDepth
+
 * `module` {Module}
 * `depth` {number}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `setDepthIfLower(module, depth)`
 
+---
+### setDepthIfLower
+
 * `module` {Module}
 * `depth` {number}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `setIssuer(module, issuer)`
 
+---
+### setIssuer
+
 * `module` {Module}
 * `issuer` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `setIssuerIfUnset(module, issuer)`
 
+---
+### setIssuerIfUnset
+
 * `module` {Module}
 * `issuer` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `setModuleMemCaches(moduleMemCaches)`
 
+---
+### setModuleMemCaches
+
 * `moduleMemCaches` {Map<Module, WeakTupleMap<any[], any>>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `setParentDependenciesBlockIndex(dependency, index)`
 
+---
+### setParentDependenciesBlockIndex
+
 * `dependency` {Dependency}
 * `index` {number}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `setParents(dependency, block, module[, indexInBlock])`
+
+---
+### setParents
 
 * `dependency` {Dependency}
 * `block` {DependenciesBlock}
 * `module` {Module}
 * `indexInBlock` {number}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `setPostOrderIndex(module, index)`
 
+---
+### setPostOrderIndex
+
 * `module` {Module}
 * `index` {number}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `setPostOrderIndexIfUnset(module, index)`
 
+---
+### setPostOrderIndexIfUnset
+
 * `module` {Module}
 * `index` {number}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `setPreOrderIndex(module, index)`
 
+---
+### setPreOrderIndex
+
 * `module` {Module}
 * `index` {number}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `setPreOrderIndexIfUnset(module, index)`
 
+---
+### setPreOrderIndexIfUnset
+
 * `module` {Module}
 * `index` {number}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `setProfile(module[, profile])`
 
+---
+### setProfile
+
 * `module` {Module}
 * `profile` {ModuleProfile}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `setResolvedModule(originModule, dependency, module)`
+
+---
+### setResolvedModule
 
 * `originModule` {Module}
 * `dependency` {Dependency}
 * `module` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `unfreeze()`
 
-* Returns: {void}
+---
+### unfreeze
+
+* ###Returns: {void}
 
 #### `updateModule(dependency, module)`
 
+---
+### updateModule
+
 * `dependency` {Dependency}
 * `module` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `updateParent(dependency[, connection][, parentModule])`
+
+---
+### updateParent
 
 * `dependency` {Dependency}
 * `connection` {ModuleGraphConnection}
 * `parentModule` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `clearModuleGraphForModule(module)`
+
+---
+### clearModuleGraphForModule
 
 > Stability: 0 - Deprecated
 
 * `module` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `getModuleGraphForModule(module, deprecateMessage, deprecationCode)`
+
+---
+### getModuleGraphForModule
 
 > Stability: 0 - Deprecated
 
 * `module` {Module}
 * `deprecateMessage` {string}
 * `deprecationCode` {string}
-* Returns: {ModuleGraph}
+
+* ###Returns: {ModuleGraph}
 
 #### Static method: `setModuleGraphForModule(module, moduleGraph)`
+
+---
+### setModuleGraphForModule
 
 > Stability: 0 - Deprecated
 
 * `module` {Module}
 * `moduleGraph` {ModuleGraph}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## Class: `ModuleGraphConnection`
+## 
+### Class: `ModuleGraphConnection`
 
 ### Constructors
 
 #### `new ModuleGraphConnection(originModule, dependency, module[, explanation][, weak][, condition])`
+
+---
+### ModuleGraphConnection
 
 * `originModule` {Module}
 * `dependency` {Dependency}
@@ -4450,7 +6856,8 @@ In webpack 6, call getSourceBasicTypes() directly on the module instance instead
 * `explanation` {string}
 * `weak` {boolean}
 * `condition` {false|object}
-* Returns: {ModuleGraphConnection}
+
+* ###Returns: {ModuleGraphConnection}
 
 ### Properties
 
@@ -4472,49 +6879,81 @@ In webpack 6, call getSourceBasicTypes() directly on the module instance instead
 
 #### `addCondition(condition)`
 
+---
+### addCondition
+
 * `condition` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addExplanation(explanation)`
 
+---
+### addExplanation
+
 * `explanation` {string}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `clone()`
 
-* Returns: {ModuleGraphConnection}
+---
+### clone
+
+* ###Returns: {ModuleGraphConnection}
 
 #### `getActiveState(runtime)`
 
+---
+### getActiveState
+
 * `runtime` {RuntimeSpec}
-* Returns: {ConnectionState}
+
+* ###Returns: {ConnectionState}
 
 #### `isActive(runtime)`
 
+---
+### isActive
+
 * `runtime` {RuntimeSpec}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isTargetActive(runtime)`
 
+---
+### isTargetActive
+
 * `runtime` {RuntimeSpec}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `setActive(value)`
 
+---
+### setActive
+
 * `value` {boolean}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## Class: `MultiCompiler`
+## 
+### Class: `MultiCompiler`
 
 ### Constructors
 
 #### `new MultiCompiler(compilers, options)`
 
+---
+### MultiCompiler
+
 * `compilers` {Compiler[]|Record<string, Compiler>}
 * `options` {MultiCompilerOptions}
-* Returns: {MultiCompiler}
+
+* ###Returns: {MultiCompiler}
 
 ### Properties
 
@@ -4533,60 +6972,95 @@ In webpack 6, call getSourceBasicTypes() directly on the module instance instead
 
 #### `close(callback)`
 
+---
+### close
+
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `getInfrastructureLogger(name)`
 
+---
+### getInfrastructureLogger
+
 * `name` {string|object}
-* Returns: {WebpackLogger}
+
+* ###Returns: {WebpackLogger}
 
 #### `purgeInputFileSystem()`
 
-* Returns: {void}
+---
+### purgeInputFileSystem
+
+* ###Returns: {void}
 
 #### `run(callback)`
 
+---
+### run
+
 * `callback` {CallbackWebpackFunction_2<MultiStats, void>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `runWithDependencies(compilers, fn, callback)`
+
+---
+### runWithDependencies
 
 > Stability: 0 - Deprecated
 
 * `compilers` {Compiler[]}
 * `fn` {object}
 * `callback` {CallbackWebpackFunction_2<Stats[], void>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 This method should have been private
 
 #### `setDependencies(compiler, dependencies)`
 
+---
+### setDependencies
+
 * `compiler` {Compiler}
 * `dependencies` {string[]}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `validateDependencies(callback)`
 
+---
+### validateDependencies
+
 * `callback` {CallbackWebpackFunction_2<MultiStats, void>}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `watch(watchOptions, handler)`
 
+---
+### watch
+
 * `watchOptions` {WatchOptions|WatchOptions[]}
 * `handler` {CallbackWebpackFunction_2<MultiStats, void>}
-* Returns: {MultiWatching}
+
+* ###Returns: {MultiWatching}
 
 ***
 
-## Class: `MultiStats`
+## 
+### Class: `MultiStats`
 
 ### Constructors
 
 #### `new MultiStats()`
 
-* Returns: {MultiStats}
+---
+### MultiStats
+
+* ###Returns: {MultiStats}
 
 ### Properties
 
@@ -4597,44 +7071,67 @@ This method should have been private
 
 #### `hasErrors()`
 
-* Returns: {boolean}
+---
+### hasErrors
+
+* ###Returns: {boolean}
 
 #### `hasWarnings()`
 
-* Returns: {boolean}
+---
+### hasWarnings
+
+* ###Returns: {boolean}
 
 #### `toJson([options])`
 
+---
+### toJson
+
 * `options` {boolean|"verbose"|"none"|"summary"|"errors-only"|"errors-warnings"|"minimal"|"normal"|"detailed"|StatsOptions}
-* Returns: {StatsCompilation}
+
+* ###Returns: {StatsCompilation}
 
 #### `toString([options])`
 
+---
+### toString
+
 * `options` {boolean|"verbose"|"none"|"summary"|"errors-only"|"errors-warnings"|"minimal"|"normal"|"detailed"|StatsOptions}
-* Returns: {string}
+
+* ###Returns: {string}
 
 ***
 
-## Class: `NoEmitOnErrorsPlugin`
+## 
+### Class: `NoEmitOnErrorsPlugin`
 
 ### Constructors
 
 #### `new NoEmitOnErrorsPlugin()`
 
-* Returns: {NoEmitOnErrorsPlugin}
+---
+### NoEmitOnErrorsPlugin
+
+* ###Returns: {NoEmitOnErrorsPlugin}
 
 ### Methods
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `NormalModule`
+## 
+### Class: `NormalModule`
 
 ### Extends
 
@@ -4644,8 +7141,12 @@ Apply the plugin
 
 #### `new NormalModule(__namedParameters)`
 
+---
+### NormalModule
+
 * `__namedParameters` {NormalModuleCreateData}
-* Returns: {NormalModule}
+
+* ###Returns: {NormalModule}
 
 ### Properties
 
@@ -4704,169 +7205,278 @@ Apply the plugin
 
 #### `addBlock(block)`
 
+---
+### addBlock
+
 * `block` {AsyncDependenciesBlock}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Adds a DependencyBlock to DependencyBlock relationship.
 This is used for when a Module has a AsyncDependencyBlock tie (for code-splitting)
 
 #### `addCacheDependencies(fileDependencies, contextDependencies, missingDependencies, buildDependencies)`
 
+---
+### addCacheDependencies
+
 * `fileDependencies` {LazySet<string>}
 * `contextDependencies` {LazySet<string>}
 * `missingDependencies` {LazySet<string>}
 * `buildDependencies` {LazySet<string>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addChunk(chunk)`
 
+---
+### addChunk
+
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `addCodeGenerationDependency(codeGenerationDependency)`
 
+---
+### addCodeGenerationDependency
+
 * `codeGenerationDependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addDependency(dependency)`
 
+---
+### addDependency
+
 * `dependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addError(error)`
 
+---
+### addError
+
 * `error` {WebpackError}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addPresentationalDependency(presentationalDependency)`
 
+---
+### addPresentationalDependency
+
 * `presentationalDependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addWarning(warning)`
 
+---
+### addWarning
+
 * `warning` {WebpackError}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `applyNoParseRule(rule, content)`
 
+---
+### applyNoParseRule
+
 * `rule` {string|RegExp|object}
 * `content` {string}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `build(options, compilation, resolver, fs, callback)`
+
+---
+### build
 
 * `options` {WebpackOptionsNormalizedWithDefaults}
 * `compilation` {Compilation}
 * `resolver` {ResolverWithOptions}
 * `fs` {InputFileSystem}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `chunkCondition(chunk, compilation)`
 
+---
+### chunkCondition
+
 * `chunk` {Chunk}
 * `compilation` {Compilation}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `cleanupForCache()`
 
-* Returns: {void}
+---
+### cleanupForCache
+
+* ###Returns: {void}
 
 Assuming this module is in the cache. Remove internal references to allow freeing some memory.
 
 #### `clearDependenciesAndBlocks()`
 
-* Returns: {void}
+---
+### clearDependenciesAndBlocks
+
+* ###Returns: {void}
 
 Removes all dependencies and blocks
 
 #### `clearWarningsAndErrors()`
 
-* Returns: {void}
+---
+### clearWarningsAndErrors
+
+* ###Returns: {void}
 
 removes all warnings and errors
 
 #### `codeGeneration(context)`
 
+---
+### codeGeneration
+
 * `context` {CodeGenerationContext}
-* Returns: {CodeGenerationResult}
+
+* ###Returns: {CodeGenerationResult}
 
 #### `createSource(context, content[, sourceMap][, associatedObjectForCache])`
+
+---
+### createSource
 
 * `context` {string}
 * `content` {string|Buffer<ArrayBufferLike>}
 * `sourceMap` {string|RawSourceMap}
 * `associatedObjectForCache` {object}
-* Returns: {Source}
+
+* ###Returns: {Source}
 
 #### `createSourceForAsset(context, name, content[, sourceMap][, associatedObjectForCache])`
+
+---
+### createSourceForAsset
 
 * `context` {string}
 * `name` {string}
 * `content` {string|Buffer<ArrayBufferLike>}
 * `sourceMap` {string|RawSourceMap}
 * `associatedObjectForCache` {object}
-* Returns: {Source}
+
+* ###Returns: {Source}
 
 #### `deserialize(__namedParameters)`
 
+---
+### deserialize
+
 * `__namedParameters` {ObjectDeserializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `getChunks()`
 
-* Returns: {Chunk[]}
+---
+### getChunks
+
+* ###Returns: {Chunk[]}
 
 #### `getConcatenationBailoutReason(context)`
 
+---
+### getConcatenationBailoutReason
+
 * `context` {ConcatenationBailoutReasonContext}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `getCurrentLoader(loaderContext[, index])`
 
+---
+### getCurrentLoader
+
 * `loaderContext` {AnyLoaderContext}
 * `index` {number}
-* Returns: {LoaderItem}
+
+* ###Returns: {LoaderItem}
 
 #### `getErrors()`
 
-* Returns: {Iterable<WebpackError, any, any>}
+---
+### getErrors
+
+* ###Returns: {Iterable<WebpackError, any, any>}
 
 #### `getExportsType(moduleGraph[, strict])`
 
+---
+### getExportsType
+
 * `moduleGraph` {ModuleGraph}
 * `strict` {boolean}
-* Returns: {ExportsType}
+
+* ###Returns: {ExportsType}
 
 #### `getNumberOfChunks()`
 
-* Returns: {number}
+---
+### getNumberOfChunks
+
+* ###Returns: {number}
 
 #### `getNumberOfErrors()`
 
-* Returns: {number}
+---
+### getNumberOfErrors
+
+* ###Returns: {number}
 
 #### `getNumberOfWarnings()`
 
-* Returns: {number}
+---
+### getNumberOfWarnings
+
+* ###Returns: {number}
 
 #### `getResource()`
 
-* Returns: {string}
+---
+### getResource
+
+* ###Returns: {string}
 
 #### `getRootBlock()`
 
-* Returns: {DependenciesBlock}
+---
+### getRootBlock
+
+* ###Returns: {DependenciesBlock}
 
 #### `getSideEffectsConnectionState(moduleGraph)`
 
+---
+### getSideEffectsConnectionState
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {ConnectionState}
+
+* ###Returns: {ConnectionState}
 
 #### `getSourceBasicTypes()`
 
-* Returns: {ReadonlySet<string>}
+---
+### getSourceBasicTypes
+
+* ###Returns: {ReadonlySet<string>}
 
 Basic source types are high-level categories like javascript, css, webassembly, etc.
 We only have built-in knowledge about the javascript basic type here; other basic types may be
@@ -4876,165 +7486,272 @@ from getSourceTypes(), but their generated output is still JavaScript, i.e. thei
 
 #### `getSourceTypes()`
 
-* Returns: {ReadonlySet<string>}
+---
+### getSourceTypes
+
+* ###Returns: {ReadonlySet<string>}
 
 #### `getUnsafeCacheData()`
 
-* Returns: {UnsafeCacheData}
+---
+### getUnsafeCacheData
+
+* ###Returns: {UnsafeCacheData}
 
 Module should be unsafe cached. Get data that's needed for that.
 This data will be passed to restoreFromUnsafeCache later.
 
 #### `getWarnings()`
 
-* Returns: {Iterable<WebpackError, any, any>}
+---
+### getWarnings
+
+* ###Returns: {Iterable<WebpackError, any, any>}
 
 #### `hasChunkCondition()`
 
-* Returns: {boolean}
+---
+### hasChunkCondition
+
+* ###Returns: {boolean}
 
 #### `hasReasonForChunk(chunk, moduleGraph, chunkGraph)`
+
+---
+### hasReasonForChunk
 
 * `chunk` {Chunk}
 * `moduleGraph` {ModuleGraph}
 * `chunkGraph` {ChunkGraph}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `hasReasons(moduleGraph, runtime)`
 
+---
+### hasReasons
+
 * `moduleGraph` {ModuleGraph}
 * `runtime` {RuntimeSpec}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `identifier()`
 
-* Returns: {string}
+---
+### identifier
+
+* ###Returns: {string}
 
 #### `invalidateBuild()`
 
-* Returns: {void}
+---
+### invalidateBuild
+
+* ###Returns: {void}
 
 #### `isAccessibleInChunk(chunkGraph, chunk[, ignoreChunk])`
+
+---
+### isAccessibleInChunk
 
 * `chunkGraph` {ChunkGraph}
 * `chunk` {Chunk}
 * `ignoreChunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isAccessibleInChunkGroup(chunkGraph, chunkGroup[, ignoreChunk])`
+
+---
+### isAccessibleInChunkGroup
 
 * `chunkGraph` {ChunkGraph}
 * `chunkGroup` {ChunkGroup}
 * `ignoreChunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isEntryModule()`
 
-* Returns: {boolean}
+---
+### isEntryModule
+
+* ###Returns: {boolean}
 
 #### `isInChunk(chunk)`
 
+---
+### isInChunk
+
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isOptional(moduleGraph)`
 
+---
+### isOptional
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isProvided(exportName)`
 
+---
+### isProvided
+
 * `exportName` {string}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `libIdent(options)`
 
+---
+### libIdent
+
 * `options` {LibIdentOptions}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `markModuleAsErrored(error)`
 
+---
+### markModuleAsErrored
+
 * `error` {WebpackError}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `nameForCondition()`
 
-* Returns: {string}
+---
+### nameForCondition
+
+* ###Returns: {string}
 
 #### `needBuild(context, callback)`
 
+---
+### needBuild
+
 * `context` {NeedBuildContext}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `needRebuild(fileTimestamps, contextTimestamps)`
+
+---
+### needRebuild
 
 > Stability: 0 - Deprecated
 
 * `fileTimestamps` {Map<string, number>}
 * `contextTimestamps` {Map<string, number>}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 Use needBuild instead
 
 #### `originalSource()`
 
-* Returns: {Source}
+---
+### originalSource
+
+* ###Returns: {Source}
 
 #### `readableIdentifier(requestShortener)`
 
+---
+### readableIdentifier
+
 * `requestShortener` {RequestShortener}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `removeChunk(chunk)`
 
+---
+### removeChunk
+
 * `chunk` {Chunk}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `removeDependency(dependency)`
 
+---
+### removeDependency
+
 * `dependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `restoreFromUnsafeCache(unsafeCacheData, normalModuleFactory)`
 
+---
+### restoreFromUnsafeCache
+
 * `unsafeCacheData` {UnsafeCacheData}
 * `normalModuleFactory` {NormalModuleFactory}
-* Returns: {void}
+
+* ###Returns: {void}
 
 restore unsafe cache data
 
 #### `serialize(__namedParameters)`
 
+---
+### serialize
+
 * `__namedParameters` {ObjectSerializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `shouldPreventParsing(noParseRule, request)`
 
+---
+### shouldPreventParsing
+
 * `noParseRule` {string|RegExp|object|string|RegExp|object[]}
 * `request` {string}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `size([type])`
 
+---
+### size
+
 * `type` {string}
-* Returns: {number}
+
+* ###Returns: {number}
 
 #### `source(dependencyTemplates, runtimeTemplate[, type])`
+
+---
+### source
 
 > Stability: 0 - Deprecated
 
 * `dependencyTemplates` {DependencyTemplates}
 * `runtimeTemplate` {RuntimeTemplate}
 * `type` {string}
-* Returns: {Source}
+
+* ###Returns: {Source}
 
 Use codeGeneration() instead
 
 #### `updateCacheModule(module)`
 
+---
+### updateCacheModule
+
 * `module` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Assuming this module is in the cache. Update the (cached) module with
 the fresh module from the factory. Usually updates internal references
@@ -5042,40 +7759,61 @@ and properties.
 
 #### `updateHash(hash, context)`
 
+---
+### updateHash
+
 * `hash` {Hash}
 * `context` {UpdateHashContextDependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `deserialize(context)`
 
+---
+### deserialize
+
 * `context` {ObjectDeserializerContext}
-* Returns: {NormalModule}
+
+* ###Returns: {NormalModule}
 
 #### Static method: `getCompilationHooks(compilation)`
 
+---
+### getCompilationHooks
+
 * `compilation` {Compilation}
-* Returns: {NormalModuleCompilationHooks}
+
+* ###Returns: {NormalModuleCompilationHooks}
 
 #### Static method: `getSourceBasicTypes(module)`
+
+---
+### getSourceBasicTypes
 
 > Stability: 0 - Deprecated
 
 * `module` {Module}
-* Returns: {ReadonlySet<string>}
+
+* ###Returns: {ReadonlySet<string>}
 
 In webpack 6, call getSourceBasicTypes() directly on the module instance instead of using this static method.
 
 ***
 
-## Class: `NormalModuleReplacementPlugin`
+## 
+### Class: `NormalModuleReplacementPlugin`
 
 ### Constructors
 
 #### `new NormalModuleReplacementPlugin(resourceRegExp, newResource)`
 
+---
+### NormalModuleReplacementPlugin
+
 * `resourceRegExp` {RegExp}
 * `newResource` {string|object}
-* Returns: {NormalModuleReplacementPlugin}
+
+* ###Returns: {NormalModuleReplacementPlugin}
 
 Create an instance of the plugin
 
@@ -5088,14 +7826,19 @@ Create an instance of the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `Parser`
+## 
+### Class: `Parser`
 
 ### Extended by
 
@@ -5105,26 +7848,38 @@ Apply the plugin
 
 #### `new Parser()`
 
-* Returns: {ParserClass}
+---
+### Parser
+
+* ###Returns: {ParserClass}
 
 ### Methods
 
 #### `parse(source, state)`
 
+---
+### parse
+
 * `source` {string|Buffer<ArrayBufferLike>|PreparsedAst}
 * `state` {ParserState}
-* Returns: {ParserState}
+
+* ###Returns: {ParserState}
 
 ***
 
-## Class: `PlatformPlugin`
+## 
+### Class: `PlatformPlugin`
 
 ### Constructors
 
 #### `new PlatformPlugin(platform)`
 
+---
+### PlatformPlugin
+
 * `platform` {Partial<PlatformTargetProperties>}
-* Returns: {PlatformPlugin}
+
+* ###Returns: {PlatformPlugin}
 
 ### Properties
 
@@ -5134,22 +7889,31 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `PrefetchPlugin`
+## 
+### Class: `PrefetchPlugin`
 
 ### Constructors
 
 #### `new PrefetchPlugin(context[, request])`
 
+---
+### PrefetchPlugin
+
 * `context` {string}
 * `request` {string}
-* Returns: {PrefetchPlugin}
+
+* ###Returns: {PrefetchPlugin}
 
 ### Properties
 
@@ -5160,21 +7924,30 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `ProgressPlugin`
+## 
+### Class: `ProgressPlugin`
 
 ### Constructors
 
 #### `new ProgressPlugin([options])`
 
+---
+### ProgressPlugin
+
 * `options` {ProgressPluginArgument}
-* Returns: {ProgressPlugin}
+
+* ###Returns: {ProgressPlugin}
 
 ### Properties
 
@@ -5195,24 +7968,37 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler|MultiCompiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `getReporter(compiler)`
 
+---
+### getReporter
+
 * `compiler` {Compiler}
-* Returns: {object}
+
+* ###Returns: {object}
 
 ***
 
-## Class: `ProvidePlugin`
+## 
+### Class: `ProvidePlugin`
 
 ### Constructors
 
 #### `new ProvidePlugin(definitions)`
 
+---
+### ProvidePlugin
+
 * `definitions` {Record<string, string|string[]>}
-* Returns: {ProvidePlugin}
+
+* ###Returns: {ProvidePlugin}
 
 ### Properties
 
@@ -5222,20 +8008,28 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `Resolver`
+## 
+### Class: `Resolver`
 
 ### Constructors
 
 #### `new Resolver()`
 
-* Returns: {Resolver}
+---
+### Resolver
+
+* ###Returns: {Resolver}
 
 ### Properties
 
@@ -5247,73 +8041,118 @@ Apply the plugin
 
 #### `doResolve(hook, request, message, resolveContext, callback)`
 
+---
+### doResolve
+
 * `hook` {AsyncSeriesBailHook<Tuple<ResolveRequest, ResolveContext>, ResolveRequest>}
 * `request` {ResolveRequest}
 * `message` {string}
 * `resolveContext` {ResolveContext}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `ensureHook(name)`
 
+---
+### ensureHook
+
 * `name` {string|AsyncSeriesBailHook<Tuple<ResolveRequest, ResolveContext>, ResolveRequest, UnsetAdditionalOptions>}
-* Returns: {AsyncSeriesBailHook<Tuple<ResolveRequest, ResolveContext>, ResolveRequest>}
+
+* ###Returns: {AsyncSeriesBailHook<Tuple<ResolveRequest, ResolveContext>, ResolveRequest>}
 
 #### `getHook(name)`
 
+---
+### getHook
+
 * `name` {string|AsyncSeriesBailHook<Tuple<ResolveRequest, ResolveContext>, ResolveRequest, UnsetAdditionalOptions>}
-* Returns: {AsyncSeriesBailHook<Tuple<ResolveRequest, ResolveContext>, ResolveRequest>}
+
+* ###Returns: {AsyncSeriesBailHook<Tuple<ResolveRequest, ResolveContext>, ResolveRequest>}
 
 #### `isDirectory(path)`
 
+---
+### isDirectory
+
 * `path` {string}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isModule(path)`
 
+---
+### isModule
+
 * `path` {string}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isPrivate(path)`
 
+---
+### isPrivate
+
 * `path` {string}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `join(path, request)`
 
+---
+### join
+
 * `path` {string}
 * `request` {string}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `normalize(path)`
 
+---
+### normalize
+
 * `path` {string}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `parse(identifier)`
 
+---
+### parse
+
 * `identifier` {string}
-* Returns: {ParsedIdentifier}
+
+* ###Returns: {ParsedIdentifier}
 
 #### `resolve(context, path, request, resolveContext, callback)`
+
+---
+### resolve
 
 * `context` {ContextTypes}
 * `path` {string}
 * `request` {string}
 * `resolveContext` {ResolveContext}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `resolveSync(context, path, request)`
+
+---
+### resolveSync
 
 * `context` {ContextTypes}
 * `path` {string}
 * `request` {string}
-* Returns: {string|false}
+
+* ###Returns: {string|false}
 
 ***
 
-## Class: `RuntimeModule`
+## 
+### Class: `RuntimeModule`
 
 ### Extends
 
@@ -5330,9 +8169,13 @@ Apply the plugin
 
 #### `new RuntimeModule(name[, stage])`
 
+---
+### RuntimeModule
+
 * `name` {string}
 * `stage` {number}
-* Returns: {RuntimeModule}
+
+* ###Returns: {RuntimeModule}
 
 ### Properties
 
@@ -5388,151 +8231,251 @@ Apply the plugin
 
 #### `addBlock(block)`
 
+---
+### addBlock
+
 * `block` {AsyncDependenciesBlock}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Adds a DependencyBlock to DependencyBlock relationship.
 This is used for when a Module has a AsyncDependencyBlock tie (for code-splitting)
 
 #### `addCacheDependencies(fileDependencies, contextDependencies, missingDependencies, buildDependencies)`
 
+---
+### addCacheDependencies
+
 * `fileDependencies` {LazySet<string>}
 * `contextDependencies` {LazySet<string>}
 * `missingDependencies` {LazySet<string>}
 * `buildDependencies` {LazySet<string>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addChunk(chunk)`
 
+---
+### addChunk
+
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `addCodeGenerationDependency(codeGenerationDependency)`
 
+---
+### addCodeGenerationDependency
+
 * `codeGenerationDependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addDependency(dependency)`
 
+---
+### addDependency
+
 * `dependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addError(error)`
 
+---
+### addError
+
 * `error` {WebpackError}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addPresentationalDependency(presentationalDependency)`
 
+---
+### addPresentationalDependency
+
 * `presentationalDependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addWarning(warning)`
 
+---
+### addWarning
+
 * `warning` {WebpackError}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `attach(compilation, chunk[, chunkGraph])`
+
+---
+### attach
 
 * `compilation` {Compilation}
 * `chunk` {Chunk}
 * `chunkGraph` {ChunkGraph}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `build(options, compilation, resolver, fs, callback)`
+
+---
+### build
 
 * `options` {WebpackOptionsNormalizedWithDefaults}
 * `compilation` {Compilation}
 * `resolver` {ResolverWithOptions}
 * `fs` {InputFileSystem}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `chunkCondition(chunk, compilation)`
 
+---
+### chunkCondition
+
 * `chunk` {Chunk}
 * `compilation` {Compilation}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `cleanupForCache()`
 
-* Returns: {void}
+---
+### cleanupForCache
+
+* ###Returns: {void}
 
 Assuming this module is in the cache. Remove internal references to allow freeing some memory.
 
 #### `clearDependenciesAndBlocks()`
 
-* Returns: {void}
+---
+### clearDependenciesAndBlocks
+
+* ###Returns: {void}
 
 Removes all dependencies and blocks
 
 #### `clearWarningsAndErrors()`
 
-* Returns: {void}
+---
+### clearWarningsAndErrors
+
+* ###Returns: {void}
 
 removes all warnings and errors
 
 #### `codeGeneration(context)`
 
+---
+### codeGeneration
+
 * `context` {CodeGenerationContext}
-* Returns: {CodeGenerationResult}
+
+* ###Returns: {CodeGenerationResult}
 
 #### `deserialize(__namedParameters)`
 
+---
+### deserialize
+
 * `__namedParameters` {ObjectDeserializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `generate()`
 
-* Returns: {string}
+---
+### generate
+
+* ###Returns: {string}
 
 #### `getChunks()`
 
-* Returns: {Chunk[]}
+---
+### getChunks
+
+* ###Returns: {Chunk[]}
 
 #### `getConcatenationBailoutReason(context)`
 
+---
+### getConcatenationBailoutReason
+
 * `context` {ConcatenationBailoutReasonContext}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `getErrors()`
 
-* Returns: {Iterable<WebpackError, any, any>}
+---
+### getErrors
+
+* ###Returns: {Iterable<WebpackError, any, any>}
 
 #### `getExportsType(moduleGraph[, strict])`
 
+---
+### getExportsType
+
 * `moduleGraph` {ModuleGraph}
 * `strict` {boolean}
-* Returns: {ExportsType}
+
+* ###Returns: {ExportsType}
 
 #### `getGeneratedCode()`
 
-* Returns: {string}
+---
+### getGeneratedCode
+
+* ###Returns: {string}
 
 #### `getNumberOfChunks()`
 
-* Returns: {number}
+---
+### getNumberOfChunks
+
+* ###Returns: {number}
 
 #### `getNumberOfErrors()`
 
-* Returns: {number}
+---
+### getNumberOfErrors
+
+* ###Returns: {number}
 
 #### `getNumberOfWarnings()`
 
-* Returns: {number}
+---
+### getNumberOfWarnings
+
+* ###Returns: {number}
 
 #### `getRootBlock()`
 
-* Returns: {DependenciesBlock}
+---
+### getRootBlock
+
+* ###Returns: {DependenciesBlock}
 
 #### `getSideEffectsConnectionState(moduleGraph)`
 
+---
+### getSideEffectsConnectionState
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {ConnectionState}
+
+* ###Returns: {ConnectionState}
 
 #### `getSourceBasicTypes()`
 
-* Returns: {ReadonlySet<string>}
+---
+### getSourceBasicTypes
+
+* ###Returns: {ReadonlySet<string>}
 
 Basic source types are high-level categories like javascript, css, webassembly, etc.
 We only have built-in knowledge about the javascript basic type here; other basic types may be
@@ -5542,150 +8485,248 @@ from getSourceTypes(), but their generated output is still JavaScript, i.e. thei
 
 #### `getSourceTypes()`
 
-* Returns: {ReadonlySet<string>}
+---
+### getSourceTypes
+
+* ###Returns: {ReadonlySet<string>}
 
 #### `getUnsafeCacheData()`
 
-* Returns: {UnsafeCacheData}
+---
+### getUnsafeCacheData
+
+* ###Returns: {UnsafeCacheData}
 
 Module should be unsafe cached. Get data that's needed for that.
 This data will be passed to restoreFromUnsafeCache later.
 
 #### `getWarnings()`
 
-* Returns: {Iterable<WebpackError, any, any>}
+---
+### getWarnings
+
+* ###Returns: {Iterable<WebpackError, any, any>}
 
 #### `hasChunkCondition()`
 
-* Returns: {boolean}
+---
+### hasChunkCondition
+
+* ###Returns: {boolean}
 
 #### `hasReasonForChunk(chunk, moduleGraph, chunkGraph)`
+
+---
+### hasReasonForChunk
 
 * `chunk` {Chunk}
 * `moduleGraph` {ModuleGraph}
 * `chunkGraph` {ChunkGraph}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `hasReasons(moduleGraph, runtime)`
 
+---
+### hasReasons
+
 * `moduleGraph` {ModuleGraph}
 * `runtime` {RuntimeSpec}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `identifier()`
 
-* Returns: {string}
+---
+### identifier
+
+* ###Returns: {string}
 
 #### `invalidateBuild()`
 
-* Returns: {void}
+---
+### invalidateBuild
+
+* ###Returns: {void}
 
 #### `isAccessibleInChunk(chunkGraph, chunk[, ignoreChunk])`
+
+---
+### isAccessibleInChunk
 
 * `chunkGraph` {ChunkGraph}
 * `chunk` {Chunk}
 * `ignoreChunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isAccessibleInChunkGroup(chunkGraph, chunkGroup[, ignoreChunk])`
+
+---
+### isAccessibleInChunkGroup
 
 * `chunkGraph` {ChunkGraph}
 * `chunkGroup` {ChunkGroup}
 * `ignoreChunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isEntryModule()`
 
-* Returns: {boolean}
+---
+### isEntryModule
+
+* ###Returns: {boolean}
 
 #### `isInChunk(chunk)`
 
+---
+### isInChunk
+
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isOptional(moduleGraph)`
 
+---
+### isOptional
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isProvided(exportName)`
 
+---
+### isProvided
+
 * `exportName` {string}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `libIdent(options)`
 
+---
+### libIdent
+
 * `options` {LibIdentOptions}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `nameForCondition()`
 
-* Returns: {string}
+---
+### nameForCondition
+
+* ###Returns: {string}
 
 #### `needBuild(context, callback)`
 
+---
+### needBuild
+
 * `context` {NeedBuildContext}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `needRebuild(fileTimestamps, contextTimestamps)`
+
+---
+### needRebuild
 
 > Stability: 0 - Deprecated
 
 * `fileTimestamps` {Map<string, number>}
 * `contextTimestamps` {Map<string, number>}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 Use needBuild instead
 
 #### `originalSource()`
 
-* Returns: {Source}
+---
+### originalSource
+
+* ###Returns: {Source}
 
 #### `readableIdentifier(requestShortener)`
 
+---
+### readableIdentifier
+
 * `requestShortener` {RequestShortener}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `removeChunk(chunk)`
 
+---
+### removeChunk
+
 * `chunk` {Chunk}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `removeDependency(dependency)`
 
+---
+### removeDependency
+
 * `dependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `serialize(__namedParameters)`
 
+---
+### serialize
+
 * `__namedParameters` {ObjectSerializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `shouldIsolate()`
 
-* Returns: {boolean}
+---
+### shouldIsolate
+
+* ###Returns: {boolean}
 
 #### `size([type])`
 
+---
+### size
+
 * `type` {string}
-* Returns: {number}
+
+* ###Returns: {number}
 
 #### `source(dependencyTemplates, runtimeTemplate[, type])`
+
+---
+### source
 
 > Stability: 0 - Deprecated
 
 * `dependencyTemplates` {DependencyTemplates}
 * `runtimeTemplate` {RuntimeTemplate}
 * `type` {string}
-* Returns: {Source}
+
+* ###Returns: {Source}
 
 Use codeGeneration() instead
 
 #### `updateCacheModule(module)`
 
+---
+### updateCacheModule
+
 * `module` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Assuming this module is in the cache. Update the (cached) module with
 the fresh module from the factory. Usually updates internal references
@@ -5693,29 +8734,42 @@ and properties.
 
 #### `updateHash(hash, context)`
 
+---
+### updateHash
+
 * `hash` {Hash}
 * `context` {UpdateHashContextDependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `getSourceBasicTypes(module)`
+
+---
+### getSourceBasicTypes
 
 > Stability: 0 - Deprecated
 
 * `module` {Module}
-* Returns: {ReadonlySet<string>}
+
+* ###Returns: {ReadonlySet<string>}
 
 In webpack 6, call getSourceBasicTypes() directly on the module instance instead of using this static method.
 
 ***
 
-## Class: `SourceMapDevToolPlugin`
+## 
+### Class: `SourceMapDevToolPlugin`
 
 ### Constructors
 
 #### `new SourceMapDevToolPlugin([options])`
 
+---
+### SourceMapDevToolPlugin
+
 * `options` {SourceMapDevToolPluginOptions}
-* Returns: {SourceMapDevToolPlugin}
+
+* ###Returns: {SourceMapDevToolPlugin}
 
 ### Properties
 
@@ -5730,21 +8784,30 @@ In webpack 6, call getSourceBasicTypes() directly on the module instance instead
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `Stats`
+## 
+### Class: `Stats`
 
 ### Constructors
 
 #### `new Stats(compilation)`
 
+---
+### Stats
+
 * `compilation` {Compilation}
-* Returns: {Stats}
+
+* ###Returns: {Stats}
 
 ### Properties
 
@@ -5757,31 +8820,49 @@ Apply the plugin
 
 #### `hasErrors()`
 
-* Returns: {boolean}
+---
+### hasErrors
+
+* ###Returns: {boolean}
 
 #### `hasWarnings()`
 
-* Returns: {boolean}
+---
+### hasWarnings
+
+* ###Returns: {boolean}
 
 #### `toJson([options])`
 
+---
+### toJson
+
 * `options` {boolean|"verbose"|"none"|"summary"|"errors-only"|"errors-warnings"|"minimal"|"normal"|"detailed"|StatsOptions}
-* Returns: {StatsCompilation}
+
+* ###Returns: {StatsCompilation}
 
 #### `toString([options])`
 
+---
+### toString
+
 * `options` {boolean|"verbose"|"none"|"summary"|"errors-only"|"errors-warnings"|"minimal"|"normal"|"detailed"|StatsOptions}
-* Returns: {string}
+
+* ###Returns: {string}
 
 ***
 
-## Class: `Template`
+## 
+### Class: `Template`
 
 ### Constructors
 
 #### `new Template()`
 
-* Returns: {Template}
+---
+### Template
+
+* ###Returns: {Template}
 
 ### Properties
 
@@ -5792,90 +8873,151 @@ Apply the plugin
 
 #### Static method: `asString(str)`
 
+---
+### asString
+
 * `str` {string|string[]}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### Static method: `getFunctionContent(fn)`
 
+---
+### getFunctionContent
+
 * `fn` {Stringable}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### Static method: `getModulesArrayBounds(modules)`
 
+---
+### getModulesArrayBounds
+
 * `modules` {WithId[]}
-* Returns: {false|Tuple<number, number>}
+
+* ###Returns: {false|Tuple<number, number>}
 
 #### Static method: `indent(s)`
 
+---
+### indent
+
 * `s` {string|string[]}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### Static method: `numberToIdentifier(n)`
 
+---
+### numberToIdentifier
+
 * `n` {number}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### Static method: `numberToIdentifierContinuation(n)`
 
+---
+### numberToIdentifierContinuation
+
 * `n` {number}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### Static method: `prefix(s, prefix)`
 
+---
+### prefix
+
 * `s` {string|string[]}
 * `prefix` {string}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### Static method: `renderChunkModules(renderContext, modules, renderModule[, prefix])`
+
+---
+### renderChunkModules
 
 * `renderContext` {ChunkRenderContextJavascriptModulesPlugin}
 * `modules` {Module[]}
 * `renderModule` {object}
 * `prefix` {string}
-* Returns: {Source}
+
+* ###Returns: {Source}
 
 #### Static method: `renderChunkRuntimeModules(runtimeModules, renderContext)`
 
+---
+### renderChunkRuntimeModules
+
 * `runtimeModules` {RuntimeModule[]}
 * `renderContext` {RenderContextJavascriptModulesPlugin}
-* Returns: {Source}
+
+* ###Returns: {Source}
 
 #### Static method: `renderRuntimeModules(runtimeModules, renderContext)`
 
+---
+### renderRuntimeModules
+
 * `runtimeModules` {RuntimeModule[]}
 * `renderContext` {RenderContextJavascriptModulesPlugin|object}
-* Returns: {Source}
+
+* ###Returns: {Source}
 
 #### Static method: `toComment(str)`
 
+---
+### toComment
+
 * `str` {string}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### Static method: `toIdentifier(str)`
 
+---
+### toIdentifier
+
 * `str` {string}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### Static method: `toNormalComment(str)`
 
+---
+### toNormalComment
+
 * `str` {string}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### Static method: `toPath(str)`
 
+---
+### toPath
+
 * `str` {string}
-* Returns: {string}
+
+* ###Returns: {string}
 
 ***
 
-## Class: `WatchIgnorePlugin`
+## 
+### Class: `WatchIgnorePlugin`
 
 ### Constructors
 
 #### `new WatchIgnorePlugin(options)`
 
+---
+### WatchIgnorePlugin
+
 * `options` {WatchIgnorePluginOptions}
-* Returns: {WatchIgnorePlugin}
+
+* ###Returns: {WatchIgnorePlugin}
 
 ### Properties
 
@@ -5885,20 +9027,28 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `Watching`
+## 
+### Class: `Watching`
 
 ### Constructors
 
 #### `new Watching()`
 
-* Returns: {Watching}
+---
+### Watching
+
+* ###Returns: {Watching}
 
 ### Properties
 
@@ -5920,32 +9070,51 @@ Apply the plugin
 
 #### `close(callback)`
 
+---
+### close
+
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `invalidate([callback])`
 
+---
+### invalidate
+
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `resume()`
 
-* Returns: {void}
+---
+### resume
+
+* ###Returns: {void}
 
 #### `suspend()`
 
-* Returns: {void}
+---
+### suspend
+
+* ###Returns: {void}
 
 #### `watch(files, dirs, missing)`
+
+---
+### watch
 
 * `files` {Iterable<string>}
 * `dirs` {Iterable<string>}
 * `missing` {Iterable<string>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## Class: `WebpackError`
+## 
+### Class: `WebpackError`
 
 ### Extends
 
@@ -5959,9 +9128,13 @@ Apply the plugin
 
 #### `new WebpackError([message][, options])`
 
+---
+### WebpackError
+
 * `message` {string}
 * `options` {object}
-* Returns: {WebpackError}
+
+* ###Returns: {WebpackError}
 
 Creates an instance of WebpackError.
 
@@ -5988,19 +9161,31 @@ not capture any frames.
 
 #### `deserialize(__namedParameters)`
 
+---
+### deserialize
+
 * `__namedParameters` {ObjectDeserializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `serialize(__namedParameters)`
 
+---
+### serialize
+
 * `__namedParameters` {ObjectSerializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `captureStackTrace(targetObject[, constructorOpt])`
 
+---
+### captureStackTrace
+
 * `targetObject` {object}
 * `constructorOpt` {Function}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Creates a `.stack` property on `targetObject`, which when accessed returns
 a string representing the location in the code at which
@@ -6039,13 +9224,18 @@ a();
 
 #### Static method: `prepareStackTrace(err, stackTraces)`
 
+---
+### prepareStackTrace
+
 * `err` {Error}
 * `stackTraces` {CallSite[]}
-* Returns: {any}
+
+* ###Returns: {any}
 
 ***
 
-## Class: `WebpackOptionsApply`
+## 
+### Class: `WebpackOptionsApply`
 
 ### Extends
 
@@ -6055,37 +9245,53 @@ a();
 
 #### `new WebpackOptionsApply()`
 
-* Returns: {WebpackOptionsApply}
+---
+### WebpackOptionsApply
+
+* ###Returns: {WebpackOptionsApply}
 
 ### Methods
 
 #### `process(options, compiler[, interception])`
 
+---
+### process
+
 * `options` {WebpackOptionsNormalizedWithDefaults}
 * `compiler` {Compiler}
 * `interception` {WebpackOptionsInterception}
-* Returns: {WebpackOptionsNormalizedWithDefaults}
+
+* ###Returns: {WebpackOptionsNormalizedWithDefaults}
 
 ***
 
-## Class: `WebpackOptionsDefaulter`
+## 
+### Class: `WebpackOptionsDefaulter`
 
 ### Constructors
 
 #### `new WebpackOptionsDefaulter()`
 
-* Returns: {WebpackOptionsDefaulter}
+---
+### WebpackOptionsDefaulter
+
+* ###Returns: {WebpackOptionsDefaulter}
 
 ### Methods
 
 #### `process(options)`
 
+---
+### process
+
 * `options` {Configuration}
-* Returns: {WebpackOptionsNormalized}
+
+* ###Returns: {WebpackOptionsNormalized}
 
 ***
 
-## Class: `WebpackOptionsValidationError`
+## 
+### Class: `WebpackOptionsValidationError`
 
 ### Extends
 
@@ -6095,10 +9301,14 @@ a();
 
 #### `new WebpackOptionsValidationError(errors, schema[, configuration])`
 
+---
+### WebpackOptionsValidationError
+
 * `errors` {SchemaUtilErrorObject[]} array of error objects
 * `schema` {Schema} schema
 * `configuration` {ValidationErrorConfiguration} configuration
-* Returns: {ValidationError}
+
+* ###Returns: {ValidationError}
 
 ### Properties
 
@@ -6124,44 +9334,72 @@ not capture any frames.
 
 #### `formatSchema(schema[, logic][, prevSchemas])`
 
+---
+### formatSchema
+
 * `schema` {Schema} schema
 * `logic` {boolean} logic
 * `prevSchemas` {object[]} prev schemas
-* Returns: {string} formatted schema
+
+* ###Returns: {string} formatted schema
 
 #### `formatValidationError(error)`
 
+---
+### formatValidationError
+
 * `error` {SchemaUtilErrorObject} error object
-* Returns: {string} formatted error object
+
+* ###Returns: {string} formatted error object
 
 #### `formatValidationErrors(errors)`
 
+---
+### formatValidationErrors
+
 * `errors` {SchemaUtilErrorObject[]} errors
-* Returns: {string} formatted errors
+
+* ###Returns: {string} formatted errors
 
 #### `getSchemaPart(path)`
 
+---
+### getSchemaPart
+
 * `path` {string} path
-* Returns: {Schema} schema
+
+* ###Returns: {Schema} schema
 
 #### `getSchemaPartDescription([schemaPart])`
 
+---
+### getSchemaPartDescription
+
 * `schemaPart` {Schema} schema part
-* Returns: {string} schema part description
+
+* ###Returns: {string} schema part description
 
 #### `getSchemaPartText([schemaPart][, additionalPath][, needDot][, logic])`
+
+---
+### getSchemaPartText
 
 * `schemaPart` {Schema} schema part
 * `additionalPath` {boolean|string[]} additional path
 * `needDot` {boolean} true when need dot
 * `logic` {boolean} logic
-* Returns: {string} schema part text
+
+* ###Returns: {string} schema part text
 
 #### Static method: `captureStackTrace(targetObject[, constructorOpt])`
 
+---
+### captureStackTrace
+
 * `targetObject` {object}
 * `constructorOpt` {Function}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Creates a `.stack` property on `targetObject`, which when accessed returns
 a string representing the location in the code at which
@@ -6209,13 +9447,18 @@ a();
 
 #### Static method: `prepareStackTrace(err, stackTraces)`
 
+---
+### prepareStackTrace
+
 * `err` {Error}
 * `stackTraces` {CallSite[]}
-* Returns: {any}
+
+* ###Returns: {any}
 
 ***
 
-## Interface: `Argument`
+## 
+### Interface: `Argument`
 
 ### Properties
 
@@ -6226,7 +9469,8 @@ a();
 
 ***
 
-## Interface: `Asset`
+## 
+### Interface: `Asset`
 
 ### Properties
 
@@ -6236,7 +9480,8 @@ a();
 
 ***
 
-## Interface: `AssetEmittedInfo`
+## 
+### Interface: `AssetEmittedInfo`
 
 ### Properties
 
@@ -6248,7 +9493,8 @@ a();
 
 ***
 
-## Interface: `Colors`
+## 
+### Interface: `Colors`
 
 ### Properties
 
@@ -6296,7 +9542,8 @@ a();
 
 ***
 
-## Interface: `ColorsOptions`
+## 
+### Interface: `ColorsOptions`
 
 ### Properties
 
@@ -6304,7 +9551,8 @@ a();
 
 ***
 
-## Interface: `Configuration`
+## 
+### Interface: `Configuration`
 
 Options object as provided by the user.
 
@@ -6350,7 +9598,8 @@ Options object as provided by the user.
 
 ***
 
-## Interface: `EntryObject`
+## 
+### Interface: `EntryObject`
 
 Multiple entry bundles are created. The key is the entry name. The value can be a string, an array or an entry description object.
 
@@ -6360,7 +9609,8 @@ Multiple entry bundles are created. The key is the entry name. The value can be 
 
 ***
 
-## Interface: `ExternalItemFunctionData`
+## 
+### Interface: `ExternalItemFunctionData`
 
 ### Properties
 
@@ -6372,7 +9622,8 @@ Multiple entry bundles are created. The key is the entry name. The value can be 
 
 ***
 
-## Interface: `ExternalItemObjectKnown`
+## 
+### Interface: `ExternalItemObjectKnown`
 
 If an dependency matches exactly a property of the object, the property value is used as dependency.
 
@@ -6382,7 +9633,8 @@ If an dependency matches exactly a property of the object, the property value is
 
 ***
 
-## Interface: `ExternalItemObjectUnknown`
+## 
+### Interface: `ExternalItemObjectUnknown`
 
 If an dependency matches exactly a property of the object, the property value is used as dependency.
 
@@ -6392,7 +9644,8 @@ If an dependency matches exactly a property of the object, the property value is
 
 ***
 
-## Interface: `FileCacheOptions`
+## 
+### Interface: `FileCacheOptions`
 
 Options object for persistent file-based caching.
 
@@ -6421,7 +9674,8 @@ Options object for persistent file-based caching.
 
 ***
 
-## Interface: `GeneratorOptionsByModuleTypeKnown`
+## 
+### Interface: `GeneratorOptionsByModuleTypeKnown`
 
 Specify options for each generator.
 
@@ -6444,7 +9698,8 @@ Specify options for each generator.
 
 ***
 
-## Interface: `InputFileSystem`
+## 
+### Interface: `InputFileSystem`
 
 ### Properties
 
@@ -6469,7 +9724,8 @@ Specify options for each generator.
 
 ***
 
-## Interface: `LibraryOptions`
+## 
+### Interface: `LibraryOptions`
 
 Options for library.
 
@@ -6496,15 +9752,20 @@ Options for library.
 
 `ContextAdditions` = {object}
 
+---
+### LoaderDefinitionFunction
+
 * `this` {NormalModuleLoaderContext<OptionsType>|LoaderRunnerLoaderContext<OptionsType>|LoaderPluginLoaderContext|HotModuleReplacementPluginLoaderContext|ContextAdditions}
 * `content` {string}
 * `sourceMap` {string|RawSourceMap}
 * `additionalData` {AdditionalData}
-* Returns: {string|void|Buffer<ArrayBufferLike>|Promise<string|Buffer<ArrayBufferLike>>}
+
+* ###Returns: {string|void|Buffer<ArrayBufferLike>|Promise<string|Buffer<ArrayBufferLike>>}
 
 ***
 
-## Interface: `LoaderModule`
+## 
+### Interface: `LoaderModule`
 
 ### Type Parameters
 
@@ -6524,7 +9785,8 @@ Options for library.
 
 ***
 
-## Interface: `MemoryCacheOptions`
+## 
+### Interface: `MemoryCacheOptions`
 
 Options object for in-memory caching.
 
@@ -6536,7 +9798,8 @@ Options object for in-memory caching.
 
 ***
 
-## Interface: `ModuleOptions`
+## 
+### Interface: `ModuleOptions`
 
 Options affecting the normal modules (`NormalModuleFactory`).
 
@@ -6564,7 +9827,8 @@ Options affecting the normal modules (`NormalModuleFactory`).
 
 ***
 
-## Interface: `MultiCompilerOptions`
+## 
+### Interface: `MultiCompilerOptions`
 
 ### Properties
 
@@ -6572,7 +9836,8 @@ Options affecting the normal modules (`NormalModuleFactory`).
 
 ***
 
-## Interface: `ObjectDeserializerContext`
+## 
+### Interface: `ObjectDeserializerContext`
 
 ### Properties
 
@@ -6581,7 +9846,8 @@ Options affecting the normal modules (`NormalModuleFactory`).
 
 ***
 
-## Interface: `ObjectSerializerContext`
+## 
+### Interface: `ObjectSerializerContext`
 
 ### Properties
 
@@ -6594,7 +9860,8 @@ Options affecting the normal modules (`NormalModuleFactory`).
 
 ***
 
-## Interface: `OutputFileSystem`
+## 
+### Interface: `OutputFileSystem`
 
 ### Properties
 
@@ -6613,7 +9880,8 @@ Options affecting the normal modules (`NormalModuleFactory`).
 
 ***
 
-## Interface: `ParserOptionsByModuleTypeKnown`
+## 
+### Interface: `ParserOptionsByModuleTypeKnown`
 
 Specify options for each parser.
 
@@ -6636,7 +9904,8 @@ Specify options for each parser.
 
 ***
 
-## Interface: `PathData`
+## 
+### Interface: `PathData`
 
 ### Properties
 
@@ -6649,6 +9918,7 @@ Specify options for each parser.
 * `filename` {string}
 * `hash` {string}
 * `hashWithLength` {object}
+* `local` {string}
 * `module` {Module|ModulePathData}
 * `noChunkHash` {boolean}
 * `prepareId` {object}
@@ -6670,15 +9940,20 @@ Specify options for each parser.
 
 `ContextAdditions` = {object}
 
+---
+### PitchLoaderDefinitionFunction
+
 * `this` {NormalModuleLoaderContext<OptionsType>|LoaderRunnerLoaderContext<OptionsType>|LoaderPluginLoaderContext|HotModuleReplacementPluginLoaderContext|ContextAdditions}
 * `remainingRequest` {string}
 * `previousRequest` {string}
 * `data` {object}
-* Returns: {string|void|Buffer<ArrayBufferLike>|Promise<string|Buffer<ArrayBufferLike>>}
+
+* ###Returns: {string|void|Buffer<ArrayBufferLike>|Promise<string|Buffer<ArrayBufferLike>>}
 
 ***
 
-## Interface: `Problem`
+## 
+### Interface: `Problem`
 
 ### Properties
 
@@ -6703,15 +9978,20 @@ Specify options for each parser.
 
 `ContextAdditions` = {object}
 
+---
+### RawLoaderDefinitionFunction
+
 * `this` {NormalModuleLoaderContext<OptionsType>|LoaderRunnerLoaderContext<OptionsType>|LoaderPluginLoaderContext|HotModuleReplacementPluginLoaderContext|ContextAdditions}
 * `content` {Buffer}
 * `sourceMap` {string|RawSourceMap}
 * `additionalData` {AdditionalData}
-* Returns: {string|void|Buffer<ArrayBufferLike>|Promise<string|Buffer<ArrayBufferLike>>}
+
+* ###Returns: {string|void|Buffer<ArrayBufferLike>|Promise<string|Buffer<ArrayBufferLike>>}
 
 ***
 
-## Interface: `RenderManifestOptions`
+## 
+### Interface: `RenderManifestOptions`
 
 ### Properties
 
@@ -6728,7 +10008,8 @@ Specify options for each parser.
 
 ***
 
-## Interface: `ResolveData`
+## 
+### Interface: `ResolveData`
 
 ### Properties
 
@@ -6748,7 +10029,8 @@ Specify options for each parser.
 
 ***
 
-## Interface: `ResolveOptions`
+## 
+### Interface: `ResolveOptions`
 
 Options object for resolving requests.
 
@@ -6786,7 +10068,8 @@ Options object for resolving requests.
 
 ***
 
-## Interface: `RuleSetRule`
+## 
+### Interface: `RuleSetRule`
 
 A rule description with conditions and effects for modules.
 
@@ -6824,7 +10107,8 @@ A rule description with conditions and effects for modules.
 
 ***
 
-## Interface: `StatsOptions`
+## 
+### Interface: `StatsOptions`
 
 Stats options object.
 
@@ -6912,7 +10196,8 @@ Stats options object.
 
 ***
 
-## Interface: `WebpackOptionsNormalized`
+## 
+### Interface: `WebpackOptionsNormalized`
 
 Normalized webpack options object.
 
@@ -6957,7 +10242,8 @@ Normalized webpack options object.
 
 ***
 
-## Interface: `WebpackPluginInstance`
+## 
+### Interface: `WebpackPluginInstance`
 
 Plugin instance.
 
@@ -6971,25 +10257,29 @@ Plugin instance.
 
 ***
 
-## Type: `AssetInfo`
+## 
+### Type: `AssetInfo`
 
 > **AssetInfo** = {KnownAssetInfo|Record<string, any>}
 
 ***
 
-## Type: `Entry`
+## 
+### Type: `Entry`
 
 > **Entry** = {string|object|EntryObject|string[]}
 
 ***
 
-## Type: `EntryNormalized`
+## 
+### Type: `EntryNormalized`
 
 > **EntryNormalized** = {object|EntryStaticNormalized}
 
 ***
 
-## Type: `EntryOptions`
+## 
+### Type: `EntryOptions`
 
 > **EntryOptions** = {object|Omit<EntryDescriptionNormalized, "import">}
 
@@ -6999,80 +10289,110 @@ Plugin instance.
 
 ***
 
-## Type: `ExternalItem`
+## 
+### Type: `ExternalItem`
 
 > **ExternalItem** = {string|RegExp|ExternalItemObjectKnown|ExternalItemObjectUnknown|object|object}
 
 ***
 
-## Type: `ExternalItemFunction`
+## 
+### Type: `ExternalItemFunction`
 
 > **ExternalItemFunction** = {object|object}
 
 ***
 
-## Type: `ExternalItemFunctionCallback`
+## 
+### Type: `ExternalItemFunctionCallback`
 
 > **ExternalItemFunctionCallback** = {object}
 
+---
+### __type
+
 * `data` {ExternalItemFunctionData}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## Type: `ExternalItemFunctionDataGetResolve`
+## 
+### Type: `ExternalItemFunctionDataGetResolve`
 
 > **ExternalItemFunctionDataGetResolve** = {object}
 
+---
+### __type
+
 * `options` {ResolveOptions}
-* Returns: {object|object}
+
+* ###Returns: {object|object}
 
 ***
 
-## Type: `ExternalItemFunctionDataGetResolveCallbackResult`
+## 
+### Type: `ExternalItemFunctionDataGetResolveCallbackResult`
 
 > **ExternalItemFunctionDataGetResolveCallbackResult** = {object}
+
+---
+### __type
 
 * `context` {string}
 * `request` {string}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## Type: `ExternalItemFunctionDataGetResolveResult`
+## 
+### Type: `ExternalItemFunctionDataGetResolveResult`
 
 > **ExternalItemFunctionDataGetResolveResult** = {object}
 
+---
+### __type
+
 * `context` {string}
 * `request` {string}
-* Returns: {Promise<string>}
+
+* ###Returns: {Promise<string>}
 
 ***
 
-## Type: `ExternalItemFunctionPromise`
+## 
+### Type: `ExternalItemFunctionPromise`
 
 > **ExternalItemFunctionPromise** = {object}
 
+---
+### __type
+
 * `data` {ExternalItemFunctionData}
-* Returns: {Promise<ExternalItemValue>}
+
+* ###Returns: {Promise<ExternalItemValue>}
 
 ***
 
-## Type: `ExternalItemValue`
+## 
+### Type: `ExternalItemValue`
 
 > **ExternalItemValue** = {string|boolean|string[]|object}
 
 ***
 
-## Type: `Externals`
+## 
+### Type: `Externals`
 
 > **Externals** = {string|RegExp|ExternalItemObjectKnown|ExternalItemObjectUnknown|object|object|ExternalItem[]}
 
 ***
 
-## Type: `LoaderContext`
+## 
+### Type: `LoaderContext`
 
 > **LoaderContext**\<`OptionsType`\> = {NormalModuleLoaderContext<OptionsType>|LoaderRunnerLoaderContext<OptionsType>|LoaderPluginLoaderContext|HotModuleReplacementPluginLoaderContext}
 
@@ -7084,7 +10404,8 @@ Plugin instance.
 
 ***
 
-## Type: `LoaderDefinition`
+## 
+### Type: `LoaderDefinition`
 
 > **LoaderDefinition**\<`OptionsType`, `ContextAdditions`\> = {LoaderDefinitionFunction<OptionsType, ContextAdditions>|object}
 
@@ -7105,19 +10426,22 @@ Plugin instance.
 
 ***
 
-## Type: `MultiConfiguration`
+## 
+### Type: `MultiConfiguration`
 
 > **MultiConfiguration** = {ReadonlyArray<Configuration>|MultiCompilerOptions}
 
 ***
 
-## Type: `ParserState`
+## 
+### Type: `ParserState`
 
 > **ParserState** = {ParserStateBase|Record<string, any>}
 
 ***
 
-## Type: `RawLoaderDefinition`
+## 
+### Type: `RawLoaderDefinition`
 
 > **RawLoaderDefinition**\<`OptionsType`, `ContextAdditions`\> = {RawLoaderDefinitionFunction<OptionsType, ContextAdditions>|object}
 
@@ -7138,13 +10462,15 @@ Plugin instance.
 
 ***
 
-## Type: `RenderManifestEntry`
+## 
+### Type: `RenderManifestEntry`
 
 > **RenderManifestEntry** = {RenderManifestEntryTemplated|RenderManifestEntryStatic}
 
 ***
 
-## Type: `ResolvePluginInstance`
+## 
+### Type: `ResolvePluginInstance`
 
 > **ResolvePluginInstance** = {object|object}
 
@@ -7168,19 +10494,22 @@ Plugin instance.
 
 ***
 
-## Type: `RuleSetCondition`
+## 
+### Type: `RuleSetCondition`
 
 > **RuleSetCondition** = {string|RegExp|object|RuleSetLogicalConditions|RuleSetCondition[]}
 
 ***
 
-## Type: `RuleSetConditionAbsolute`
+## 
+### Type: `RuleSetConditionAbsolute`
 
 > **RuleSetConditionAbsolute** = {string|RegExp|object|RuleSetLogicalConditionsAbsolute|RuleSetConditionAbsolute[]}
 
 ***
 
-## Type: `RuleSetUse`
+## 
+### Type: `RuleSetUse`
 
 > **RuleSetUse** = {string|undefined|null|string|false|0|RuleSetUseFunction|object[]|RuleSetUseFunction|object}
 
@@ -7208,16 +10537,22 @@ Plugin instance.
 
 ***
 
-## Type: `RuleSetUseFunction`
+## 
+### Type: `RuleSetUseFunction`
 
 > **RuleSetUseFunction** = {object}
 
+---
+### __type
+
 * `data` {EffectData}
-* Returns: {string|RuleSetUseFunction|object|undefined|null|string|false|0|RuleSetUseFunction|object[]}
+
+* ###Returns: {string|RuleSetUseFunction|object|undefined|null|string|false|0|RuleSetUseFunction|object[]}
 
 ***
 
-## Type: `RuleSetUseItem`
+## 
+### Type: `RuleSetUseItem`
 
 > **RuleSetUseItem** = {string|RuleSetUseFunction|object}
 
@@ -7241,139 +10576,172 @@ Plugin instance.
 
 ***
 
-## Type: `StatsAsset`
+## 
+### Type: `StatsAsset`
 
 > **StatsAsset** = {KnownStatsAsset|Record<string, any>}
 
 ***
 
-## Type: `StatsChunk`
+## 
+### Type: `StatsChunk`
 
 > **StatsChunk** = {KnownStatsChunk|Record<string, any>}
 
 ***
 
-## Type: `StatsChunkGroup`
+## 
+### Type: `StatsChunkGroup`
 
 > **StatsChunkGroup** = {KnownStatsChunkGroup|Record<string, any>}
 
 ***
 
-## Type: `StatsChunkOrigin`
+## 
+### Type: `StatsChunkOrigin`
 
 > **StatsChunkOrigin** = {KnownStatsChunkOrigin|Record<string, any>}
 
 ***
 
-## Type: `StatsCompilation`
+## 
+### Type: `StatsCompilation`
 
 > **StatsCompilation** = {KnownStatsCompilation|Record<string, any>}
 
 ***
 
-## Type: `StatsError`
+## 
+### Type: `StatsError`
 
 > **StatsError** = {KnownStatsError|Record<string, any>}
 
 ***
 
-## Type: `StatsLogging`
+## 
+### Type: `StatsLogging`
 
 > **StatsLogging** = {KnownStatsLogging|Record<string, any>}
 
 ***
 
-## Type: `StatsLoggingEntry`
+## 
+### Type: `StatsLoggingEntry`
 
 > **StatsLoggingEntry** = {KnownStatsLoggingEntry|Record<string, any>}
 
 ***
 
-## Type: `StatsModule`
+## 
+### Type: `StatsModule`
 
 > **StatsModule** = {KnownStatsModule|Record<string, any>}
 
 ***
 
-## Type: `StatsModuleIssuer`
+## 
+### Type: `StatsModuleIssuer`
 
 > **StatsModuleIssuer** = {KnownStatsModuleIssuer|Record<string, any>}
 
 ***
 
-## Type: `StatsModuleReason`
+## 
+### Type: `StatsModuleReason`
 
 > **StatsModuleReason** = {KnownStatsModuleReason|Record<string, any>}
 
 ***
 
-## Type: `StatsModuleTraceDependency`
+## 
+### Type: `StatsModuleTraceDependency`
 
 > **StatsModuleTraceDependency** = {KnownStatsModuleTraceDependency|Record<string, any>}
 
 ***
 
-## Type: `StatsModuleTraceItem`
+## 
+### Type: `StatsModuleTraceItem`
 
 > **StatsModuleTraceItem** = {KnownStatsModuleTraceItem|Record<string, any>}
 
 ***
 
-## Type: `StatsProfile`
+## 
+### Type: `StatsProfile`
 
 > **StatsProfile** = {KnownStatsProfile|Record<string, any>}
 
 ***
 
-## Type: `TemplatePath`
+## 
+### Type: `TemplatePath`
 
 > **TemplatePath** = {string|object}
 
 ***
 
-## Type: `WebpackPluginFunction`
+## 
+### Type: `WebpackPluginFunction`
 
 > **WebpackPluginFunction** = {object}
 
+---
+### __type
+
 * `this` {Compiler}
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## `UsageState`
+## 
+### `UsageState`
 
 > `const` **UsageState**: {Readonly<object>}
 
 ***
 
-## `validate`
+## 
+### `validate`
 
 > `const` **validate**: {object}
 
+---
+### __type
+
 * `configuration` {Configuration|MultiConfiguration}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## `validateSchema`
+## 
+### `validateSchema`
 
 > `const` **validateSchema**: {object}
+
+---
+### __type
 
 * `schema` {Parameters<validateFunction>}
 * `options` {Parameters<validateFunction>}
 * `validationConfiguration` {ValidationErrorConfiguration}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## `version`
+## 
+### `version`
 
 > `const` **version**: {string}
 
 ***
 
-## `webpack`
+## 
+### `webpack`
 
 > `const` **webpack**: {_functionWebpack}
 
@@ -7383,22 +10751,38 @@ Plugin instance.
 
 ### Call Signature
 
+---
+### export=
+
 * `options` {Configuration}
 * `callback` {CallbackWebpackFunction_2<Stats, void>}
-* Returns: {Compiler}
+
+* ###Returns: {Compiler}
 
 ### Call Signature
+
+---
+### export=
 
 * `options` {Configuration}
-* Returns: {Compiler}
+
+* ###Returns: {Compiler}
 
 ### Call Signature
+
+---
+### export=
 
 * `options` {MultiConfiguration}
 * `callback` {CallbackWebpackFunction_2<MultiStats, void>}
-* Returns: {MultiCompiler}
+
+* ###Returns: {MultiCompiler}
 
 ### Call Signature
 
+---
+### export=
+
 * `options` {MultiConfiguration}
-* Returns: {MultiCompiler}
+
+* ###Returns: {MultiCompiler}

--- a/pages/v5.x/index.md
+++ b/pages/v5.x/index.md
@@ -164,18 +164,15 @@ or are automatically applied via regex from your webpack configuration.
 |                                                                                         Name                                                                                         |     Status      |   Install Size   | Description                                                                             |
 | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-------------: | :--------------: | :-------------------------------------------------------------------------------------- |
 |     <a href="https://github.com/webpack-contrib/html-loader"><img width="48" height="48" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/html5/html5-original.svg"></a>      |   ![html-npm]   |   ![html-size]   | Exports HTML as string, requires references to static resources                         |
-|        <a href="https://github.com/pugjs/pug-loader"><img width="48" height="48" src="https://cdn.rawgit.com/pugjs/pug-logo/master/SVG/pug-final-logo-_-colour-128.svg"></a>         |   ![pug-npm]    |   ![pug-size]    | Loads Pug templates and returns a function                                              |
-|      <a href="https://github.com/webdiscus/pug-loader"><img width="48" height="48" src="https://cdn.rawgit.com/pugjs/pug-logo/master/SVG/pug-final-logo-_-colour-128.svg"></a>       |   ![pug3-npm]   |   ![pug3-size]   | Compiles Pug to a function or HTML string, useful for use with Vue, React, Angular      |
+|      <a href="https://github.com/webdiscus/pug-loader"><img width="48" height="48" src="https://cdn.rawgit.com/pugjs/pug-logo/master/SVG/pug-final-logo-_-colour-128.svg"></a>       |   ![pug-npm]    |   ![pug-size]    | Compiles Pug to a function or HTML string, useful for use with Vue, React, Angular      |
 |    <a href="https://github.com/peerigon/markdown-loader"><img width="48" height="48" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/markdown/markdown-original.svg"></a>    |    ![md-npm]    |    ![md-size]    | Compiles Markdown to HTML                                                               |
 |                      <a href="https://github.com/posthtml/posthtml-loader"><img width="48" height="48" src="https://posthtml.github.io/posthtml/logo.svg"></a>                       | ![posthtml-npm] | ![posthtml-size] | Loads and transforms a HTML file using [PostHTML](https://github.com/posthtml/posthtml) |
 | <a href="https://github.com/pcardune/handlebars-loader"><img width="48" height="48" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/handlebars/handlebars-original.svg"></a> |   ![hbs-npm]    |   ![hbs-size]    | Compiles Handlebars to HTML                                                             |
 
 [html-npm]: https://img.shields.io/npm/v/html-loader.svg
 [html-size]: https://packagephobia.com/badge?p=html-loader
-[pug-npm]: https://img.shields.io/npm/v/pug-loader.svg
-[pug-size]: https://packagephobia.com/badge?p=pug-loader
-[pug3-npm]: https://img.shields.io/npm/v/@webdiscus/pug-loader.svg
-[pug3-size]: https://packagephobia.com/badge?p=@webdiscus/pug-loader
+[pug-npm]: https://img.shields.io/npm/v/@webdiscus/pug-loader.svg
+[pug-size]: https://packagephobia.com/badge?p=@webdiscus/pug-loader
 [jade-npm]: https://img.shields.io/npm/v/jade-loader.svg
 [jade-size]: https://packagephobia.com/badge?p=jade-loader
 [md-npm]: https://img.shields.io/npm/v/markdown-loader.svg

--- a/pages/v5.x/type-map.json
+++ b/pages/v5.x/type-map.json
@@ -3461,6 +3461,7 @@
   "PathData.filename": "globals.md#filename",
   "PathData.hash": "globals.md#hash",
   "PathData.hashWithLength": "globals.md#hashwithlength",
+  "PathData.local": "globals.md#local",
   "PathData.module": "globals.md#module",
   "PathData.noChunkHash": "globals.md#nochunkhash",
   "PathData.prepareId": "globals.md#prepareid",

--- a/pages/v5.x/webpack/namespaces/ModuleFilenameHelpers.md
+++ b/pages/v5.x/webpack/namespaces/ModuleFilenameHelpers.md
@@ -1,176 +1,219 @@
 # ModuleFilenameHelpers
 
-## `ABSOLUTE_RESOURCE_PATH`
+## 
+### `ABSOLUTE_RESOURCE_PATH`
 
 > **ABSOLUTE\_RESOURCE\_PATH**: {string}
 
 ***
 
-## `ALL_LOADERS`
+## 
+### `ALL_LOADERS`
 
 > **ALL\_LOADERS**: {string}
 
 ***
 
-## `ALL_LOADERS_RESOURCE`
+## 
+### `ALL_LOADERS_RESOURCE`
 
 > **ALL\_LOADERS\_RESOURCE**: {string}
 
 ***
 
-## `createFilename`
+## 
+### `createFilename`
 
 > **createFilename**: {object}
+
+---
+### __type
 
 * `module` {string|Module}
 * `options` {object}
 * `__namedParameters` {object}
-* Returns: {string}
+
+* ###Returns: {string}
 
 ***
 
-## `HASH`
+## 
+### `HASH`
 
 > **HASH**: {string}
 
 ***
 
-## `ID`
+## 
+### `ID`
 
 > **ID**: {string}
 
 ***
 
-## `LOADERS`
+## 
+### `LOADERS`
 
 > **LOADERS**: {string}
 
 ***
 
-## `LOADERS_RESOURCE`
+## 
+### `LOADERS_RESOURCE`
 
 > **LOADERS\_RESOURCE**: {string}
 
 ***
 
-## `matchObject`
+## 
+### `matchObject`
 
 > **matchObject**: {object}
 
+---
+### __type
+
 * `obj` {MatchObject}
 * `str` {string}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 ***
 
-## `matchPart`
+## 
+### `matchPart`
 
 > **matchPart**: {object}
 
+---
+### __type
+
 * `str` {string}
 * `test` {Matcher}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 ***
 
-## `NAMESPACE`
+## 
+### `NAMESPACE`
 
 > **NAMESPACE**: {string}
 
 ***
 
-## `QUERY`
+## 
+### `QUERY`
 
 > **QUERY**: {string}
 
 ***
 
-## `REGEXP_ABSOLUTE_RESOURCE_PATH`
+## 
+### `REGEXP_ABSOLUTE_RESOURCE_PATH`
 
 > **REGEXP\_ABSOLUTE\_RESOURCE\_PATH**: {RegExp}
 
 ***
 
-## `REGEXP_ALL_LOADERS`
+## 
+### `REGEXP_ALL_LOADERS`
 
 > **REGEXP\_ALL\_LOADERS**: {RegExp}
 
 ***
 
-## `REGEXP_ALL_LOADERS_RESOURCE`
+## 
+### `REGEXP_ALL_LOADERS_RESOURCE`
 
 > **REGEXP\_ALL\_LOADERS\_RESOURCE**: {RegExp}
 
 ***
 
-## `REGEXP_HASH`
+## 
+### `REGEXP_HASH`
 
 > **REGEXP\_HASH**: {RegExp}
 
 ***
 
-## `REGEXP_ID`
+## 
+### `REGEXP_ID`
 
 > **REGEXP\_ID**: {RegExp}
 
 ***
 
-## `REGEXP_LOADERS`
+## 
+### `REGEXP_LOADERS`
 
 > **REGEXP\_LOADERS**: {RegExp}
 
 ***
 
-## `REGEXP_LOADERS_RESOURCE`
+## 
+### `REGEXP_LOADERS_RESOURCE`
 
 > **REGEXP\_LOADERS\_RESOURCE**: {RegExp}
 
 ***
 
-## `REGEXP_NAMESPACE`
+## 
+### `REGEXP_NAMESPACE`
 
 > **REGEXP\_NAMESPACE**: {RegExp}
 
 ***
 
-## `REGEXP_QUERY`
+## 
+### `REGEXP_QUERY`
 
 > **REGEXP\_QUERY**: {RegExp}
 
 ***
 
-## `REGEXP_RESOURCE`
+## 
+### `REGEXP_RESOURCE`
 
 > **REGEXP\_RESOURCE**: {RegExp}
 
 ***
 
-## `REGEXP_RESOURCE_PATH`
+## 
+### `REGEXP_RESOURCE_PATH`
 
 > **REGEXP\_RESOURCE\_PATH**: {RegExp}
 
 ***
 
-## `replaceDuplicates`
+## 
+### `replaceDuplicates`
 
 > **replaceDuplicates**: {object}
+
+---
+### __type
 
 #### T
 
 `T`
+
 * `array` {T[]}
 * `fn` {object}
 * `comparator` {object}
-* Returns: {T[]}
+
+* ###Returns: {T[]}
 
 ***
 
-## `RESOURCE`
+## 
+### `RESOURCE`
 
 > **RESOURCE**: {string}
 
 ***
 
-## `RESOURCE_PATH`
+## 
+### `RESOURCE_PATH`
 
 > **RESOURCE\_PATH**: {string}

--- a/pages/v5.x/webpack/namespaces/OptimizationStages.md
+++ b/pages/v5.x/webpack/namespaces/OptimizationStages.md
@@ -1,17 +1,20 @@
 # OptimizationStages
 
-## `STAGE_ADVANCED`
+## 
+### `STAGE_ADVANCED`
 
 > **STAGE\_ADVANCED**: {10}
 
 ***
 
-## `STAGE_BASIC`
+## 
+### `STAGE_BASIC`
 
 > **STAGE\_BASIC**: {-10}
 
 ***
 
-## `STAGE_DEFAULT`
+## 
+### `STAGE_DEFAULT`
 
 > **STAGE\_DEFAULT**: {0}

--- a/pages/v5.x/webpack/namespaces/RuntimeGlobals.md
+++ b/pages/v5.x/webpack/namespaces/RuntimeGlobals.md
@@ -1,497 +1,580 @@
 # RuntimeGlobals
 
-## `amdDefine`
+## 
+### `amdDefine`
 
 > **amdDefine**: {"__webpack_require__.amdD"}
 
 ***
 
-## `amdOptions`
+## 
+### `amdOptions`
 
 > **amdOptions**: {"__webpack_require__.amdO"}
 
 ***
 
-## `asyncModule`
+## 
+### `asyncModule`
 
 > **asyncModule**: {"__webpack_require__.a"}
 
 ***
 
-## `asyncModuleDoneSymbol`
+## 
+### `asyncModuleDoneSymbol`
 
 > **asyncModuleDoneSymbol**: {"__webpack_require__.aD"}
 
 ***
 
-## `asyncModuleExportSymbol`
+## 
+### `asyncModuleExportSymbol`
 
 > **asyncModuleExportSymbol**: {"__webpack_require__.aE"}
 
 ***
 
-## `baseURI`
+## 
+### `baseURI`
 
 > **baseURI**: {"__webpack_require__.b"}
 
 ***
 
-## `chunkCallback`
+## 
+### `chunkCallback`
 
 > **chunkCallback**: {"webpackChunk"}
 
 ***
 
-## `chunkName`
+## 
+### `chunkName`
 
 > **chunkName**: {"__webpack_require__.cn"}
 
 ***
 
-## `compatGetDefaultExport`
+## 
+### `compatGetDefaultExport`
 
 > **compatGetDefaultExport**: {"__webpack_require__.n"}
 
 ***
 
-## `createFakeNamespaceObject`
+## 
+### `createFakeNamespaceObject`
 
 > **createFakeNamespaceObject**: {"__webpack_require__.t"}
 
 ***
 
-## `createScript`
+## 
+### `createScript`
 
 > **createScript**: {"__webpack_require__.ts"}
 
 ***
 
-## `createScriptUrl`
+## 
+### `createScriptUrl`
 
 > **createScriptUrl**: {"__webpack_require__.tu"}
 
 ***
 
-## `cssInjectStyle`
+## 
+### `cssInjectStyle`
 
 > **cssInjectStyle**: {"__webpack_require__.is"}
 
 ***
 
-## `cssMergeStyleSheets`
+## 
+### `cssMergeStyleSheets`
 
 > **cssMergeStyleSheets**: {"__webpack_require__.mcs"}
 
 ***
 
-## `currentRemoteGetScope`
+## 
+### `currentRemoteGetScope`
 
 > **currentRemoteGetScope**: {"__webpack_require__.R"}
 
 ***
 
-## `deferredModuleAsyncTransitiveDependencies`
+## 
+### `deferredModuleAsyncTransitiveDependencies`
 
 > **deferredModuleAsyncTransitiveDependencies**: {"__webpack_require__.zT"}
 
 ***
 
-## `deferredModuleAsyncTransitiveDependenciesSymbol`
+## 
+### `deferredModuleAsyncTransitiveDependenciesSymbol`
 
 > **deferredModuleAsyncTransitiveDependenciesSymbol**: {"__webpack_require__.zS"}
 
 ***
 
-## `definePropertyGetters`
+## 
+### `definePropertyGetters`
 
 > **definePropertyGetters**: {"__webpack_require__.d"}
 
 ***
 
-## `ensureChunk`
+## 
+### `ensureChunk`
 
 > **ensureChunk**: {"__webpack_require__.e"}
 
 ***
 
-## `ensureChunkHandlers`
+## 
+### `ensureChunkHandlers`
 
 > **ensureChunkHandlers**: {"__webpack_require__.f"}
 
 ***
 
-## `ensureChunkIncludeEntries`
+## 
+### `ensureChunkIncludeEntries`
 
 > **ensureChunkIncludeEntries**: {"__webpack_require__.f (include entries)"}
 
 ***
 
-## `entryModuleId`
+## 
+### `entryModuleId`
 
 > **entryModuleId**: {"__webpack_require__.s"}
 
 ***
 
-## `esmId`
+## 
+### `esmId`
 
 > **esmId**: {"__webpack_esm_id__"}
 
 ***
 
-## `esmIds`
+## 
+### `esmIds`
 
 > **esmIds**: {"__webpack_esm_ids__"}
 
 ***
 
-## `esmModules`
+## 
+### `esmModules`
 
 > **esmModules**: {"__webpack_esm_modules__"}
 
 ***
 
-## `esmRuntime`
+## 
+### `esmRuntime`
 
 > **esmRuntime**: {"__webpack_esm_runtime__"}
 
 ***
 
-## `exports`
+## 
+### `exports`
 
 > **exports**: {"__webpack_exports__"}
 
 ***
 
-## `externalInstallChunk`
+## 
+### `externalInstallChunk`
 
 > **externalInstallChunk**: {"__webpack_require__.C"}
 
 ***
 
-## `getChunkCssFilename`
+## 
+### `getChunkCssFilename`
 
 > **getChunkCssFilename**: {"__webpack_require__.k"}
 
 ***
 
-## `getChunkScriptFilename`
+## 
+### `getChunkScriptFilename`
 
 > **getChunkScriptFilename**: {"__webpack_require__.u"}
 
 ***
 
-## `getChunkUpdateCssFilename`
+## 
+### `getChunkUpdateCssFilename`
 
 > **getChunkUpdateCssFilename**: {"__webpack_require__.hk"}
 
 ***
 
-## `getChunkUpdateScriptFilename`
+## 
+### `getChunkUpdateScriptFilename`
 
 > **getChunkUpdateScriptFilename**: {"__webpack_require__.hu"}
 
 ***
 
-## `getFullHash`
+## 
+### `getFullHash`
 
 > **getFullHash**: {"__webpack_require__.h"}
 
 ***
 
-## `getTrustedTypesPolicy`
+## 
+### `getTrustedTypesPolicy`
 
 > **getTrustedTypesPolicy**: {"__webpack_require__.tt"}
 
 ***
 
-## `getUpdateManifestFilename`
+## 
+### `getUpdateManifestFilename`
 
 > **getUpdateManifestFilename**: {"__webpack_require__.hmrF"}
 
 ***
 
-## `global`
+## 
+### `global`
 
 > **global**: {"__webpack_require__.g"}
 
 ***
 
-## `harmonyModuleDecorator`
+## 
+### `harmonyModuleDecorator`
 
 > **harmonyModuleDecorator**: {"__webpack_require__.hmd"}
 
 ***
 
-## `hasCssModules`
+## 
+### `hasCssModules`
 
 > **hasCssModules**: {"has css modules"}
 
 ***
 
-## `hasFetchPriority`
+## 
+### `hasFetchPriority`
 
 > **hasFetchPriority**: {"has fetch priority"}
 
 ***
 
-## `hasOwnProperty`
+## 
+### `hasOwnProperty`
 
 > **hasOwnProperty**: {"__webpack_require__.o"}
 
 ***
 
-## `hmrDownloadManifest`
+## 
+### `hmrDownloadManifest`
 
 > **hmrDownloadManifest**: {"__webpack_require__.hmrM"}
 
 ***
 
-## `hmrDownloadUpdateHandlers`
+## 
+### `hmrDownloadUpdateHandlers`
 
 > **hmrDownloadUpdateHandlers**: {"__webpack_require__.hmrC"}
 
 ***
 
-## `hmrInvalidateModuleHandlers`
+## 
+### `hmrInvalidateModuleHandlers`
 
 > **hmrInvalidateModuleHandlers**: {"__webpack_require__.hmrI"}
 
 ***
 
-## `hmrModuleData`
+## 
+### `hmrModuleData`
 
 > **hmrModuleData**: {"__webpack_require__.hmrD"}
 
 ***
 
-## `hmrRuntimeStatePrefix`
+## 
+### `hmrRuntimeStatePrefix`
 
 > **hmrRuntimeStatePrefix**: {"__webpack_require__.hmrS"}
 
 ***
 
-## `initializeSharing`
+## 
+### `initializeSharing`
 
 > **initializeSharing**: {"__webpack_require__.I"}
 
 ***
 
-## `instantiateWasm`
+## 
+### `instantiateWasm`
 
 > **instantiateWasm**: {"__webpack_require__.v"}
 
 ***
 
-## `interceptModuleExecution`
+## 
+### `interceptModuleExecution`
 
 > **interceptModuleExecution**: {"__webpack_require__.i"}
 
 ***
 
-## `loadScript`
+## 
+### `loadScript`
 
 > **loadScript**: {"__webpack_require__.l"}
 
 ***
 
-## `makeDeferredNamespaceObject`
+## 
+### `makeDeferredNamespaceObject`
 
 > **makeDeferredNamespaceObject**: {"__webpack_require__.z"}
 
 ***
 
-## `makeNamespaceObject`
+## 
+### `makeNamespaceObject`
 
 > **makeNamespaceObject**: {"__webpack_require__.r"}
 
 ***
 
-## `makeOptimizedDeferredNamespaceObject`
+## 
+### `makeOptimizedDeferredNamespaceObject`
 
 > **makeOptimizedDeferredNamespaceObject**: {"__webpack_require__.zO"}
 
 ***
 
-## `module`
+## 
+### `module`
 
 > **module**: {"module"}
 
 ***
 
-## `moduleCache`
+## 
+### `moduleCache`
 
 > **moduleCache**: {"__webpack_require__.c"}
 
 ***
 
-## `moduleFactories`
+## 
+### `moduleFactories`
 
 > **moduleFactories**: {"__webpack_require__.m"}
 
 ***
 
-## `moduleFactoriesAddOnly`
+## 
+### `moduleFactoriesAddOnly`
 
 > **moduleFactoriesAddOnly**: {"__webpack_require__.m (add only)"}
 
 ***
 
-## `moduleId`
+## 
+### `moduleId`
 
 > **moduleId**: {"module.id"}
 
 ***
 
-## `moduleLoaded`
+## 
+### `moduleLoaded`
 
 > **moduleLoaded**: {"module.loaded"}
 
 ***
 
-## `nodeModuleDecorator`
+## 
+### `nodeModuleDecorator`
 
 > **nodeModuleDecorator**: {"__webpack_require__.nmd"}
 
 ***
 
-## `onChunksLoaded`
+## 
+### `onChunksLoaded`
 
 > **onChunksLoaded**: {"__webpack_require__.O"}
 
 ***
 
-## `prefetchChunk`
+## 
+### `prefetchChunk`
 
 > **prefetchChunk**: {"__webpack_require__.E"}
 
 ***
 
-## `prefetchChunkHandlers`
+## 
+### `prefetchChunkHandlers`
 
 > **prefetchChunkHandlers**: {"__webpack_require__.F"}
 
 ***
 
-## `preloadChunk`
+## 
+### `preloadChunk`
 
 > **preloadChunk**: {"__webpack_require__.G"}
 
 ***
 
-## `preloadChunkHandlers`
+## 
+### `preloadChunkHandlers`
 
 > **preloadChunkHandlers**: {"__webpack_require__.H"}
 
 ***
 
-## `publicPath`
+## 
+### `publicPath`
 
 > **publicPath**: {"__webpack_require__.p"}
 
 ***
 
-## `relativeUrl`
+## 
+### `relativeUrl`
 
 > **relativeUrl**: {"__webpack_require__.U"}
 
 ***
 
-## `require`
+## 
+### `require`
 
 > **require**: {"__webpack_require__"}
 
 ***
 
-## `requireScope`
+## 
+### `requireScope`
 
 > **requireScope**: {"__webpack_require__.*"}
 
 ***
 
-## `returnExportsFromRuntime`
+## 
+### `returnExportsFromRuntime`
 
 > **returnExportsFromRuntime**: {"return-exports-from-runtime"}
 
 ***
 
-## `runtimeId`
+## 
+### `runtimeId`
 
 > **runtimeId**: {"__webpack_require__.j"}
 
 ***
 
-## `scriptNonce`
+## 
+### `scriptNonce`
 
 > **scriptNonce**: {"__webpack_require__.nc"}
 
 ***
 
-## `shareScopeMap`
+## 
+### `shareScopeMap`
 
 > **shareScopeMap**: {"__webpack_require__.S"}
 
 ***
 
-## `startup`
+## 
+### `startup`
 
 > **startup**: {"__webpack_require__.x"}
 
 ***
 
-## `startupEntrypoint`
+## 
+### `startupEntrypoint`
 
 > **startupEntrypoint**: {"__webpack_require__.X"}
 
 ***
 
-## `startupNoDefault`
+## 
+### `startupNoDefault`
 
 > **startupNoDefault**: {"__webpack_require__.x (no default handler)"}
 
 ***
 
-## `startupOnlyAfter`
+## 
+### `startupOnlyAfter`
 
 > **startupOnlyAfter**: {"__webpack_require__.x (only after)"}
 
 ***
 
-## `startupOnlyBefore`
+## 
+### `startupOnlyBefore`
 
 > **startupOnlyBefore**: {"__webpack_require__.x (only before)"}
 
 ***
 
-## `system`
+## 
+### `system`
 
 > **system**: {"__webpack_require__.System"}
 
 ***
 
-## `systemContext`
+## 
+### `systemContext`
 
 > **systemContext**: {"__webpack_require__.y"}
 
 ***
 
-## `thisAsExports`
+## 
+### `thisAsExports`
 
 > **thisAsExports**: {"top-level-this-exports"}
 
 ***
 
-## `toBinary`
+## 
+### `toBinary`
 
 > **toBinary**: {"__webpack_require__.tb"}
 
 ***
 
-## `uncaughtErrorHandler`
+## 
+### `uncaughtErrorHandler`
 
 > **uncaughtErrorHandler**: {"__webpack_require__.oe"}
 
 ***
 
-## `wasmInstances`
+## 
+### `wasmInstances`
 
 > **wasmInstances**: {"__webpack_require__.w"}

--- a/pages/v5.x/webpack/namespaces/cache.md
+++ b/pages/v5.x/webpack/namespaces/cache.md
@@ -1,18 +1,26 @@
 # cache
 
-## Class: `MemoryCachePlugin`
+## 
+### Class: `MemoryCachePlugin`
 
 ### Constructors
 
 #### `new MemoryCachePlugin()`
 
-* Returns: {MemoryCachePlugin}
+---
+### MemoryCachePlugin
+
+* ###Returns: {MemoryCachePlugin}
 
 ### Methods
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin

--- a/pages/v5.x/webpack/namespaces/cli.md
+++ b/pages/v5.x/webpack/namespaces/cli.md
@@ -1,36 +1,55 @@
 # cli
 
-## `createColors`
+## 
+### `createColors`
 
 > **createColors**: {object}
 
+---
+### __type
+
 * `__namedParameters` {ColorsOptions}
-* Returns: {Colors}
+
+* ###Returns: {Colors}
 
 ***
 
-## `getArguments`
+## 
+### `getArguments`
 
 > **getArguments**: {object}
 
+---
+### __type
+
 * `schema` {JSONSchema4|object|JSONSchema6|object|JSONSchema7|object}
-* Returns: {Flags}
+
+* ###Returns: {Flags}
 
 ***
 
-## `isColorSupported`
+## 
+### `isColorSupported`
 
 > **isColorSupported**: {object}
 
-* Returns: {boolean}
+---
+### __type
+
+* ###Returns: {boolean}
 
 ***
 
-## `processArguments`
+## 
+### `processArguments`
 
 > **processArguments**: {object}
+
+---
+### __type
 
 * `args` {Flags}
 * `config` {ObjectConfiguration}
 * `values` {Values}
-* Returns: {null|Problem[]}
+
+* ###Returns: {null|Problem[]}

--- a/pages/v5.x/webpack/namespaces/config.md
+++ b/pages/v5.x/webpack/namespaces/config.md
@@ -1,18 +1,28 @@
 # config
 
-## `applyWebpackOptionsDefaults`
+## 
+### `applyWebpackOptionsDefaults`
 
 > `const` **applyWebpackOptionsDefaults**: {object}
 
+---
+### __type
+
 * `options` {WebpackOptionsNormalized}
 * `compilerIndex` {number}
-* Returns: {ResolvedOptions}
+
+* ###Returns: {ResolvedOptions}
 
 ***
 
-## `getNormalizedWebpackOptions`
+## 
+### `getNormalizedWebpackOptions`
 
 > `const` **getNormalizedWebpackOptions**: {object}
 
+---
+### __type
+
 * `config` {Configuration}
-* Returns: {WebpackOptionsNormalized}
+
+* ###Returns: {WebpackOptionsNormalized}

--- a/pages/v5.x/webpack/namespaces/container.md
+++ b/pages/v5.x/webpack/namespaces/container.md
@@ -1,13 +1,18 @@
 # container
 
-## Class: `ContainerPlugin`
+## 
+### Class: `ContainerPlugin`
 
 ### Constructors
 
 #### `new ContainerPlugin(options)`
 
+---
+### ContainerPlugin
+
 * `options` {ContainerPluginOptions}
-* Returns: {ContainerPlugin}
+
+* ###Returns: {ContainerPlugin}
 
 ### Properties
 
@@ -17,21 +22,30 @@
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `ContainerReferencePlugin`
+## 
+### Class: `ContainerReferencePlugin`
 
 ### Constructors
 
 #### `new ContainerReferencePlugin(options)`
 
+---
+### ContainerReferencePlugin
+
 * `options` {ContainerReferencePluginOptions}
-* Returns: {ContainerReferencePlugin}
+
+* ###Returns: {ContainerReferencePlugin}
 
 ### Properties
 
@@ -41,21 +55,30 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `ModuleFederationPlugin`
+## 
+### Class: `ModuleFederationPlugin`
 
 ### Constructors
 
 #### `new ModuleFederationPlugin(options)`
 
+---
+### ModuleFederationPlugin
+
 * `options` {ModuleFederationPluginOptions}
-* Returns: {ModuleFederationPlugin}
+
+* ###Returns: {ModuleFederationPlugin}
 
 ### Properties
 
@@ -65,27 +88,41 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 #### Static method: `getCompilationHooks(compilation)`
 
+---
+### getCompilationHooks
+
 * `compilation` {Compilation}
-* Returns: {CompilationHooksModuleFederationPlugin}
+
+* ###Returns: {CompilationHooksModuleFederationPlugin}
 
 Get the compilation hooks associated with this plugin.
 
 ***
 
-## `scope`
+## 
+### `scope`
 
 > `const` **scope**: {object}
+
+---
+### __type
 
 #### T
 
 `T`
+
 * `scope` {string}
 * `options` {ContainerOptionsFormat<T>}
-* Returns: {Record<string, string|string[]|T>}
+
+* ###Returns: {Record<string, string|string[]|T>}

--- a/pages/v5.x/webpack/namespaces/css.md
+++ b/pages/v5.x/webpack/namespaces/css.md
@@ -1,62 +1,98 @@
 # css
 
-## Class: `CssModulesPlugin`
+## 
+### Class: `CssModulesPlugin`
 
 ### Constructors
 
 #### `new CssModulesPlugin()`
 
-* Returns: {CssModulesPlugin}
+---
+### CssModulesPlugin
+
+* ###Returns: {CssModulesPlugin}
 
 ### Methods
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 #### `getModulesInOrder(chunk, modules, compilation)`
 
+---
+### getModulesInOrder
+
 * `chunk` {Chunk}
 * `modules` {Iterable<Module, any, any>}
 * `compilation` {Compilation}
-* Returns: {Module[]}
+
+* ###Returns: {Module[]}
 
 #### `getOrderedChunkCssModules(chunk, chunkGraph, compilation)`
 
+---
+### getOrderedChunkCssModules
+
 * `chunk` {Chunk}
 * `chunkGraph` {ChunkGraph}
 * `compilation` {Compilation}
-* Returns: {CssModule[]}
+
+* ###Returns: {CssModule[]}
 
 #### `renderChunk(__namedParameters, hooks)`
 
+---
+### renderChunk
+
 * `__namedParameters` {RenderContextCssModulesPlugin}
 * `hooks` {CompilationHooksCssModulesPlugin}
-* Returns: {Source}
+
+* ###Returns: {Source}
 
 #### Static method: `chunkHasCss(chunk, chunkGraph)`
 
+---
+### chunkHasCss
+
 * `chunk` {Chunk}
 * `chunkGraph` {ChunkGraph}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### Static method: `getChunkFilenameTemplate(chunk, outputOptions)`
 
+---
+### getChunkFilenameTemplate
+
 * `chunk` {Chunk}
 * `outputOptions` {OutputNormalizedWithDefaults}
-* Returns: {TemplatePath}
+
+* ###Returns: {TemplatePath}
 
 #### Static method: `getCompilationHooks(compilation)`
 
+---
+### getCompilationHooks
+
 * `compilation` {Compilation}
-* Returns: {CompilationHooksCssModulesPlugin}
+
+* ###Returns: {CompilationHooksCssModulesPlugin}
 
 #### Static method: `renderModule(module, renderContext, hooks)`
+
+---
+### renderModule
 
 * `module` {CssModule}
 * `renderContext` {ChunkRenderContextCssModulesPlugin}
 * `hooks` {CompilationHooksCssModulesPlugin}
-* Returns: {Source}
+
+* ###Returns: {Source}

--- a/pages/v5.x/webpack/namespaces/debug.md
+++ b/pages/v5.x/webpack/namespaces/debug.md
@@ -1,13 +1,18 @@
 # debug
 
-## Class: `ProfilingPlugin`
+## 
+### Class: `ProfilingPlugin`
 
 ### Constructors
 
 #### `new ProfilingPlugin([options])`
 
+---
+### ProfilingPlugin
+
 * `options` {ProfilingPluginOptions}
-* Returns: {ProfilingPlugin}
+
+* ###Returns: {ProfilingPlugin}
 
 ### Properties
 
@@ -18,7 +23,11 @@
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin

--- a/pages/v5.x/webpack/namespaces/dependencies.md
+++ b/pages/v5.x/webpack/namespaces/dependencies.md
@@ -1,6 +1,7 @@
 # dependencies
 
-## Class: `ConstDependency`
+## 
+### Class: `ConstDependency`
 
 ### Extends
 
@@ -10,10 +11,14 @@
 
 #### `new ConstDependency(expression, range[, runtimeRequirements])`
 
+---
+### ConstDependency
+
 * `expression` {string}
 * `range` {number|Tuple<number, number>}
 * `runtimeRequirements` {string[]}
-* Returns: {ConstDependency}
+
+* ###Returns: {ConstDependency}
 
 ### Properties
 
@@ -36,109 +41,174 @@
 
 #### `couldAffectReferencingModule()`
 
-* Returns: {boolean|TRANSITIVE}
+---
+### couldAffectReferencingModule
+
+* ###Returns: {boolean|TRANSITIVE}
 
 #### `createIgnoredModule(context)`
 
+---
+### createIgnoredModule
+
 * `context` {string}
-* Returns: {Module}
+
+* ###Returns: {Module}
 
 #### `deserialize(__namedParameters)`
 
+---
+### deserialize
+
 * `__namedParameters` {ObjectDeserializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `getCondition(moduleGraph)`
 
+---
+### getCondition
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {false|object}
+
+* ###Returns: {false|object}
 
 #### `getContext()`
 
-* Returns: {string}
+---
+### getContext
+
+* ###Returns: {string}
 
 #### `getErrors(moduleGraph)`
 
+---
+### getErrors
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {WebpackError[]}
+
+* ###Returns: {WebpackError[]}
 
 Returns errors
 
 #### `getExports(moduleGraph)`
 
+---
+### getExports
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {ExportsSpec}
+
+* ###Returns: {ExportsSpec}
 
 Returns the exported names
 
 #### `getModuleEvaluationSideEffectsState(moduleGraph)`
 
+---
+### getModuleEvaluationSideEffectsState
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {ConnectionState}
+
+* ###Returns: {ConnectionState}
 
 #### `getNumberOfIdOccurrences()`
 
-* Returns: {number}
+---
+### getNumberOfIdOccurrences
+
+* ###Returns: {number}
 
 implement this method to allow the occurrence order plugin to count correctly
 
 #### `getReference(moduleGraph)`
 
+---
+### getReference
+
 > Stability: 0 - Deprecated
 
 * `moduleGraph` {ModuleGraph}
-* Returns: {never}
+
+* ###Returns: {never}
 
 Returns the referenced module and export
 
 #### `getReferencedExports(moduleGraph, runtime)`
 
+---
+### getReferencedExports
+
 * `moduleGraph` {ModuleGraph}
 * `runtime` {RuntimeSpec}
-* Returns: {string[]|ReferencedExport[]}
+
+* ###Returns: {string[]|ReferencedExport[]}
 
 Returns list of exports referenced by this dependency
 
 #### `getResourceIdentifier()`
 
-* Returns: {string}
+---
+### getResourceIdentifier
+
+* ###Returns: {string}
 
 #### `getWarnings(moduleGraph)`
 
+---
+### getWarnings
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {WebpackError[]}
+
+* ###Returns: {WebpackError[]}
 
 Returns warnings
 
 #### `serialize(__namedParameters)`
 
+---
+### serialize
+
 * `__namedParameters` {ObjectSerializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `setLoc(startLine, startColumn, endLine, endColumn)`
+
+---
+### setLoc
 
 * `startLine` {number}
 * `startColumn` {number}
 * `endLine` {number}
 * `endColumn` {number}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `updateHash(hash, context)`
 
+---
+### updateHash
+
 * `hash` {Hash}
 * `context` {UpdateHashContextDependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Update the hash
 
 #### Static method: `isLowPriorityDependency(dependency)`
 
+---
+### isLowPriorityDependency
+
 * `dependency` {Dependency}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 ***
 
-## Class: `HarmonyImportDependency`
+## 
+### Class: `HarmonyImportDependency`
 
 ### Extends
 
@@ -148,11 +218,15 @@ Update the hash
 
 #### `new HarmonyImportDependency(request, sourceOrder[, phase][, attributes])`
 
+---
+### HarmonyImportDependency
+
 * `request` {string}
 * `sourceOrder` {number}
 * `phase` {0|1|2}
 * `attributes` {ImportAttributes}
-* Returns: {HarmonyImportDependency}
+
+* ###Returns: {HarmonyImportDependency}
 
 ### Properties
 
@@ -180,132 +254,213 @@ Update the hash
 
 #### `couldAffectReferencingModule()`
 
-* Returns: {boolean|TRANSITIVE}
+---
+### couldAffectReferencingModule
+
+* ###Returns: {boolean|TRANSITIVE}
 
 #### `createIgnoredModule(context)`
 
+---
+### createIgnoredModule
+
 * `context` {string}
-* Returns: {Module}
+
+* ###Returns: {Module}
 
 #### `deserialize(__namedParameters)`
 
+---
+### deserialize
+
 * `__namedParameters` {ObjectDeserializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `getCondition(moduleGraph)`
 
+---
+### getCondition
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {false|object}
+
+* ###Returns: {false|object}
 
 #### `getContext()`
 
-* Returns: {string}
+---
+### getContext
+
+* ###Returns: {string}
 
 #### `getErrors(moduleGraph)`
 
+---
+### getErrors
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {WebpackError[]}
+
+* ###Returns: {WebpackError[]}
 
 Returns errors
 
 #### `getExports(moduleGraph)`
 
+---
+### getExports
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {ExportsSpec}
+
+* ###Returns: {ExportsSpec}
 
 Returns the exported names
 
 #### `getImportStatement(update, __namedParameters)`
 
+---
+### getImportStatement
+
 * `update` {boolean}
 * `__namedParameters` {DependencyTemplateContext}
-* Returns: {Tuple<string, string>}
+
+* ###Returns: {Tuple<string, string>}
 
 #### `getImportVar(moduleGraph)`
 
+---
+### getImportVar
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `getLinkingErrors(moduleGraph, ids, additionalMessage)`
+
+---
+### getLinkingErrors
 
 * `moduleGraph` {ModuleGraph}
 * `ids` {string[]}
 * `additionalMessage` {string}
-* Returns: {WebpackError[]}
+
+* ###Returns: {WebpackError[]}
 
 #### `getModuleEvaluationSideEffectsState(moduleGraph)`
 
+---
+### getModuleEvaluationSideEffectsState
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {ConnectionState}
+
+* ###Returns: {ConnectionState}
 
 #### `getModuleExports(__namedParameters)`
 
+---
+### getModuleExports
+
 * `__namedParameters` {DependencyTemplateContext}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `getNumberOfIdOccurrences()`
 
-* Returns: {number}
+---
+### getNumberOfIdOccurrences
+
+* ###Returns: {number}
 
 implement this method to allow the occurrence order plugin to count correctly
 
 #### `getReference(moduleGraph)`
 
+---
+### getReference
+
 > Stability: 0 - Deprecated
 
 * `moduleGraph` {ModuleGraph}
-* Returns: {never}
+
+* ###Returns: {never}
 
 Returns the referenced module and export
 
 #### `getReferencedExports(moduleGraph, runtime)`
 
+---
+### getReferencedExports
+
 * `moduleGraph` {ModuleGraph}
 * `runtime` {RuntimeSpec}
-* Returns: {string[]|ReferencedExport[]}
+
+* ###Returns: {string[]|ReferencedExport[]}
 
 Returns list of exports referenced by this dependency
 
 #### `getResourceIdentifier()`
 
-* Returns: {string}
+---
+### getResourceIdentifier
+
+* ###Returns: {string}
 
 #### `getWarnings(moduleGraph)`
 
+---
+### getWarnings
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {WebpackError[]}
+
+* ###Returns: {WebpackError[]}
 
 Returns warnings
 
 #### `serialize(__namedParameters)`
 
+---
+### serialize
+
 * `__namedParameters` {ObjectSerializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `setLoc(startLine, startColumn, endLine, endColumn)`
+
+---
+### setLoc
 
 * `startLine` {number}
 * `startColumn` {number}
 * `endLine` {number}
 * `endColumn` {number}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `updateHash(hash, context)`
 
+---
+### updateHash
+
 * `hash` {Hash}
 * `context` {UpdateHashContextDependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Update the hash
 
 #### Static method: `isLowPriorityDependency(dependency)`
 
+---
+### isLowPriorityDependency
+
 * `dependency` {Dependency}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 ***
 
-## Class: `ModuleDependency`
+## 
+### Class: `ModuleDependency`
 
 ### Extends
 
@@ -319,9 +474,13 @@ Update the hash
 
 #### `new ModuleDependency(request[, sourceOrder])`
 
+---
+### ModuleDependency
+
 * `request` {string}
 * `sourceOrder` {number}
-* Returns: {ModuleDependency}
+
+* ###Returns: {ModuleDependency}
 
 ### Properties
 
@@ -345,109 +504,174 @@ Update the hash
 
 #### `couldAffectReferencingModule()`
 
-* Returns: {boolean|TRANSITIVE}
+---
+### couldAffectReferencingModule
+
+* ###Returns: {boolean|TRANSITIVE}
 
 #### `createIgnoredModule(context)`
 
+---
+### createIgnoredModule
+
 * `context` {string}
-* Returns: {Module}
+
+* ###Returns: {Module}
 
 #### `deserialize(__namedParameters)`
 
+---
+### deserialize
+
 * `__namedParameters` {ObjectDeserializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `getCondition(moduleGraph)`
 
+---
+### getCondition
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {false|object}
+
+* ###Returns: {false|object}
 
 #### `getContext()`
 
-* Returns: {string}
+---
+### getContext
+
+* ###Returns: {string}
 
 #### `getErrors(moduleGraph)`
 
+---
+### getErrors
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {WebpackError[]}
+
+* ###Returns: {WebpackError[]}
 
 Returns errors
 
 #### `getExports(moduleGraph)`
 
+---
+### getExports
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {ExportsSpec}
+
+* ###Returns: {ExportsSpec}
 
 Returns the exported names
 
 #### `getModuleEvaluationSideEffectsState(moduleGraph)`
 
+---
+### getModuleEvaluationSideEffectsState
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {ConnectionState}
+
+* ###Returns: {ConnectionState}
 
 #### `getNumberOfIdOccurrences()`
 
-* Returns: {number}
+---
+### getNumberOfIdOccurrences
+
+* ###Returns: {number}
 
 implement this method to allow the occurrence order plugin to count correctly
 
 #### `getReference(moduleGraph)`
 
+---
+### getReference
+
 > Stability: 0 - Deprecated
 
 * `moduleGraph` {ModuleGraph}
-* Returns: {never}
+
+* ###Returns: {never}
 
 Returns the referenced module and export
 
 #### `getReferencedExports(moduleGraph, runtime)`
 
+---
+### getReferencedExports
+
 * `moduleGraph` {ModuleGraph}
 * `runtime` {RuntimeSpec}
-* Returns: {string[]|ReferencedExport[]}
+
+* ###Returns: {string[]|ReferencedExport[]}
 
 Returns list of exports referenced by this dependency
 
 #### `getResourceIdentifier()`
 
-* Returns: {string}
+---
+### getResourceIdentifier
+
+* ###Returns: {string}
 
 #### `getWarnings(moduleGraph)`
 
+---
+### getWarnings
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {WebpackError[]}
+
+* ###Returns: {WebpackError[]}
 
 Returns warnings
 
 #### `serialize(__namedParameters)`
 
+---
+### serialize
+
 * `__namedParameters` {ObjectSerializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `setLoc(startLine, startColumn, endLine, endColumn)`
+
+---
+### setLoc
 
 * `startLine` {number}
 * `startColumn` {number}
 * `endLine` {number}
 * `endColumn` {number}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `updateHash(hash, context)`
 
+---
+### updateHash
+
 * `hash` {Hash}
 * `context` {UpdateHashContextDependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Update the hash
 
 #### Static method: `isLowPriorityDependency(dependency)`
 
+---
+### isLowPriorityDependency
+
 * `dependency` {Dependency}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 ***
 
-## Class: `NullDependency`
+## 
+### Class: `NullDependency`
 
 ### Extends
 
@@ -461,7 +685,10 @@ Update the hash
 
 #### `new NullDependency()`
 
-* Returns: {NullDependency}
+---
+### NullDependency
+
+* ###Returns: {NullDependency}
 
 ### Properties
 
@@ -481,102 +708,166 @@ Update the hash
 
 #### `couldAffectReferencingModule()`
 
-* Returns: {boolean|TRANSITIVE}
+---
+### couldAffectReferencingModule
+
+* ###Returns: {boolean|TRANSITIVE}
 
 #### `createIgnoredModule(context)`
 
+---
+### createIgnoredModule
+
 * `context` {string}
-* Returns: {Module}
+
+* ###Returns: {Module}
 
 #### `deserialize(__namedParameters)`
 
+---
+### deserialize
+
 * `__namedParameters` {ObjectDeserializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `getCondition(moduleGraph)`
 
+---
+### getCondition
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {false|object}
+
+* ###Returns: {false|object}
 
 #### `getContext()`
 
-* Returns: {string}
+---
+### getContext
+
+* ###Returns: {string}
 
 #### `getErrors(moduleGraph)`
 
+---
+### getErrors
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {WebpackError[]}
+
+* ###Returns: {WebpackError[]}
 
 Returns errors
 
 #### `getExports(moduleGraph)`
 
+---
+### getExports
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {ExportsSpec}
+
+* ###Returns: {ExportsSpec}
 
 Returns the exported names
 
 #### `getModuleEvaluationSideEffectsState(moduleGraph)`
 
+---
+### getModuleEvaluationSideEffectsState
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {ConnectionState}
+
+* ###Returns: {ConnectionState}
 
 #### `getNumberOfIdOccurrences()`
 
-* Returns: {number}
+---
+### getNumberOfIdOccurrences
+
+* ###Returns: {number}
 
 implement this method to allow the occurrence order plugin to count correctly
 
 #### `getReference(moduleGraph)`
 
+---
+### getReference
+
 > Stability: 0 - Deprecated
 
 * `moduleGraph` {ModuleGraph}
-* Returns: {never}
+
+* ###Returns: {never}
 
 Returns the referenced module and export
 
 #### `getReferencedExports(moduleGraph, runtime)`
 
+---
+### getReferencedExports
+
 * `moduleGraph` {ModuleGraph}
 * `runtime` {RuntimeSpec}
-* Returns: {string[]|ReferencedExport[]}
+
+* ###Returns: {string[]|ReferencedExport[]}
 
 Returns list of exports referenced by this dependency
 
 #### `getResourceIdentifier()`
 
-* Returns: {string}
+---
+### getResourceIdentifier
+
+* ###Returns: {string}
 
 #### `getWarnings(moduleGraph)`
 
+---
+### getWarnings
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {WebpackError[]}
+
+* ###Returns: {WebpackError[]}
 
 Returns warnings
 
 #### `serialize(__namedParameters)`
 
+---
+### serialize
+
 * `__namedParameters` {ObjectSerializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `setLoc(startLine, startColumn, endLine, endColumn)`
+
+---
+### setLoc
 
 * `startLine` {number}
 * `startColumn` {number}
 * `endLine` {number}
 * `endColumn` {number}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `updateHash(hash, context)`
 
+---
+### updateHash
+
 * `hash` {Hash}
 * `context` {UpdateHashContextDependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Update the hash
 
 #### Static method: `isLowPriorityDependency(dependency)`
 
+---
+### isLowPriorityDependency
+
 * `dependency` {Dependency}
-* Returns: {boolean}
+
+* ###Returns: {boolean}

--- a/pages/v5.x/webpack/namespaces/electron.md
+++ b/pages/v5.x/webpack/namespaces/electron.md
@@ -1,19 +1,28 @@
 # electron
 
-## Class: `ElectronTargetPlugin`
+## 
+### Class: `ElectronTargetPlugin`
 
 ### Constructors
 
 #### `new ElectronTargetPlugin([context])`
 
+---
+### ElectronTargetPlugin
+
 * `context` {"main"|"preload"|"renderer"}
-* Returns: {ElectronTargetPlugin}
+
+* ###Returns: {ElectronTargetPlugin}
 
 ### Methods
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin

--- a/pages/v5.x/webpack/namespaces/esm.md
+++ b/pages/v5.x/webpack/namespaces/esm.md
@@ -1,6 +1,7 @@
 # esm
 
-## Class: `ModuleChunkLoadingRuntimeModule`
+## 
+### Class: `ModuleChunkLoadingRuntimeModule`
 
 ### Extends
 
@@ -10,8 +11,12 @@
 
 #### `new ModuleChunkLoadingRuntimeModule(runtimeRequirements)`
 
+---
+### ModuleChunkLoadingRuntimeModule
+
 * `runtimeRequirements` {ReadonlySet<string>}
-* Returns: {ModuleChunkLoadingRuntimeModule}
+
+* ###Returns: {ModuleChunkLoadingRuntimeModule}
 
 ### Properties
 
@@ -67,151 +72,251 @@
 
 #### `addBlock(block)`
 
+---
+### addBlock
+
 * `block` {AsyncDependenciesBlock}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Adds a DependencyBlock to DependencyBlock relationship.
 This is used for when a Module has a AsyncDependencyBlock tie (for code-splitting)
 
 #### `addCacheDependencies(fileDependencies, contextDependencies, missingDependencies, buildDependencies)`
 
+---
+### addCacheDependencies
+
 * `fileDependencies` {LazySet<string>}
 * `contextDependencies` {LazySet<string>}
 * `missingDependencies` {LazySet<string>}
 * `buildDependencies` {LazySet<string>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addChunk(chunk)`
 
+---
+### addChunk
+
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `addCodeGenerationDependency(codeGenerationDependency)`
 
+---
+### addCodeGenerationDependency
+
 * `codeGenerationDependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addDependency(dependency)`
 
+---
+### addDependency
+
 * `dependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addError(error)`
 
+---
+### addError
+
 * `error` {WebpackError}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addPresentationalDependency(presentationalDependency)`
 
+---
+### addPresentationalDependency
+
 * `presentationalDependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addWarning(warning)`
 
+---
+### addWarning
+
 * `warning` {WebpackError}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `attach(compilation, chunk[, chunkGraph])`
+
+---
+### attach
 
 * `compilation` {Compilation}
 * `chunk` {Chunk}
 * `chunkGraph` {ChunkGraph}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `build(options, compilation, resolver, fs, callback)`
+
+---
+### build
 
 * `options` {WebpackOptionsNormalizedWithDefaults}
 * `compilation` {Compilation}
 * `resolver` {ResolverWithOptions}
 * `fs` {InputFileSystem}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `chunkCondition(chunk, compilation)`
 
+---
+### chunkCondition
+
 * `chunk` {Chunk}
 * `compilation` {Compilation}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `cleanupForCache()`
 
-* Returns: {void}
+---
+### cleanupForCache
+
+* ###Returns: {void}
 
 Assuming this module is in the cache. Remove internal references to allow freeing some memory.
 
 #### `clearDependenciesAndBlocks()`
 
-* Returns: {void}
+---
+### clearDependenciesAndBlocks
+
+* ###Returns: {void}
 
 Removes all dependencies and blocks
 
 #### `clearWarningsAndErrors()`
 
-* Returns: {void}
+---
+### clearWarningsAndErrors
+
+* ###Returns: {void}
 
 removes all warnings and errors
 
 #### `codeGeneration(context)`
 
+---
+### codeGeneration
+
 * `context` {CodeGenerationContext}
-* Returns: {CodeGenerationResult}
+
+* ###Returns: {CodeGenerationResult}
 
 #### `deserialize(__namedParameters)`
 
+---
+### deserialize
+
 * `__namedParameters` {ObjectDeserializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `generate()`
 
-* Returns: {string}
+---
+### generate
+
+* ###Returns: {string}
 
 #### `getChunks()`
 
-* Returns: {Chunk[]}
+---
+### getChunks
+
+* ###Returns: {Chunk[]}
 
 #### `getConcatenationBailoutReason(context)`
 
+---
+### getConcatenationBailoutReason
+
 * `context` {ConcatenationBailoutReasonContext}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `getErrors()`
 
-* Returns: {Iterable<WebpackError, any, any>}
+---
+### getErrors
+
+* ###Returns: {Iterable<WebpackError, any, any>}
 
 #### `getExportsType(moduleGraph[, strict])`
 
+---
+### getExportsType
+
 * `moduleGraph` {ModuleGraph}
 * `strict` {boolean}
-* Returns: {ExportsType}
+
+* ###Returns: {ExportsType}
 
 #### `getGeneratedCode()`
 
-* Returns: {string}
+---
+### getGeneratedCode
+
+* ###Returns: {string}
 
 #### `getNumberOfChunks()`
 
-* Returns: {number}
+---
+### getNumberOfChunks
+
+* ###Returns: {number}
 
 #### `getNumberOfErrors()`
 
-* Returns: {number}
+---
+### getNumberOfErrors
+
+* ###Returns: {number}
 
 #### `getNumberOfWarnings()`
 
-* Returns: {number}
+---
+### getNumberOfWarnings
+
+* ###Returns: {number}
 
 #### `getRootBlock()`
 
-* Returns: {DependenciesBlock}
+---
+### getRootBlock
+
+* ###Returns: {DependenciesBlock}
 
 #### `getSideEffectsConnectionState(moduleGraph)`
 
+---
+### getSideEffectsConnectionState
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {ConnectionState}
+
+* ###Returns: {ConnectionState}
 
 #### `getSourceBasicTypes()`
 
-* Returns: {ReadonlySet<string>}
+---
+### getSourceBasicTypes
+
+* ###Returns: {ReadonlySet<string>}
 
 Basic source types are high-level categories like javascript, css, webassembly, etc.
 We only have built-in knowledge about the javascript basic type here; other basic types may be
@@ -221,150 +326,248 @@ from getSourceTypes(), but their generated output is still JavaScript, i.e. thei
 
 #### `getSourceTypes()`
 
-* Returns: {ReadonlySet<string>}
+---
+### getSourceTypes
+
+* ###Returns: {ReadonlySet<string>}
 
 #### `getUnsafeCacheData()`
 
-* Returns: {UnsafeCacheData}
+---
+### getUnsafeCacheData
+
+* ###Returns: {UnsafeCacheData}
 
 Module should be unsafe cached. Get data that's needed for that.
 This data will be passed to restoreFromUnsafeCache later.
 
 #### `getWarnings()`
 
-* Returns: {Iterable<WebpackError, any, any>}
+---
+### getWarnings
+
+* ###Returns: {Iterable<WebpackError, any, any>}
 
 #### `hasChunkCondition()`
 
-* Returns: {boolean}
+---
+### hasChunkCondition
+
+* ###Returns: {boolean}
 
 #### `hasReasonForChunk(chunk, moduleGraph, chunkGraph)`
+
+---
+### hasReasonForChunk
 
 * `chunk` {Chunk}
 * `moduleGraph` {ModuleGraph}
 * `chunkGraph` {ChunkGraph}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `hasReasons(moduleGraph, runtime)`
 
+---
+### hasReasons
+
 * `moduleGraph` {ModuleGraph}
 * `runtime` {RuntimeSpec}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `identifier()`
 
-* Returns: {string}
+---
+### identifier
+
+* ###Returns: {string}
 
 #### `invalidateBuild()`
 
-* Returns: {void}
+---
+### invalidateBuild
+
+* ###Returns: {void}
 
 #### `isAccessibleInChunk(chunkGraph, chunk[, ignoreChunk])`
+
+---
+### isAccessibleInChunk
 
 * `chunkGraph` {ChunkGraph}
 * `chunk` {Chunk}
 * `ignoreChunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isAccessibleInChunkGroup(chunkGraph, chunkGroup[, ignoreChunk])`
+
+---
+### isAccessibleInChunkGroup
 
 * `chunkGraph` {ChunkGraph}
 * `chunkGroup` {ChunkGroup}
 * `ignoreChunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isEntryModule()`
 
-* Returns: {boolean}
+---
+### isEntryModule
+
+* ###Returns: {boolean}
 
 #### `isInChunk(chunk)`
 
+---
+### isInChunk
+
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isOptional(moduleGraph)`
 
+---
+### isOptional
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isProvided(exportName)`
 
+---
+### isProvided
+
 * `exportName` {string}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `libIdent(options)`
 
+---
+### libIdent
+
 * `options` {LibIdentOptions}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `nameForCondition()`
 
-* Returns: {string}
+---
+### nameForCondition
+
+* ###Returns: {string}
 
 #### `needBuild(context, callback)`
 
+---
+### needBuild
+
 * `context` {NeedBuildContext}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `needRebuild(fileTimestamps, contextTimestamps)`
+
+---
+### needRebuild
 
 > Stability: 0 - Deprecated
 
 * `fileTimestamps` {Map<string, number>}
 * `contextTimestamps` {Map<string, number>}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 Use needBuild instead
 
 #### `originalSource()`
 
-* Returns: {Source}
+---
+### originalSource
+
+* ###Returns: {Source}
 
 #### `readableIdentifier(requestShortener)`
 
+---
+### readableIdentifier
+
 * `requestShortener` {RequestShortener}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `removeChunk(chunk)`
 
+---
+### removeChunk
+
 * `chunk` {Chunk}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `removeDependency(dependency)`
 
+---
+### removeDependency
+
 * `dependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `serialize(__namedParameters)`
 
+---
+### serialize
+
 * `__namedParameters` {ObjectSerializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `shouldIsolate()`
 
-* Returns: {boolean}
+---
+### shouldIsolate
+
+* ###Returns: {boolean}
 
 #### `size([type])`
 
+---
+### size
+
 * `type` {string}
-* Returns: {number}
+
+* ###Returns: {number}
 
 #### `source(dependencyTemplates, runtimeTemplate[, type])`
+
+---
+### source
 
 > Stability: 0 - Deprecated
 
 * `dependencyTemplates` {DependencyTemplates}
 * `runtimeTemplate` {RuntimeTemplate}
 * `type` {string}
-* Returns: {Source}
+
+* ###Returns: {Source}
 
 Use codeGeneration() instead
 
 #### `updateCacheModule(module)`
 
+---
+### updateCacheModule
+
 * `module` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Assuming this module is in the cache. Update the (cached) module with
 the fresh module from the factory. Usually updates internal references
@@ -372,20 +575,32 @@ and properties.
 
 #### `updateHash(hash, context)`
 
+---
+### updateHash
+
 * `hash` {Hash}
 * `context` {UpdateHashContextDependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `getCompilationHooks(compilation)`
 
+---
+### getCompilationHooks
+
 * `compilation` {Compilation}
-* Returns: {JsonpCompilationPluginHooks}
+
+* ###Returns: {JsonpCompilationPluginHooks}
 
 #### Static method: `getSourceBasicTypes(module)`
+
+---
+### getSourceBasicTypes
 
 > Stability: 0 - Deprecated
 
 * `module` {Module}
-* Returns: {ReadonlySet<string>}
+
+* ###Returns: {ReadonlySet<string>}
 
 In webpack 6, call getSourceBasicTypes() directly on the module instance instead of using this static method.

--- a/pages/v5.x/webpack/namespaces/experiments/namespaces/ids.md
+++ b/pages/v5.x/webpack/namespaces/experiments/namespaces/ids.md
@@ -1,13 +1,18 @@
 # ids
 
-## Class: `SyncModuleIdsPlugin`
+## 
+### Class: `SyncModuleIdsPlugin`
 
 ### Constructors
 
 #### `new SyncModuleIdsPlugin(options)`
 
+---
+### SyncModuleIdsPlugin
+
 * `options` {SyncModuleIdsPluginOptions}
-* Returns: {SyncModuleIdsPlugin}
+
+* ###Returns: {SyncModuleIdsPlugin}
 
 ### Properties
 
@@ -17,7 +22,11 @@
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin

--- a/pages/v5.x/webpack/namespaces/experiments/namespaces/schemes.md
+++ b/pages/v5.x/webpack/namespaces/experiments/namespaces/schemes.md
@@ -1,13 +1,18 @@
 # schemes
 
-## Class: `HttpUriPlugin`
+## 
+### Class: `HttpUriPlugin`
 
 ### Constructors
 
 #### `new HttpUriPlugin(options)`
 
+---
+### HttpUriPlugin
+
 * `options` {HttpUriOptions}
-* Returns: {HttpUriPlugin}
+
+* ###Returns: {HttpUriPlugin}
 
 ### Properties
 
@@ -17,22 +22,31 @@
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `VirtualUrlPlugin`
+## 
+### Class: `VirtualUrlPlugin`
 
 ### Constructors
 
 #### `new VirtualUrlPlugin(modules[, schemeOrOptions])`
 
+---
+### VirtualUrlPlugin
+
 * `modules` {VirtualModules}
 * `schemeOrOptions` {string|Omit<VirtualUrlOptions, "modules">}
-* Returns: {VirtualUrlPlugin}
+
+* ###Returns: {VirtualUrlPlugin}
 
 ### Properties
 
@@ -46,19 +60,31 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 #### `findVirtualModuleConfigById(id)`
 
+---
+### findVirtualModuleConfigById
+
 * `id` {string}
-* Returns: {VirtualModule}
+
+* ###Returns: {VirtualModule}
 
 #### `getCacheVersion(version)`
 
+---
+### getCacheVersion
+
 * `version` {string|true|object}
-* Returns: {string}
+
+* ###Returns: {string}
 
 Get the cache version for a given version value

--- a/pages/v5.x/webpack/namespaces/ids.md
+++ b/pages/v5.x/webpack/namespaces/ids.md
@@ -1,13 +1,18 @@
 # ids
 
-## Class: `ChunkModuleIdRangePlugin`
+## 
+### Class: `ChunkModuleIdRangePlugin`
 
 ### Constructors
 
 #### `new ChunkModuleIdRangePlugin(options)`
 
+---
+### ChunkModuleIdRangePlugin
+
 * `options` {ChunkModuleIdRangePluginOptions}
-* Returns: {ChunkModuleIdRangePlugin}
+
+* ###Returns: {ChunkModuleIdRangePlugin}
 
 ### Properties
 
@@ -17,21 +22,30 @@
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `DeterministicChunkIdsPlugin`
+## 
+### Class: `DeterministicChunkIdsPlugin`
 
 ### Constructors
 
 #### `new DeterministicChunkIdsPlugin([options])`
 
+---
+### DeterministicChunkIdsPlugin
+
 * `options` {DeterministicChunkIdsPluginOptions}
-* Returns: {DeterministicChunkIdsPlugin}
+
+* ###Returns: {DeterministicChunkIdsPlugin}
 
 ### Properties
 
@@ -41,21 +55,30 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `DeterministicModuleIdsPlugin`
+## 
+### Class: `DeterministicModuleIdsPlugin`
 
 ### Constructors
 
 #### `new DeterministicModuleIdsPlugin([options])`
 
+---
+### DeterministicModuleIdsPlugin
+
 * `options` {DeterministicModuleIdsPluginOptions}
-* Returns: {DeterministicModuleIdsPlugin}
+
+* ###Returns: {DeterministicModuleIdsPlugin}
 
 ### Properties
 
@@ -65,21 +88,30 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `HashedModuleIdsPlugin`
+## 
+### Class: `HashedModuleIdsPlugin`
 
 ### Constructors
 
 #### `new HashedModuleIdsPlugin([options])`
 
+---
+### HashedModuleIdsPlugin
+
 * `options` {HashedModuleIdsPluginOptions}
-* Returns: {HashedModuleIdsPlugin}
+
+* ###Returns: {HashedModuleIdsPlugin}
 
 ### Properties
 
@@ -89,21 +121,30 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `NamedChunkIdsPlugin`
+## 
+### Class: `NamedChunkIdsPlugin`
 
 ### Constructors
 
 #### `new NamedChunkIdsPlugin([options])`
 
+---
+### NamedChunkIdsPlugin
+
 * `options` {NamedChunkIdsPluginOptions}
-* Returns: {NamedChunkIdsPlugin}
+
+* ###Returns: {NamedChunkIdsPlugin}
 
 ### Properties
 
@@ -113,21 +154,30 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `NamedModuleIdsPlugin`
+## 
+### Class: `NamedModuleIdsPlugin`
 
 ### Constructors
 
 #### `new NamedModuleIdsPlugin([options])`
 
+---
+### NamedModuleIdsPlugin
+
 * `options` {NamedModuleIdsPluginOptions}
-* Returns: {NamedModuleIdsPlugin}
+
+* ###Returns: {NamedModuleIdsPlugin}
 
 ### Properties
 
@@ -137,40 +187,57 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `NaturalModuleIdsPlugin`
+## 
+### Class: `NaturalModuleIdsPlugin`
 
 ### Constructors
 
 #### `new NaturalModuleIdsPlugin()`
 
-* Returns: {NaturalModuleIdsPlugin}
+---
+### NaturalModuleIdsPlugin
+
+* ###Returns: {NaturalModuleIdsPlugin}
 
 ### Methods
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `OccurrenceChunkIdsPlugin`
+## 
+### Class: `OccurrenceChunkIdsPlugin`
 
 ### Constructors
 
 #### `new OccurrenceChunkIdsPlugin([options])`
 
+---
+### OccurrenceChunkIdsPlugin
+
 * `options` {OccurrenceChunkIdsPluginOptions}
-* Returns: {OccurrenceChunkIdsPlugin}
+
+* ###Returns: {OccurrenceChunkIdsPlugin}
 
 ### Properties
 
@@ -180,21 +247,30 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `OccurrenceModuleIdsPlugin`
+## 
+### Class: `OccurrenceModuleIdsPlugin`
 
 ### Constructors
 
 #### `new OccurrenceModuleIdsPlugin([options])`
 
+---
+### OccurrenceModuleIdsPlugin
+
 * `options` {OccurrenceModuleIdsPluginOptions}
-* Returns: {OccurrenceModuleIdsPlugin}
+
+* ###Returns: {OccurrenceModuleIdsPlugin}
 
 ### Properties
 
@@ -204,7 +280,11 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin

--- a/pages/v5.x/webpack/namespaces/javascript.md
+++ b/pages/v5.x/webpack/namespaces/javascript.md
@@ -1,13 +1,18 @@
 # javascript
 
-## Class: `EnableChunkLoadingPlugin`
+## 
+### Class: `EnableChunkLoadingPlugin`
 
 ### Constructors
 
 #### `new EnableChunkLoadingPlugin(type)`
 
+---
+### EnableChunkLoadingPlugin
+
 * `type` {string}
-* Returns: {EnableChunkLoadingPlugin}
+
+* ###Returns: {EnableChunkLoadingPlugin}
 
 ### Properties
 
@@ -17,26 +22,39 @@
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 #### Static method: `checkEnabled(compiler, type)`
 
+---
+### checkEnabled
+
 * `compiler` {Compiler}
 * `type` {string}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `setEnabled(compiler, type)`
 
+---
+### setEnabled
+
 * `compiler` {Compiler}
 * `type` {string}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## Class: `JavascriptParser`
+## 
+### Class: `JavascriptParser`
 
 ### Extends
 
@@ -46,9 +64,13 @@ Apply the plugin
 
 #### `new JavascriptParser([sourceType][, options])`
 
+---
+### JavascriptParser
+
 * `sourceType` {"module"|"auto"|"script"}
 * `options` {object}
-* Returns: {JavascriptParser}
+
+* ###Returns: {JavascriptParser}
 
 ### Properties
 
@@ -75,43 +97,74 @@ Apply the plugin
 
 #### `blockPreWalkClassDeclaration(statement)`
 
+---
+### blockPreWalkClassDeclaration
+
 * `statement` {ClassDeclaration|MaybeNamedClassDeclaration}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `blockPreWalkExportDefaultDeclaration(statement)`
 
+---
+### blockPreWalkExportDefaultDeclaration
+
 * `statement` {ExportDefaultDeclaration}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `blockPreWalkExportNamedDeclaration(statement)`
 
+---
+### blockPreWalkExportNamedDeclaration
+
 * `statement` {ExportNamedDeclaration}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `blockPreWalkExpressionStatement(statement)`
 
+---
+### blockPreWalkExpressionStatement
+
 * `statement` {ExpressionStatement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `blockPreWalkStatement(statement)`
 
+---
+### blockPreWalkStatement
+
 * `statement` {ClassDeclaration|MaybeNamedClassDeclaration|FunctionDeclaration|MaybeNamedFunctionDeclaration|ImportDeclaration|ExportNamedDeclaration|ExportDefaultDeclaration|ExportAllDeclaration|ExpressionStatement|BlockStatement|StaticBlock|EmptyStatement|DebuggerStatement|WithStatement|ReturnStatement|LabeledStatement|BreakStatement|ContinueStatement|IfStatement|SwitchStatement|ThrowStatement|TryStatement|WhileStatement|DoWhileStatement|ForStatement|ForInStatement|ForOfStatement|VariableDeclaration}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `blockPreWalkStatements(statements)`
 
+---
+### blockPreWalkStatements
+
 * `statements` {ClassDeclaration|FunctionDeclaration|ImportDeclaration|ExportNamedDeclaration|ExportDefaultDeclaration|ExportAllDeclaration|ExpressionStatement|BlockStatement|StaticBlock|EmptyStatement|DebuggerStatement|WithStatement|ReturnStatement|LabeledStatement|BreakStatement|ContinueStatement|IfStatement|SwitchStatement|ThrowStatement|TryStatement|WhileStatement|DoWhileStatement|ForStatement|ForInStatement|ForOfStatement|VariableDeclaration[]}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Block pre walking iterates the scope for block variable declarations
 
 #### `blockPreWalkVariableDeclaration(statement)`
 
+---
+### blockPreWalkVariableDeclaration
+
 * `statement` {VariableDeclaration}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `callHooksForExpression(hookMap, expr, args)`
 
+---
+### callHooksForExpression
+
 ###### T
 
 `T`
@@ -119,13 +172,18 @@ Block pre walking iterates the scope for block variable declarations
 ###### R
 
 `R`
+
 * `hookMap` {HookMap<SyncBailHook<T, R, UnsetAdditionalOptions>>}
 * `expr` {ClassExpression|Identifier|SimpleLiteral|RegExpLiteral|BigIntLiteral|ArrayExpression|ArrowFunctionExpression|AssignmentExpression|AwaitExpression|BinaryExpression|SimpleCallExpression|NewExpression|ChainExpression|ConditionalExpression|FunctionExpression|ImportExpression|LogicalExpression|MemberExpression|MetaProperty|ObjectExpression|SequenceExpression|TaggedTemplateExpression|TemplateLiteral|ThisExpression|UnaryExpression|UpdateExpression|YieldExpression|Super}
 * `args` {AsArray<T>}
-* Returns: {R}
+
+* ###Returns: {R}
 
 #### `callHooksForExpressionWithFallback(hookMap, expr, fallback, defined, args)`
 
+---
+### callHooksForExpressionWithFallback
+
 ###### T
 
 `T`
@@ -133,15 +191,20 @@ Block pre walking iterates the scope for block variable declarations
 ###### R
 
 `R`
+
 * `hookMap` {HookMap<SyncBailHook<T, R, UnsetAdditionalOptions>>}
 * `expr` {ClassExpression|Identifier|SimpleLiteral|RegExpLiteral|BigIntLiteral|ArrayExpression|ArrowFunctionExpression|AssignmentExpression|AwaitExpression|BinaryExpression|SimpleCallExpression|NewExpression|ChainExpression|ConditionalExpression|FunctionExpression|ImportExpression|LogicalExpression|MemberExpression|MetaProperty|ObjectExpression|SequenceExpression|TaggedTemplateExpression|TemplateLiteral|ThisExpression|UnaryExpression|UpdateExpression|YieldExpression|Super}
 * `fallback` {object}
 * `defined` {object}
 * `args` {AsArray<T>}
-* Returns: {R}
+
+* ###Returns: {R}
 
 #### `callHooksForInfo(hookMap, info, args)`
 
+---
+### callHooksForInfo
+
 ###### T
 
 `T`
@@ -149,13 +212,18 @@ Block pre walking iterates the scope for block variable declarations
 ###### R
 
 `R`
+
 * `hookMap` {HookMap<SyncBailHook<T, R, UnsetAdditionalOptions>>}
 * `info` {ExportedVariableInfo}
 * `args` {AsArray<T>}
-* Returns: {R}
+
+* ###Returns: {R}
 
 #### `callHooksForInfoWithFallback(hookMap, info, fallback, defined, args)`
 
+---
+### callHooksForInfoWithFallback
+
 ###### T
 
 `T`
@@ -163,15 +231,20 @@ Block pre walking iterates the scope for block variable declarations
 ###### R
 
 `R`
+
 * `hookMap` {HookMap<SyncBailHook<T, R, UnsetAdditionalOptions>>}
 * `info` {ExportedVariableInfo}
 * `fallback` {object}
 * `defined` {object}
 * `args` {AsArray<T>}
-* Returns: {R}
+
+* ###Returns: {R}
 
 #### `callHooksForName(hookMap, name, args)`
 
+---
+### callHooksForName
+
 ###### T
 
 `T`
@@ -179,12 +252,17 @@ Block pre walking iterates the scope for block variable declarations
 ###### R
 
 `R`
+
 * `hookMap` {HookMap<SyncBailHook<T, R, UnsetAdditionalOptions>>}
 * `name` {string}
 * `args` {AsArray<T>}
-* Returns: {R}
+
+* ###Returns: {R}
 
 #### `callHooksForNameWithFallback(hookMap, name, fallback, defined, args)`
+
+---
+### callHooksForNameWithFallback
 
 ###### T
 
@@ -193,550 +271,953 @@ Block pre walking iterates the scope for block variable declarations
 ###### R
 
 `R`
+
 * `hookMap` {HookMap<SyncBailHook<T, R, UnsetAdditionalOptions>>}
 * `name` {string}
 * `fallback` {object}
 * `defined` {object}
 * `args` {AsArray<T>}
-* Returns: {R}
+
+* ###Returns: {R}
 
 #### `defineVariable(name)`
 
+---
+### defineVariable
+
 * `name` {string}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `destructuringAssignmentPropertiesFor(node)`
 
+---
+### destructuringAssignmentPropertiesFor
+
 * `node` {Expression}
-* Returns: {Set<DestructuringAssignmentProperty>}
+
+* ###Returns: {Set<DestructuringAssignmentProperty>}
 
 #### `detectMode(statements)`
 
+---
+### detectMode
+
 * `statements` {ClassDeclaration|FunctionDeclaration|ImportDeclaration|ExportNamedDeclaration|ExportDefaultDeclaration|ExportAllDeclaration|ExpressionStatement|BlockStatement|StaticBlock|EmptyStatement|DebuggerStatement|WithStatement|ReturnStatement|LabeledStatement|BreakStatement|ContinueStatement|IfStatement|SwitchStatement|ThrowStatement|TryStatement|WhileStatement|DoWhileStatement|ForStatement|ForInStatement|ForOfStatement|VariableDeclaration|Directive[]}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `enterArrayPattern(pattern, onIdent)`
 
+---
+### enterArrayPattern
+
 * `pattern` {ArrayPattern}
 * `onIdent` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `enterAssignmentPattern(pattern, onIdent)`
 
+---
+### enterAssignmentPattern
+
 * `pattern` {AssignmentPattern}
 * `onIdent` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `enterDeclaration(declaration, onIdent)`
 
+---
+### enterDeclaration
+
 * `declaration` {Declaration}
 * `onIdent` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `enterDestructuringAssignment(pattern, expression)`
 
+---
+### enterDestructuringAssignment
+
 * `pattern` {Pattern}
 * `expression` {Expression}
-* Returns: {ClassExpression|Identifier|SimpleLiteral|RegExpLiteral|BigIntLiteral|ArrayExpression|ArrowFunctionExpression|AssignmentExpression|AwaitExpression|BinaryExpression|SimpleCallExpression|NewExpression|ChainExpression|ConditionalExpression|FunctionExpression|ImportExpression|LogicalExpression|MemberExpression|MetaProperty|ObjectExpression|SequenceExpression|TaggedTemplateExpression|TemplateLiteral|ThisExpression|UnaryExpression|UpdateExpression|YieldExpression}
+
+* ###Returns: {ClassExpression|Identifier|SimpleLiteral|RegExpLiteral|BigIntLiteral|ArrayExpression|ArrowFunctionExpression|AssignmentExpression|AwaitExpression|BinaryExpression|SimpleCallExpression|NewExpression|ChainExpression|ConditionalExpression|FunctionExpression|ImportExpression|LogicalExpression|MemberExpression|MetaProperty|ObjectExpression|SequenceExpression|TaggedTemplateExpression|TemplateLiteral|ThisExpression|UnaryExpression|UpdateExpression|YieldExpression}
 
 #### `enterIdentifier(pattern, onIdent)`
 
+---
+### enterIdentifier
+
 * `pattern` {Identifier}
 * `onIdent` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `enterObjectPattern(pattern, onIdent)`
 
+---
+### enterObjectPattern
+
 * `pattern` {ObjectPattern}
 * `onIdent` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `enterPattern(pattern, onIdent)`
 
+---
+### enterPattern
+
 * `pattern` {Property|Identifier|MemberExpression|ObjectPattern|ArrayPattern|RestElement|AssignmentPattern}
 * `onIdent` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `enterPatterns(patterns, onIdent)`
 
+---
+### enterPatterns
+
 * `patterns` {string|Property|Identifier|MemberExpression|ObjectPattern|ArrayPattern|RestElement|AssignmentPattern[]}
 * `onIdent` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `enterRestElement(pattern, onIdent)`
 
+---
+### enterRestElement
+
 * `pattern` {RestElement}
 * `onIdent` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `evaluate(source)`
 
+---
+### evaluate
+
 * `source` {string}
-* Returns: {BasicEvaluatedExpression}
+
+* ###Returns: {BasicEvaluatedExpression}
 
 #### `evaluatedVariable(tagInfo)`
 
+---
+### evaluatedVariable
+
 * `tagInfo` {TagInfo}
-* Returns: {VariableInfo}
+
+* ###Returns: {VariableInfo}
 
 #### `evaluateExpression(expression)`
 
+---
+### evaluateExpression
+
 * `expression` {ClassExpression|Identifier|SimpleLiteral|RegExpLiteral|BigIntLiteral|ArrayExpression|ArrowFunctionExpression|AssignmentExpression|AwaitExpression|BinaryExpression|SimpleCallExpression|NewExpression|ChainExpression|ConditionalExpression|FunctionExpression|ImportExpression|LogicalExpression|MemberExpression|MetaProperty|ObjectExpression|SequenceExpression|TaggedTemplateExpression|TemplateLiteral|ThisExpression|UnaryExpression|UpdateExpression|YieldExpression|PrivateIdentifier|SpreadElement|Super}
-* Returns: {BasicEvaluatedExpression}
+
+* ###Returns: {BasicEvaluatedExpression}
 
 #### `extractMemberExpressionChain(expression)`
 
+---
+### extractMemberExpressionChain
+
 * `expression` {ClassExpression|Identifier|SimpleLiteral|RegExpLiteral|BigIntLiteral|ArrayExpression|ArrowFunctionExpression|AssignmentExpression|AwaitExpression|BinaryExpression|SimpleCallExpression|NewExpression|ChainExpression|ConditionalExpression|FunctionExpression|ImportExpression|LogicalExpression|MemberExpression|MetaProperty|ObjectExpression|SequenceExpression|TaggedTemplateExpression|TemplateLiteral|ThisExpression|UnaryExpression|UpdateExpression|YieldExpression|Super}
-* Returns: {object}
+
+* ###Returns: {object}
 
 #### `getComments(range)`
 
+---
+### getComments
+
 * `range` {Tuple<number, number>}
-* Returns: {CommentJavascriptParser[]}
+
+* ###Returns: {CommentJavascriptParser[]}
 
 #### `getFreeInfoFromVariable(varName)`
 
+---
+### getFreeInfoFromVariable
+
 * `varName` {string}
-* Returns: {object}
+
+* ###Returns: {object}
 
 #### `getMemberExpressionInfo(expression, allowedTypes)`
 
+---
+### getMemberExpressionInfo
+
 * `expression` {ClassExpression|Identifier|SimpleLiteral|RegExpLiteral|BigIntLiteral|ArrayExpression|ArrowFunctionExpression|AssignmentExpression|AwaitExpression|BinaryExpression|SimpleCallExpression|NewExpression|ChainExpression|ConditionalExpression|FunctionExpression|ImportExpression|LogicalExpression|MemberExpression|MetaProperty|ObjectExpression|SequenceExpression|TaggedTemplateExpression|TemplateLiteral|ThisExpression|UnaryExpression|UpdateExpression|YieldExpression|Super}
 * `allowedTypes` {number}
-* Returns: {CallExpressionInfo|ExpressionExpressionInfo}
+
+* ###Returns: {CallExpressionInfo|ExpressionExpressionInfo}
 
 #### `getNameForExpression(expression)`
 
+---
+### getNameForExpression
+
 * `expression` {Expression}
-* Returns: {object}
+
+* ###Returns: {object}
 
 #### `getNameInfoFromVariable(varName)`
 
+---
+### getNameInfoFromVariable
+
 * `varName` {string}
-* Returns: {object}
+
+* ###Returns: {object}
 
 #### `getRenameIdentifier(expr)`
 
+---
+### getRenameIdentifier
+
 * `expr` {ClassExpression|Identifier|SimpleLiteral|RegExpLiteral|BigIntLiteral|ArrayExpression|ArrowFunctionExpression|AssignmentExpression|AwaitExpression|BinaryExpression|SimpleCallExpression|NewExpression|ChainExpression|ConditionalExpression|FunctionExpression|ImportExpression|LogicalExpression|MemberExpression|MetaProperty|ObjectExpression|SequenceExpression|TaggedTemplateExpression|TemplateLiteral|ThisExpression|UnaryExpression|UpdateExpression|YieldExpression|SpreadElement}
-* Returns: {string|VariableInfo}
+
+* ###Returns: {string|VariableInfo}
 
 #### `getTagData(name, tag)`
 
+---
+### getTagData
+
 * `name` {string}
 * `tag` {symbol}
-* Returns: {Record<string, any>|TopLevelSymbol|HarmonySettings|ImportSettings|CommonJsImportSettings|CompatibilitySettings|HarmonySpecifierGuards}
+
+* ###Returns: {Record<string, any>|TopLevelSymbol|HarmonySettings|ImportSettings|CommonJsImportSettings|CompatibilitySettings|HarmonySpecifierGuards}
 
 #### `getVariableInfo(name)`
 
+---
+### getVariableInfo
+
 * `name` {string}
-* Returns: {ExportedVariableInfo}
+
+* ###Returns: {ExportedVariableInfo}
 
 #### `inBlockScope(fn[, inExecutedPath])`
 
+---
+### inBlockScope
+
 * `fn` {object}
 * `inExecutedPath` {boolean}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `inClassScope(hasThis, params, fn)`
+
+---
+### inClassScope
 
 * `hasThis` {boolean}
 * `params` {Identifier[]}
 * `fn` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `inFunctionScope(hasThis, params, fn)`
+
+---
+### inFunctionScope
 
 * `hasThis` {boolean}
 * `params` {string|Identifier|MemberExpression|ObjectPattern|ArrayPattern|RestElement|AssignmentPattern[]}
 * `fn` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `inScope(params, fn)`
+
+---
+### inScope
 
 > Stability: 0 - Deprecated
 
 * `params` {string|Property|Identifier|MemberExpression|ObjectPattern|ArrayPattern|RestElement|AssignmentPattern[]}
 * `fn` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `isAsiPosition(pos)`
 
+---
+### isAsiPosition
+
 * `pos` {number}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isPure(expr, commentsStartPos)`
 
+---
+### isPure
+
 * `expr` {ClassDeclaration|MaybeNamedClassDeclaration|ClassExpression|Identifier|SimpleLiteral|RegExpLiteral|BigIntLiteral|ArrayExpression|ArrowFunctionExpression|AssignmentExpression|AwaitExpression|BinaryExpression|SimpleCallExpression|NewExpression|ChainExpression|ConditionalExpression|FunctionExpression|ImportExpression|LogicalExpression|MemberExpression|MetaProperty|ObjectExpression|SequenceExpression|TaggedTemplateExpression|TemplateLiteral|ThisExpression|UnaryExpression|UpdateExpression|YieldExpression|FunctionDeclaration|MaybeNamedFunctionDeclaration|PrivateIdentifier|VariableDeclaration}
 * `commentsStartPos` {number}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isStatementLevelExpression(expr)`
 
+---
+### isStatementLevelExpression
+
 * `expr` {Expression}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isVariableDefined(name)`
 
+---
+### isVariableDefined
+
 * `name` {string}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `modulePreWalkExportAllDeclaration(statement)`
 
+---
+### modulePreWalkExportAllDeclaration
+
 * `statement` {ExportAllDeclaration}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `modulePreWalkExportNamedDeclaration(statement)`
 
+---
+### modulePreWalkExportNamedDeclaration
+
 * `statement` {ExportNamedDeclaration}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `modulePreWalkImportDeclaration(statement)`
 
+---
+### modulePreWalkImportDeclaration
+
 * `statement` {ImportDeclaration}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `modulePreWalkStatements(statements)`
 
+---
+### modulePreWalkStatements
+
 * `statements` {ClassDeclaration|FunctionDeclaration|ImportDeclaration|ExportNamedDeclaration|ExportDefaultDeclaration|ExportAllDeclaration|ExpressionStatement|BlockStatement|StaticBlock|EmptyStatement|DebuggerStatement|WithStatement|ReturnStatement|LabeledStatement|BreakStatement|ContinueStatement|IfStatement|SwitchStatement|ThrowStatement|TryStatement|WhileStatement|DoWhileStatement|ForStatement|ForInStatement|ForOfStatement|VariableDeclaration[]}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Module pre walking iterates the scope for import entries
 
 #### `parse(source, state)`
 
+---
+### parse
+
 * `source` {string|Buffer<ArrayBufferLike>|PreparsedAst}
 * `state` {ParserState}
-* Returns: {ParserState}
+
+* ###Returns: {ParserState}
 
 #### `parseCalculatedString(expression)`
 
+---
+### parseCalculatedString
+
 * `expression` {Expression}
-* Returns: {CalculatedStringResult}
+
+* ###Returns: {CalculatedStringResult}
 
 #### `parseCommentOptions(range)`
 
+---
+### parseCommentOptions
+
 * `range` {Tuple<number, number>}
-* Returns: {object}
+
+* ###Returns: {object}
 
 #### `parseString(expression)`
 
+---
+### parseString
+
 * `expression` {Expression}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `preWalkAssignmentExpression(expression)`
 
+---
+### preWalkAssignmentExpression
+
 * `expression` {AssignmentExpression}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `preWalkBlockStatement(statement)`
 
+---
+### preWalkBlockStatement
+
 * `statement` {BlockStatement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `preWalkCatchClause(catchClause)`
 
+---
+### preWalkCatchClause
+
 * `catchClause` {CatchClause}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `preWalkDoWhileStatement(statement)`
 
+---
+### preWalkDoWhileStatement
+
 * `statement` {DoWhileStatement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `preWalkForInStatement(statement)`
 
+---
+### preWalkForInStatement
+
 * `statement` {ForInStatement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `preWalkForOfStatement(statement)`
 
+---
+### preWalkForOfStatement
+
 * `statement` {ForOfStatement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `preWalkForStatement(statement)`
 
+---
+### preWalkForStatement
+
 * `statement` {ForStatement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `preWalkFunctionDeclaration(statement)`
 
+---
+### preWalkFunctionDeclaration
+
 * `statement` {FunctionDeclaration|MaybeNamedFunctionDeclaration}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `preWalkIfStatement(statement)`
 
+---
+### preWalkIfStatement
+
 * `statement` {IfStatement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `preWalkLabeledStatement(statement)`
 
+---
+### preWalkLabeledStatement
+
 * `statement` {LabeledStatement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `preWalkStatement(statement)`
 
+---
+### preWalkStatement
+
 * `statement` {ClassDeclaration|MaybeNamedClassDeclaration|FunctionDeclaration|MaybeNamedFunctionDeclaration|ImportDeclaration|ExportNamedDeclaration|ExportDefaultDeclaration|ExportAllDeclaration|ExpressionStatement|BlockStatement|StaticBlock|EmptyStatement|DebuggerStatement|WithStatement|ReturnStatement|LabeledStatement|BreakStatement|ContinueStatement|IfStatement|SwitchStatement|ThrowStatement|TryStatement|WhileStatement|DoWhileStatement|ForStatement|ForInStatement|ForOfStatement|VariableDeclaration}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Walking iterates the statements and expressions and processes them
 
 #### `preWalkStatements(statements)`
 
+---
+### preWalkStatements
+
 * `statements` {ClassDeclaration|FunctionDeclaration|ImportDeclaration|ExportNamedDeclaration|ExportDefaultDeclaration|ExportAllDeclaration|ExpressionStatement|BlockStatement|StaticBlock|EmptyStatement|DebuggerStatement|WithStatement|ReturnStatement|LabeledStatement|BreakStatement|ContinueStatement|IfStatement|SwitchStatement|ThrowStatement|TryStatement|WhileStatement|DoWhileStatement|ForStatement|ForInStatement|ForOfStatement|VariableDeclaration[]}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Pre walking iterates the scope for variable declarations
 
 #### `preWalkSwitchCases(switchCases)`
 
+---
+### preWalkSwitchCases
+
 * `switchCases` {SwitchCase[]}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `preWalkSwitchStatement(statement)`
 
+---
+### preWalkSwitchStatement
+
 * `statement` {SwitchStatement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `preWalkTryStatement(statement)`
 
+---
+### preWalkTryStatement
+
 * `statement` {TryStatement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `preWalkVariableDeclaration(statement)`
 
+---
+### preWalkVariableDeclaration
+
 * `statement` {VariableDeclaration}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `preWalkVariableDeclarator(declarator)`
 
+---
+### preWalkVariableDeclarator
+
 * `declarator` {VariableDeclarator}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `preWalkWhileStatement(statement)`
 
+---
+### preWalkWhileStatement
+
 * `statement` {WhileStatement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `preWalkWithStatement(statement)`
 
+---
+### preWalkWithStatement
+
 * `statement` {WithStatement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `setAsiPosition(pos)`
 
+---
+### setAsiPosition
+
 * `pos` {number}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `setVariable(name, variableInfo)`
 
+---
+### setVariable
+
 * `name` {string}
 * `variableInfo` {ExportedVariableInfo}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `tagVariable(name, tag[, data][, flags])`
+
+---
+### tagVariable
 
 * `name` {string}
 * `tag` {symbol}
 * `data` {Record<string, any>|TopLevelSymbol|HarmonySettings|ImportSettings|CommonJsImportSettings|CompatibilitySettings|HarmonySpecifierGuards}
 * `flags` {0|1|2|4}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `undefineVariable(name)`
 
+---
+### undefineVariable
+
 * `name` {string}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `unsetAsiPosition(pos)`
 
+---
+### unsetAsiPosition
+
 * `pos` {number}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkArrayExpression(expression)`
 
+---
+### walkArrayExpression
+
 * `expression` {ArrayExpression}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkArrayPattern(pattern)`
 
+---
+### walkArrayPattern
+
 * `pattern` {ArrayPattern}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkArrowFunctionExpression(expression)`
 
+---
+### walkArrowFunctionExpression
+
 * `expression` {ArrowFunctionExpression}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkAssignmentExpression(expression)`
 
+---
+### walkAssignmentExpression
+
 * `expression` {AssignmentExpression}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkAssignmentPattern(pattern)`
 
+---
+### walkAssignmentPattern
+
 * `pattern` {AssignmentPattern}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkAwaitExpression(expression)`
 
+---
+### walkAwaitExpression
+
 * `expression` {AwaitExpression}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkBinaryExpression(expression)`
 
+---
+### walkBinaryExpression
+
 * `expression` {BinaryExpression}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkBlockStatement(statement)`
 
+---
+### walkBlockStatement
+
 * `statement` {BlockStatement|StaticBlock}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkCallExpression(expression)`
 
+---
+### walkCallExpression
+
 * `expression` {CallExpression}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkCatchClause(catchClause)`
 
+---
+### walkCatchClause
+
 * `catchClause` {CatchClause}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkChainExpression(expression)`
 
+---
+### walkChainExpression
+
 * `expression` {ChainExpression}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkClass(classy)`
 
+---
+### walkClass
+
 * `classy` {ClassDeclaration|MaybeNamedClassDeclaration|ClassExpression}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkClassDeclaration(statement)`
 
+---
+### walkClassDeclaration
+
 * `statement` {ClassDeclaration|MaybeNamedClassDeclaration}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkClassExpression(expression)`
 
+---
+### walkClassExpression
+
 * `expression` {ClassExpression}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkConditionalExpression(expression)`
 
+---
+### walkConditionalExpression
+
 * `expression` {ConditionalExpression}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkDoWhileStatement(statement)`
 
+---
+### walkDoWhileStatement
+
 * `statement` {DoWhileStatement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkExportDefaultDeclaration(statement)`
 
+---
+### walkExportDefaultDeclaration
+
 * `statement` {ExportDefaultDeclaration}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkExportNamedDeclaration(statement)`
 
+---
+### walkExportNamedDeclaration
+
 * `statement` {ExportNamedDeclaration}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkExpression(expression)`
 
+---
+### walkExpression
+
 * `expression` {ClassExpression|Identifier|SimpleLiteral|RegExpLiteral|BigIntLiteral|ArrayExpression|ArrowFunctionExpression|AssignmentExpression|AwaitExpression|BinaryExpression|SimpleCallExpression|NewExpression|ChainExpression|ConditionalExpression|FunctionExpression|ImportExpression|LogicalExpression|MemberExpression|MetaProperty|ObjectExpression|SequenceExpression|TaggedTemplateExpression|TemplateLiteral|ThisExpression|UnaryExpression|UpdateExpression|YieldExpression|PrivateIdentifier|SpreadElement|Super}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkExpressions(expressions)`
 
+---
+### walkExpressions
+
 * `expressions` {ClassExpression|Identifier|SimpleLiteral|RegExpLiteral|BigIntLiteral|ArrayExpression|ArrowFunctionExpression|AssignmentExpression|AwaitExpression|BinaryExpression|SimpleCallExpression|NewExpression|ChainExpression|ConditionalExpression|FunctionExpression|ImportExpression|LogicalExpression|MemberExpression|MetaProperty|ObjectExpression|SequenceExpression|TaggedTemplateExpression|TemplateLiteral|ThisExpression|UnaryExpression|UpdateExpression|YieldExpression|SpreadElement[]}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkExpressionStatement(statement)`
 
+---
+### walkExpressionStatement
+
 * `statement` {ExpressionStatement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkForInStatement(statement)`
 
+---
+### walkForInStatement
+
 * `statement` {ForInStatement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkForOfStatement(statement)`
 
+---
+### walkForOfStatement
+
 * `statement` {ForOfStatement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkForStatement(statement)`
 
+---
+### walkForStatement
+
 * `statement` {ForStatement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkFunctionDeclaration(statement)`
 
+---
+### walkFunctionDeclaration
+
 * `statement` {FunctionDeclaration|MaybeNamedFunctionDeclaration}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkFunctionExpression(expression)`
 
+---
+### walkFunctionExpression
+
 * `expression` {FunctionExpression}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkIdentifier(expression)`
 
+---
+### walkIdentifier
+
 * `expression` {Identifier}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkIfStatement(statement)`
 
+---
+### walkIfStatement
+
 * `statement` {IfStatement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkImportExpression(expression)`
 
+---
+### walkImportExpression
+
 * `expression` {ImportExpressionJavascriptParser}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkLabeledStatement(statement)`
 
+---
+### walkLabeledStatement
+
 * `statement` {LabeledStatement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkLeftRightExpression(expression)`
 
+---
+### walkLeftRightExpression
+
 * `expression` {BinaryExpression|LogicalExpression}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkLogicalExpression(expression)`
 
+---
+### walkLogicalExpression
+
 * `expression` {LogicalExpression}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkMemberExpression(expression)`
 
+---
+### walkMemberExpression
+
 * `expression` {MemberExpression}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkMemberExpressionWithExpressionName(expression, name, rootInfo, members, onUnhandled)`
+
+---
+### walkMemberExpressionWithExpressionName
 
 ###### R
 
 `R`
+
 * `expression` {MemberExpression}
 * `name` {string}
 * `rootInfo` {string|VariableInfo}
 * `members` {string[]}
 * `onUnhandled` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkMetaProperty(metaProperty)`
 
+---
+### walkMetaProperty
+
 * `metaProperty` {MetaProperty}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkNestedStatement(statement)`
 
+---
+### walkNestedStatement
+
 * `statement` {Statement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Walks a statements that is nested within a parent statement
 and can potentially be a non-block statement.
@@ -744,132 +1225,236 @@ This enforces the nested statement to never be in ASI position.
 
 #### `walkNewExpression(expression)`
 
+---
+### walkNewExpression
+
 * `expression` {NewExpression}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkObjectExpression(expression)`
 
+---
+### walkObjectExpression
+
 * `expression` {ObjectExpression}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkObjectPattern(pattern)`
 
+---
+### walkObjectPattern
+
 * `pattern` {ObjectPattern}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkPattern(pattern)`
 
+---
+### walkPattern
+
 * `pattern` {Pattern}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkProperty(prop)`
 
+---
+### walkProperty
+
 * `prop` {Property|SpreadElement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkRestElement(pattern)`
 
+---
+### walkRestElement
+
 * `pattern` {RestElement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkReturnStatement(statement)`
 
+---
+### walkReturnStatement
+
 * `statement` {ReturnStatement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkSequenceExpression(expression)`
 
+---
+### walkSequenceExpression
+
 * `expression` {SequenceExpression}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkSpreadElement(expression)`
 
+---
+### walkSpreadElement
+
 * `expression` {SpreadElement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkStatement(statement)`
 
+---
+### walkStatement
+
 * `statement` {ClassDeclaration|MaybeNamedClassDeclaration|FunctionDeclaration|MaybeNamedFunctionDeclaration|ImportDeclaration|ExportNamedDeclaration|ExportDefaultDeclaration|ExportAllDeclaration|ExpressionStatement|BlockStatement|StaticBlock|EmptyStatement|DebuggerStatement|WithStatement|ReturnStatement|LabeledStatement|BreakStatement|ContinueStatement|IfStatement|SwitchStatement|ThrowStatement|TryStatement|WhileStatement|DoWhileStatement|ForStatement|ForInStatement|ForOfStatement|VariableDeclaration}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkStatements(statements)`
 
+---
+### walkStatements
+
 * `statements` {ClassDeclaration|FunctionDeclaration|ImportDeclaration|ExportNamedDeclaration|ExportDefaultDeclaration|ExportAllDeclaration|ExpressionStatement|BlockStatement|StaticBlock|EmptyStatement|DebuggerStatement|WithStatement|ReturnStatement|LabeledStatement|BreakStatement|ContinueStatement|IfStatement|SwitchStatement|ThrowStatement|TryStatement|WhileStatement|DoWhileStatement|ForStatement|ForInStatement|ForOfStatement|VariableDeclaration[]}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Walking iterates the statements and expressions and processes them
 
 #### `walkSwitchCases(switchCases)`
 
+---
+### walkSwitchCases
+
 * `switchCases` {SwitchCase[]}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkSwitchStatement(statement)`
 
+---
+### walkSwitchStatement
+
 * `statement` {SwitchStatement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkTaggedTemplateExpression(expression)`
 
+---
+### walkTaggedTemplateExpression
+
 * `expression` {TaggedTemplateExpression}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkTemplateLiteral(expression)`
 
+---
+### walkTemplateLiteral
+
 * `expression` {TemplateLiteral}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkTerminatingStatement(statement)`
 
+---
+### walkTerminatingStatement
+
 * `statement` {ReturnStatement|ThrowStatement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkThisExpression(expression)`
 
+---
+### walkThisExpression
+
 * `expression` {ThisExpression}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkThrowStatement(statement)`
 
+---
+### walkThrowStatement
+
 * `statement` {ThrowStatement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkTryStatement(statement)`
 
+---
+### walkTryStatement
+
 * `statement` {TryStatement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkUnaryExpression(expression)`
 
+---
+### walkUnaryExpression
+
 * `expression` {UnaryExpression}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkUpdateExpression(expression)`
 
+---
+### walkUpdateExpression
+
 * `expression` {UpdateExpression}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkVariableDeclaration(statement)`
 
+---
+### walkVariableDeclaration
+
 * `statement` {VariableDeclaration}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkWhileStatement(statement)`
 
+---
+### walkWhileStatement
+
 * `statement` {WhileStatement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkWithStatement(statement)`
 
+---
+### walkWithStatement
+
 * `statement` {WithStatement}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `walkYieldExpression(expression)`
 
+---
+### walkYieldExpression
+
 * `expression` {YieldExpression}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `extend(plugins)`
 
+---
+### extend
+
 * `plugins` {object[]}
-* Returns: {JavascriptParser}
+
+* ###Returns: {JavascriptParser}

--- a/pages/v5.x/webpack/namespaces/library.md
+++ b/pages/v5.x/webpack/namespaces/library.md
@@ -1,6 +1,7 @@
 # library
 
-## Class: `AbstractLibraryPlugin`
+## 
+### Class: `AbstractLibraryPlugin`
 
 ### Type Parameters
 
@@ -12,11 +13,16 @@
 
 #### `new AbstractLibraryPlugin(__namedParameters)`
 
+---
+### AbstractLibraryPlugin
+
 ###### T
 
 `T`
+
 * `__namedParameters` {AbstractLibraryPluginOptions}
-* Returns: {AbstractLibraryPlugin<T>}
+
+* ###Returns: {AbstractLibraryPlugin<T>}
 
 ### Properties
 
@@ -26,85 +32,130 @@
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 #### `chunkHash(chunk, hash, chunkHashContext, libraryContext)`
 
+---
+### chunkHash
+
 * `chunk` {Chunk}
 * `hash` {Hash}
 * `chunkHashContext` {ChunkHashContext}
 * `libraryContext` {LibraryContext<T>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `embedInRuntimeBailout(module, renderContext, libraryContext)`
+
+---
+### embedInRuntimeBailout
 
 * `module` {Module}
 * `renderContext` {RenderContextJavascriptModulesPlugin}
 * `libraryContext` {LibraryContext<T>}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `finishEntryModule(module, entryName, libraryContext)`
+
+---
+### finishEntryModule
 
 * `module` {Module}
 * `entryName` {string}
 * `libraryContext` {LibraryContext<T>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `parseOptions(library)`
 
+---
+### parseOptions
+
 * `library` {LibraryOptions}
-* Returns: {T}
+
+* ###Returns: {T}
 
 #### `render(source, renderContext, libraryContext)`
+
+---
+### render
 
 * `source` {Source}
 * `renderContext` {RenderContextJavascriptModulesPlugin}
 * `libraryContext` {LibraryContext<T>}
-* Returns: {Source}
+
+* ###Returns: {Source}
 
 #### `renderModuleContent(source, module, renderContext, libraryContext)`
+
+---
+### renderModuleContent
 
 * `source` {Source}
 * `module` {Module}
 * `renderContext` {ModuleRenderContext}
 * `libraryContext` {Omit<LibraryContext<T>, "options">}
-* Returns: {Source}
+
+* ###Returns: {Source}
 
 #### `renderStartup(source, module, renderContext, libraryContext)`
+
+---
+### renderStartup
 
 * `source` {Source}
 * `module` {Module}
 * `renderContext` {StartupRenderContext}
 * `libraryContext` {LibraryContext<T>}
-* Returns: {Source}
+
+* ###Returns: {Source}
 
 #### `runtimeRequirements(chunk, set, libraryContext)`
+
+---
+### runtimeRequirements
 
 * `chunk` {Chunk}
 * `set` {Set<string>}
 * `libraryContext` {LibraryContext<T>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `strictRuntimeBailout(renderContext, libraryContext)`
 
+---
+### strictRuntimeBailout
+
 * `renderContext` {RenderContextJavascriptModulesPlugin}
 * `libraryContext` {LibraryContext<T>}
-* Returns: {string}
+
+* ###Returns: {string}
 
 ***
 
-## Class: `EnableLibraryPlugin`
+## 
+### Class: `EnableLibraryPlugin`
 
 ### Constructors
 
 #### `new EnableLibraryPlugin(type[, options])`
 
+---
+### EnableLibraryPlugin
+
 * `type` {string}
 * `options` {EnableLibraryPluginOptions}
-* Returns: {EnableLibraryPlugin}
+
+* ###Returns: {EnableLibraryPlugin}
 
 ### Properties
 
@@ -115,19 +166,31 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 #### Static method: `checkEnabled(compiler, type)`
 
+---
+### checkEnabled
+
 * `compiler` {Compiler}
 * `type` {string}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `setEnabled(compiler, type)`
 
+---
+### setEnabled
+
 * `compiler` {Compiler}
 * `type` {string}
-* Returns: {void}
+
+* ###Returns: {void}

--- a/pages/v5.x/webpack/namespaces/node.md
+++ b/pages/v5.x/webpack/namespaces/node.md
@@ -1,13 +1,18 @@
 # node
 
-## Class: `NodeEnvironmentPlugin`
+## 
+### Class: `NodeEnvironmentPlugin`
 
 ### Constructors
 
 #### `new NodeEnvironmentPlugin(options)`
 
+---
+### NodeEnvironmentPlugin
+
 * `options` {NodeEnvironmentPluginOptions}
-* Returns: {NodeEnvironmentPlugin}
+
+* ###Returns: {NodeEnvironmentPlugin}
 
 ### Properties
 
@@ -17,40 +22,57 @@
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `NodeSourcePlugin`
+## 
+### Class: `NodeSourcePlugin`
 
 ### Constructors
 
 #### `new NodeSourcePlugin()`
 
-* Returns: {NodeSourcePlugin}
+---
+### NodeSourcePlugin
+
+* ###Returns: {NodeSourcePlugin}
 
 ### Methods
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `NodeTargetPlugin`
+## 
+### Class: `NodeTargetPlugin`
 
 ### Constructors
 
 #### `new NodeTargetPlugin([type])`
 
+---
+### NodeTargetPlugin
+
 * `type` {ExternalsType}
-* Returns: {NodeTargetPlugin}
+
+* ###Returns: {NodeTargetPlugin}
 
 ### Properties
 
@@ -60,61 +82,88 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `NodeTemplatePlugin`
+## 
+### Class: `NodeTemplatePlugin`
 
 ### Constructors
 
 #### `new NodeTemplatePlugin([options])`
 
+---
+### NodeTemplatePlugin
+
 * `options` {NodeTemplatePluginOptions}
-* Returns: {NodeTemplatePlugin}
+
+* ###Returns: {NodeTemplatePlugin}
 
 ### Methods
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `ReadFileCompileAsyncWasmPlugin`
+## 
+### Class: `ReadFileCompileAsyncWasmPlugin`
 
 ### Constructors
 
 #### `new ReadFileCompileAsyncWasmPlugin([__namedParameters])`
 
+---
+### ReadFileCompileAsyncWasmPlugin
+
 * `__namedParameters` {ReadFileCompileAsyncWasmPluginOptions}
-* Returns: {ReadFileCompileAsyncWasmPlugin}
+
+* ###Returns: {ReadFileCompileAsyncWasmPlugin}
 
 ### Methods
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `ReadFileCompileWasmPlugin`
+## 
+### Class: `ReadFileCompileWasmPlugin`
 
 ### Constructors
 
 #### `new ReadFileCompileWasmPlugin([options])`
 
+---
+### ReadFileCompileWasmPlugin
+
 * `options` {ReadFileCompileWasmPluginOptions}
-* Returns: {ReadFileCompileWasmPlugin}
+
+* ###Returns: {ReadFileCompileWasmPlugin}
 
 ### Properties
 
@@ -124,7 +173,11 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin

--- a/pages/v5.x/webpack/namespaces/optimize/index.md
+++ b/pages/v5.x/webpack/namespaces/optimize/index.md
@@ -4,14 +4,19 @@
 
 - [InnerGraph](namespaces/InnerGraph.md)
 
-## Class: `AggressiveMergingPlugin`
+## 
+### Class: `AggressiveMergingPlugin`
 
 ### Constructors
 
 #### `new AggressiveMergingPlugin([options])`
 
+---
+### AggressiveMergingPlugin
+
 * `options` {AggressiveMergingPluginOptions}
-* Returns: {AggressiveMergingPlugin}
+
+* ###Returns: {AggressiveMergingPlugin}
 
 ### Properties
 
@@ -21,21 +26,30 @@
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `AggressiveSplittingPlugin`
+## 
+### Class: `AggressiveSplittingPlugin`
 
 ### Constructors
 
 #### `new AggressiveSplittingPlugin([options])`
 
+---
+### AggressiveSplittingPlugin
+
 * `options` {AggressiveSplittingPluginOptions}
-* Returns: {AggressiveSplittingPlugin}
+
+* ###Returns: {AggressiveSplittingPlugin}
 
 ### Properties
 
@@ -45,26 +59,39 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 #### Static method: `wasChunkRecorded(chunk)`
 
+---
+### wasChunkRecorded
+
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 ***
 
-## Class: `LimitChunkCountPlugin`
+## 
+### Class: `LimitChunkCountPlugin`
 
 ### Constructors
 
 #### `new LimitChunkCountPlugin([options])`
 
+---
+### LimitChunkCountPlugin
+
 * `options` {LimitChunkCountPluginOptions}
-* Returns: {LimitChunkCountPlugin}
+
+* ###Returns: {LimitChunkCountPlugin}
 
 ### Properties
 
@@ -74,19 +101,28 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## Class: `MergeDuplicateChunksPlugin`
+## 
+### Class: `MergeDuplicateChunksPlugin`
 
 ### Constructors
 
 #### `new MergeDuplicateChunksPlugin([options])`
 
+---
+### MergeDuplicateChunksPlugin
+
 * `options` {MergeDuplicateChunksPluginOptions}
-* Returns: {MergeDuplicateChunksPlugin}
+
+* ###Returns: {MergeDuplicateChunksPlugin}
 
 ### Properties
 
@@ -96,19 +132,28 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## Class: `MinChunkSizePlugin`
+## 
+### Class: `MinChunkSizePlugin`
 
 ### Constructors
 
 #### `new MinChunkSizePlugin(options)`
 
+---
+### MinChunkSizePlugin
+
 * `options` {MinChunkSizePluginOptions}
-* Returns: {MinChunkSizePlugin}
+
+* ###Returns: {MinChunkSizePlugin}
 
 ### Properties
 
@@ -118,65 +163,95 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `ModuleConcatenationPlugin`
+## 
+### Class: `ModuleConcatenationPlugin`
 
 ### Constructors
 
 #### `new ModuleConcatenationPlugin()`
 
-* Returns: {ModuleConcatenationPlugin}
+---
+### ModuleConcatenationPlugin
+
+* ###Returns: {ModuleConcatenationPlugin}
 
 ### Methods
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `RealContentHashPlugin`
+## 
+### Class: `RealContentHashPlugin`
 
 ### Constructors
 
 #### `new RealContentHashPlugin(__namedParameters)`
 
+---
+### RealContentHashPlugin
+
 * `__namedParameters` {RealContentHashPluginOptions}
-* Returns: {RealContentHashPlugin}
+
+* ###Returns: {RealContentHashPlugin}
 
 ### Methods
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 #### Static method: `getCompilationHooks(compilation)`
 
+---
+### getCompilationHooks
+
 * `compilation` {Compilation}
-* Returns: {CompilationHooksRealContentHashPlugin}
+
+* ###Returns: {CompilationHooksRealContentHashPlugin}
 
 ***
 
-## Class: `RuntimeChunkPlugin`
+## 
+### Class: `RuntimeChunkPlugin`
 
 ### Constructors
 
 #### `new RuntimeChunkPlugin([options])`
 
+---
+### RuntimeChunkPlugin
+
 * `options` {object}
-* Returns: {RuntimeChunkPlugin}
+
+* ###Returns: {RuntimeChunkPlugin}
 
 ### Properties
 
@@ -186,48 +261,70 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `SideEffectsFlagPlugin`
+## 
+### Class: `SideEffectsFlagPlugin`
 
 ### Constructors
 
 #### `new SideEffectsFlagPlugin([analyseSource])`
 
+---
+### SideEffectsFlagPlugin
+
 * `analyseSource` {boolean}
-* Returns: {SideEffectsFlagPlugin}
+
+* ###Returns: {SideEffectsFlagPlugin}
 
 ### Methods
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 #### Static method: `moduleHasSideEffects(moduleName, flagValue, cache)`
 
+---
+### moduleHasSideEffects
+
 * `moduleName` {string}
 * `flagValue` {SideEffectsFlagValue}
 * `cache` {Map<string, RegExp>}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 ***
 
-## Class: `SplitChunksPlugin`
+## 
+### Class: `SplitChunksPlugin`
 
 ### Constructors
 
 #### `new SplitChunksPlugin([options])`
 
+---
+### SplitChunksPlugin
+
 * `options` {OptimizationSplitChunksOptions}
-* Returns: {SplitChunksPlugin}
+
+* ###Returns: {SplitChunksPlugin}
 
 ### Properties
 
@@ -237,7 +334,11 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin

--- a/pages/v5.x/webpack/namespaces/optimize/namespaces/InnerGraph.md
+++ b/pages/v5.x/webpack/namespaces/optimize/namespaces/InnerGraph.md
@@ -1,13 +1,18 @@
 # InnerGraph
 
-## Class: `TopLevelSymbol`
+## 
+### Class: `TopLevelSymbol`
 
 ### Constructors
 
 #### `new TopLevelSymbol(name)`
 
+---
+### TopLevelSymbol
+
 * `name` {string}
-* Returns: {TopLevelSymbol}
+
+* ###Returns: {TopLevelSymbol}
 
 ### Properties
 
@@ -15,126 +20,187 @@
 
 ***
 
-## `addUsage`
+## 
+### `addUsage`
 
 > **addUsage**: {object}
+
+---
+### __type
 
 * `state` {ParserState}
 * `symbol` {null|TopLevelSymbol}
 * `usage` {Usage}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## `addVariableUsage`
+## 
+### `addVariableUsage`
 
 > **addVariableUsage**: {object}
+
+---
+### __type
 
 * `parser` {JavascriptParser}
 * `name` {string}
 * `usage` {Usage}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## `bailout`
+## 
+### `bailout`
 
 > **bailout**: {object}
 
+---
+### __type
+
 * `parserState` {ParserState}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## `enable`
+## 
+### `enable`
 
 > **enable**: {object}
 
+---
+### __type
+
 * `parserState` {ParserState}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## `getDependencyUsedByExportsCondition`
+## 
+### `getDependencyUsedByExportsCondition`
 
 > **getDependencyUsedByExportsCondition**: {object}
+
+---
+### __type
 
 * `dependency` {Dependency}
 * `usedByExports` {undefined|boolean|Set<string>}
 * `moduleGraph` {ModuleGraph}
-* Returns: {null|false|object}
+
+* ###Returns: {null|false|object}
 
 ***
 
-## `getTopLevelSymbol`
+## 
+### `getTopLevelSymbol`
 
 > **getTopLevelSymbol**: {object}
 
+---
+### __type
+
 * `state` {ParserState}
-* Returns: {void|TopLevelSymbol}
+
+* ###Returns: {void|TopLevelSymbol}
 
 ***
 
-## `inferDependencyUsage`
+## 
+### `inferDependencyUsage`
 
 > **inferDependencyUsage**: {object}
 
+---
+### __type
+
 * `state` {ParserState}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## `isDependencyUsedByExports`
+## 
+### `isDependencyUsedByExports`
 
 > **isDependencyUsedByExports**: {object}
+
+---
+### __type
 
 * `dependency` {Dependency}
 * `usedByExports` {undefined|boolean|Set<string>}
 * `moduleGraph` {ModuleGraph}
 * `runtime` {RuntimeSpec}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 ***
 
-## `isEnabled`
+## 
+### `isEnabled`
 
 > **isEnabled**: {object}
 
+---
+### __type
+
 * `parserState` {ParserState}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 ***
 
-## `onUsage`
+## 
+### `onUsage`
 
 > **onUsage**: {object}
 
+---
+### __type
+
 * `state` {ParserState}
 * `onUsageCallback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## `setTopLevelSymbol`
+## 
+### `setTopLevelSymbol`
 
 > **setTopLevelSymbol**: {object}
 
+---
+### __type
+
 * `state` {ParserState}
 * `symbol` {TopLevelSymbol}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## `tagTopLevelSymbol`
+## 
+### `tagTopLevelSymbol`
 
 > **tagTopLevelSymbol**: {object}
 
+---
+### __type
+
 * `parser` {JavascriptParser}
 * `name` {string}
-* Returns: {undefined|TopLevelSymbol}
+
+* ###Returns: {undefined|TopLevelSymbol}
 
 ***
 
-## `topLevelSymbolTag`
+## 
+### `topLevelSymbolTag`
 
 > `const` **topLevelSymbolTag**: {symbol}

--- a/pages/v5.x/webpack/namespaces/prefetch.md
+++ b/pages/v5.x/webpack/namespaces/prefetch.md
@@ -1,16 +1,24 @@
 # prefetch
 
-## Class: `ChunkPrefetchPreloadPlugin`
+## 
+### Class: `ChunkPrefetchPreloadPlugin`
 
 ### Constructors
 
 #### `new ChunkPrefetchPreloadPlugin()`
 
-* Returns: {ChunkPrefetchPreloadPlugin}
+---
+### ChunkPrefetchPreloadPlugin
+
+* ###Returns: {ChunkPrefetchPreloadPlugin}
 
 ### Methods
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}

--- a/pages/v5.x/webpack/namespaces/runtime.md
+++ b/pages/v5.x/webpack/namespaces/runtime.md
@@ -1,6 +1,7 @@
 # runtime
 
-## Class: `GetChunkFilenameRuntimeModule`
+## 
+### Class: `GetChunkFilenameRuntimeModule`
 
 ### Extends
 
@@ -10,12 +11,16 @@
 
 #### `new GetChunkFilenameRuntimeModule(contentType, name, global, getFilenameForChunk, allChunks)`
 
+---
+### GetChunkFilenameRuntimeModule
+
 * `contentType` {string}
 * `name` {string}
 * `global` {string}
 * `getFilenameForChunk` {object}
 * `allChunks` {boolean}
-* Returns: {GetChunkFilenameRuntimeModule}
+
+* ###Returns: {GetChunkFilenameRuntimeModule}
 
 ### Properties
 
@@ -75,151 +80,251 @@
 
 #### `addBlock(block)`
 
+---
+### addBlock
+
 * `block` {AsyncDependenciesBlock}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Adds a DependencyBlock to DependencyBlock relationship.
 This is used for when a Module has a AsyncDependencyBlock tie (for code-splitting)
 
 #### `addCacheDependencies(fileDependencies, contextDependencies, missingDependencies, buildDependencies)`
 
+---
+### addCacheDependencies
+
 * `fileDependencies` {LazySet<string>}
 * `contextDependencies` {LazySet<string>}
 * `missingDependencies` {LazySet<string>}
 * `buildDependencies` {LazySet<string>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addChunk(chunk)`
 
+---
+### addChunk
+
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `addCodeGenerationDependency(codeGenerationDependency)`
 
+---
+### addCodeGenerationDependency
+
 * `codeGenerationDependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addDependency(dependency)`
 
+---
+### addDependency
+
 * `dependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addError(error)`
 
+---
+### addError
+
 * `error` {WebpackError}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addPresentationalDependency(presentationalDependency)`
 
+---
+### addPresentationalDependency
+
 * `presentationalDependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addWarning(warning)`
 
+---
+### addWarning
+
 * `warning` {WebpackError}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `attach(compilation, chunk[, chunkGraph])`
+
+---
+### attach
 
 * `compilation` {Compilation}
 * `chunk` {Chunk}
 * `chunkGraph` {ChunkGraph}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `build(options, compilation, resolver, fs, callback)`
+
+---
+### build
 
 * `options` {WebpackOptionsNormalizedWithDefaults}
 * `compilation` {Compilation}
 * `resolver` {ResolverWithOptions}
 * `fs` {InputFileSystem}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `chunkCondition(chunk, compilation)`
 
+---
+### chunkCondition
+
 * `chunk` {Chunk}
 * `compilation` {Compilation}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `cleanupForCache()`
 
-* Returns: {void}
+---
+### cleanupForCache
+
+* ###Returns: {void}
 
 Assuming this module is in the cache. Remove internal references to allow freeing some memory.
 
 #### `clearDependenciesAndBlocks()`
 
-* Returns: {void}
+---
+### clearDependenciesAndBlocks
+
+* ###Returns: {void}
 
 Removes all dependencies and blocks
 
 #### `clearWarningsAndErrors()`
 
-* Returns: {void}
+---
+### clearWarningsAndErrors
+
+* ###Returns: {void}
 
 removes all warnings and errors
 
 #### `codeGeneration(context)`
 
+---
+### codeGeneration
+
 * `context` {CodeGenerationContext}
-* Returns: {CodeGenerationResult}
+
+* ###Returns: {CodeGenerationResult}
 
 #### `deserialize(__namedParameters)`
 
+---
+### deserialize
+
 * `__namedParameters` {ObjectDeserializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `generate()`
 
-* Returns: {string}
+---
+### generate
+
+* ###Returns: {string}
 
 #### `getChunks()`
 
-* Returns: {Chunk[]}
+---
+### getChunks
+
+* ###Returns: {Chunk[]}
 
 #### `getConcatenationBailoutReason(context)`
 
+---
+### getConcatenationBailoutReason
+
 * `context` {ConcatenationBailoutReasonContext}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `getErrors()`
 
-* Returns: {Iterable<WebpackError, any, any>}
+---
+### getErrors
+
+* ###Returns: {Iterable<WebpackError, any, any>}
 
 #### `getExportsType(moduleGraph[, strict])`
 
+---
+### getExportsType
+
 * `moduleGraph` {ModuleGraph}
 * `strict` {boolean}
-* Returns: {ExportsType}
+
+* ###Returns: {ExportsType}
 
 #### `getGeneratedCode()`
 
-* Returns: {string}
+---
+### getGeneratedCode
+
+* ###Returns: {string}
 
 #### `getNumberOfChunks()`
 
-* Returns: {number}
+---
+### getNumberOfChunks
+
+* ###Returns: {number}
 
 #### `getNumberOfErrors()`
 
-* Returns: {number}
+---
+### getNumberOfErrors
+
+* ###Returns: {number}
 
 #### `getNumberOfWarnings()`
 
-* Returns: {number}
+---
+### getNumberOfWarnings
+
+* ###Returns: {number}
 
 #### `getRootBlock()`
 
-* Returns: {DependenciesBlock}
+---
+### getRootBlock
+
+* ###Returns: {DependenciesBlock}
 
 #### `getSideEffectsConnectionState(moduleGraph)`
 
+---
+### getSideEffectsConnectionState
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {ConnectionState}
+
+* ###Returns: {ConnectionState}
 
 #### `getSourceBasicTypes()`
 
-* Returns: {ReadonlySet<string>}
+---
+### getSourceBasicTypes
+
+* ###Returns: {ReadonlySet<string>}
 
 Basic source types are high-level categories like javascript, css, webassembly, etc.
 We only have built-in knowledge about the javascript basic type here; other basic types may be
@@ -229,150 +334,248 @@ from getSourceTypes(), but their generated output is still JavaScript, i.e. thei
 
 #### `getSourceTypes()`
 
-* Returns: {ReadonlySet<string>}
+---
+### getSourceTypes
+
+* ###Returns: {ReadonlySet<string>}
 
 #### `getUnsafeCacheData()`
 
-* Returns: {UnsafeCacheData}
+---
+### getUnsafeCacheData
+
+* ###Returns: {UnsafeCacheData}
 
 Module should be unsafe cached. Get data that's needed for that.
 This data will be passed to restoreFromUnsafeCache later.
 
 #### `getWarnings()`
 
-* Returns: {Iterable<WebpackError, any, any>}
+---
+### getWarnings
+
+* ###Returns: {Iterable<WebpackError, any, any>}
 
 #### `hasChunkCondition()`
 
-* Returns: {boolean}
+---
+### hasChunkCondition
+
+* ###Returns: {boolean}
 
 #### `hasReasonForChunk(chunk, moduleGraph, chunkGraph)`
+
+---
+### hasReasonForChunk
 
 * `chunk` {Chunk}
 * `moduleGraph` {ModuleGraph}
 * `chunkGraph` {ChunkGraph}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `hasReasons(moduleGraph, runtime)`
 
+---
+### hasReasons
+
 * `moduleGraph` {ModuleGraph}
 * `runtime` {RuntimeSpec}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `identifier()`
 
-* Returns: {string}
+---
+### identifier
+
+* ###Returns: {string}
 
 #### `invalidateBuild()`
 
-* Returns: {void}
+---
+### invalidateBuild
+
+* ###Returns: {void}
 
 #### `isAccessibleInChunk(chunkGraph, chunk[, ignoreChunk])`
+
+---
+### isAccessibleInChunk
 
 * `chunkGraph` {ChunkGraph}
 * `chunk` {Chunk}
 * `ignoreChunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isAccessibleInChunkGroup(chunkGraph, chunkGroup[, ignoreChunk])`
+
+---
+### isAccessibleInChunkGroup
 
 * `chunkGraph` {ChunkGraph}
 * `chunkGroup` {ChunkGroup}
 * `ignoreChunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isEntryModule()`
 
-* Returns: {boolean}
+---
+### isEntryModule
+
+* ###Returns: {boolean}
 
 #### `isInChunk(chunk)`
 
+---
+### isInChunk
+
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isOptional(moduleGraph)`
 
+---
+### isOptional
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isProvided(exportName)`
 
+---
+### isProvided
+
 * `exportName` {string}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `libIdent(options)`
 
+---
+### libIdent
+
 * `options` {LibIdentOptions}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `nameForCondition()`
 
-* Returns: {string}
+---
+### nameForCondition
+
+* ###Returns: {string}
 
 #### `needBuild(context, callback)`
 
+---
+### needBuild
+
 * `context` {NeedBuildContext}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `needRebuild(fileTimestamps, contextTimestamps)`
+
+---
+### needRebuild
 
 > Stability: 0 - Deprecated
 
 * `fileTimestamps` {Map<string, number>}
 * `contextTimestamps` {Map<string, number>}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 Use needBuild instead
 
 #### `originalSource()`
 
-* Returns: {Source}
+---
+### originalSource
+
+* ###Returns: {Source}
 
 #### `readableIdentifier(requestShortener)`
 
+---
+### readableIdentifier
+
 * `requestShortener` {RequestShortener}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `removeChunk(chunk)`
 
+---
+### removeChunk
+
 * `chunk` {Chunk}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `removeDependency(dependency)`
 
+---
+### removeDependency
+
 * `dependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `serialize(__namedParameters)`
 
+---
+### serialize
+
 * `__namedParameters` {ObjectSerializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `shouldIsolate()`
 
-* Returns: {boolean}
+---
+### shouldIsolate
+
+* ###Returns: {boolean}
 
 #### `size([type])`
 
+---
+### size
+
 * `type` {string}
-* Returns: {number}
+
+* ###Returns: {number}
 
 #### `source(dependencyTemplates, runtimeTemplate[, type])`
+
+---
+### source
 
 > Stability: 0 - Deprecated
 
 * `dependencyTemplates` {DependencyTemplates}
 * `runtimeTemplate` {RuntimeTemplate}
 * `type` {string}
-* Returns: {Source}
+
+* ###Returns: {Source}
 
 Use codeGeneration() instead
 
 #### `updateCacheModule(module)`
 
+---
+### updateCacheModule
+
 * `module` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Assuming this module is in the cache. Update the (cached) module with
 the fresh module from the factory. Usually updates internal references
@@ -380,22 +583,31 @@ and properties.
 
 #### `updateHash(hash, context)`
 
+---
+### updateHash
+
 * `hash` {Hash}
 * `context` {UpdateHashContextDependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `getSourceBasicTypes(module)`
+
+---
+### getSourceBasicTypes
 
 > Stability: 0 - Deprecated
 
 * `module` {Module}
-* Returns: {ReadonlySet<string>}
+
+* ###Returns: {ReadonlySet<string>}
 
 In webpack 6, call getSourceBasicTypes() directly on the module instance instead of using this static method.
 
 ***
 
-## Class: `LoadScriptRuntimeModule`
+## 
+### Class: `LoadScriptRuntimeModule`
 
 ### Extends
 
@@ -405,9 +617,13 @@ In webpack 6, call getSourceBasicTypes() directly on the module instance instead
 
 #### `new LoadScriptRuntimeModule([withCreateScriptUrl][, withFetchPriority])`
 
+---
+### LoadScriptRuntimeModule
+
 * `withCreateScriptUrl` {boolean}
 * `withFetchPriority` {boolean}
-* Returns: {LoadScriptRuntimeModule}
+
+* ###Returns: {LoadScriptRuntimeModule}
 
 ### Properties
 
@@ -463,151 +679,251 @@ In webpack 6, call getSourceBasicTypes() directly on the module instance instead
 
 #### `addBlock(block)`
 
+---
+### addBlock
+
 * `block` {AsyncDependenciesBlock}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Adds a DependencyBlock to DependencyBlock relationship.
 This is used for when a Module has a AsyncDependencyBlock tie (for code-splitting)
 
 #### `addCacheDependencies(fileDependencies, contextDependencies, missingDependencies, buildDependencies)`
 
+---
+### addCacheDependencies
+
 * `fileDependencies` {LazySet<string>}
 * `contextDependencies` {LazySet<string>}
 * `missingDependencies` {LazySet<string>}
 * `buildDependencies` {LazySet<string>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addChunk(chunk)`
 
+---
+### addChunk
+
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `addCodeGenerationDependency(codeGenerationDependency)`
 
+---
+### addCodeGenerationDependency
+
 * `codeGenerationDependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addDependency(dependency)`
 
+---
+### addDependency
+
 * `dependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addError(error)`
 
+---
+### addError
+
 * `error` {WebpackError}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addPresentationalDependency(presentationalDependency)`
 
+---
+### addPresentationalDependency
+
 * `presentationalDependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addWarning(warning)`
 
+---
+### addWarning
+
 * `warning` {WebpackError}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `attach(compilation, chunk[, chunkGraph])`
+
+---
+### attach
 
 * `compilation` {Compilation}
 * `chunk` {Chunk}
 * `chunkGraph` {ChunkGraph}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `build(options, compilation, resolver, fs, callback)`
+
+---
+### build
 
 * `options` {WebpackOptionsNormalizedWithDefaults}
 * `compilation` {Compilation}
 * `resolver` {ResolverWithOptions}
 * `fs` {InputFileSystem}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `chunkCondition(chunk, compilation)`
 
+---
+### chunkCondition
+
 * `chunk` {Chunk}
 * `compilation` {Compilation}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `cleanupForCache()`
 
-* Returns: {void}
+---
+### cleanupForCache
+
+* ###Returns: {void}
 
 Assuming this module is in the cache. Remove internal references to allow freeing some memory.
 
 #### `clearDependenciesAndBlocks()`
 
-* Returns: {void}
+---
+### clearDependenciesAndBlocks
+
+* ###Returns: {void}
 
 Removes all dependencies and blocks
 
 #### `clearWarningsAndErrors()`
 
-* Returns: {void}
+---
+### clearWarningsAndErrors
+
+* ###Returns: {void}
 
 removes all warnings and errors
 
 #### `codeGeneration(context)`
 
+---
+### codeGeneration
+
 * `context` {CodeGenerationContext}
-* Returns: {CodeGenerationResult}
+
+* ###Returns: {CodeGenerationResult}
 
 #### `deserialize(__namedParameters)`
 
+---
+### deserialize
+
 * `__namedParameters` {ObjectDeserializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `generate()`
 
-* Returns: {string}
+---
+### generate
+
+* ###Returns: {string}
 
 #### `getChunks()`
 
-* Returns: {Chunk[]}
+---
+### getChunks
+
+* ###Returns: {Chunk[]}
 
 #### `getConcatenationBailoutReason(context)`
 
+---
+### getConcatenationBailoutReason
+
 * `context` {ConcatenationBailoutReasonContext}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `getErrors()`
 
-* Returns: {Iterable<WebpackError, any, any>}
+---
+### getErrors
+
+* ###Returns: {Iterable<WebpackError, any, any>}
 
 #### `getExportsType(moduleGraph[, strict])`
 
+---
+### getExportsType
+
 * `moduleGraph` {ModuleGraph}
 * `strict` {boolean}
-* Returns: {ExportsType}
+
+* ###Returns: {ExportsType}
 
 #### `getGeneratedCode()`
 
-* Returns: {string}
+---
+### getGeneratedCode
+
+* ###Returns: {string}
 
 #### `getNumberOfChunks()`
 
-* Returns: {number}
+---
+### getNumberOfChunks
+
+* ###Returns: {number}
 
 #### `getNumberOfErrors()`
 
-* Returns: {number}
+---
+### getNumberOfErrors
+
+* ###Returns: {number}
 
 #### `getNumberOfWarnings()`
 
-* Returns: {number}
+---
+### getNumberOfWarnings
+
+* ###Returns: {number}
 
 #### `getRootBlock()`
 
-* Returns: {DependenciesBlock}
+---
+### getRootBlock
+
+* ###Returns: {DependenciesBlock}
 
 #### `getSideEffectsConnectionState(moduleGraph)`
 
+---
+### getSideEffectsConnectionState
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {ConnectionState}
+
+* ###Returns: {ConnectionState}
 
 #### `getSourceBasicTypes()`
 
-* Returns: {ReadonlySet<string>}
+---
+### getSourceBasicTypes
+
+* ###Returns: {ReadonlySet<string>}
 
 Basic source types are high-level categories like javascript, css, webassembly, etc.
 We only have built-in knowledge about the javascript basic type here; other basic types may be
@@ -617,150 +933,248 @@ from getSourceTypes(), but their generated output is still JavaScript, i.e. thei
 
 #### `getSourceTypes()`
 
-* Returns: {ReadonlySet<string>}
+---
+### getSourceTypes
+
+* ###Returns: {ReadonlySet<string>}
 
 #### `getUnsafeCacheData()`
 
-* Returns: {UnsafeCacheData}
+---
+### getUnsafeCacheData
+
+* ###Returns: {UnsafeCacheData}
 
 Module should be unsafe cached. Get data that's needed for that.
 This data will be passed to restoreFromUnsafeCache later.
 
 #### `getWarnings()`
 
-* Returns: {Iterable<WebpackError, any, any>}
+---
+### getWarnings
+
+* ###Returns: {Iterable<WebpackError, any, any>}
 
 #### `hasChunkCondition()`
 
-* Returns: {boolean}
+---
+### hasChunkCondition
+
+* ###Returns: {boolean}
 
 #### `hasReasonForChunk(chunk, moduleGraph, chunkGraph)`
+
+---
+### hasReasonForChunk
 
 * `chunk` {Chunk}
 * `moduleGraph` {ModuleGraph}
 * `chunkGraph` {ChunkGraph}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `hasReasons(moduleGraph, runtime)`
 
+---
+### hasReasons
+
 * `moduleGraph` {ModuleGraph}
 * `runtime` {RuntimeSpec}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `identifier()`
 
-* Returns: {string}
+---
+### identifier
+
+* ###Returns: {string}
 
 #### `invalidateBuild()`
 
-* Returns: {void}
+---
+### invalidateBuild
+
+* ###Returns: {void}
 
 #### `isAccessibleInChunk(chunkGraph, chunk[, ignoreChunk])`
+
+---
+### isAccessibleInChunk
 
 * `chunkGraph` {ChunkGraph}
 * `chunk` {Chunk}
 * `ignoreChunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isAccessibleInChunkGroup(chunkGraph, chunkGroup[, ignoreChunk])`
+
+---
+### isAccessibleInChunkGroup
 
 * `chunkGraph` {ChunkGraph}
 * `chunkGroup` {ChunkGroup}
 * `ignoreChunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isEntryModule()`
 
-* Returns: {boolean}
+---
+### isEntryModule
+
+* ###Returns: {boolean}
 
 #### `isInChunk(chunk)`
 
+---
+### isInChunk
+
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isOptional(moduleGraph)`
 
+---
+### isOptional
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isProvided(exportName)`
 
+---
+### isProvided
+
 * `exportName` {string}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `libIdent(options)`
 
+---
+### libIdent
+
 * `options` {LibIdentOptions}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `nameForCondition()`
 
-* Returns: {string}
+---
+### nameForCondition
+
+* ###Returns: {string}
 
 #### `needBuild(context, callback)`
 
+---
+### needBuild
+
 * `context` {NeedBuildContext}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `needRebuild(fileTimestamps, contextTimestamps)`
+
+---
+### needRebuild
 
 > Stability: 0 - Deprecated
 
 * `fileTimestamps` {Map<string, number>}
 * `contextTimestamps` {Map<string, number>}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 Use needBuild instead
 
 #### `originalSource()`
 
-* Returns: {Source}
+---
+### originalSource
+
+* ###Returns: {Source}
 
 #### `readableIdentifier(requestShortener)`
 
+---
+### readableIdentifier
+
 * `requestShortener` {RequestShortener}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `removeChunk(chunk)`
 
+---
+### removeChunk
+
 * `chunk` {Chunk}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `removeDependency(dependency)`
 
+---
+### removeDependency
+
 * `dependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `serialize(__namedParameters)`
 
+---
+### serialize
+
 * `__namedParameters` {ObjectSerializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `shouldIsolate()`
 
-* Returns: {boolean}
+---
+### shouldIsolate
+
+* ###Returns: {boolean}
 
 #### `size([type])`
 
+---
+### size
+
 * `type` {string}
-* Returns: {number}
+
+* ###Returns: {number}
 
 #### `source(dependencyTemplates, runtimeTemplate[, type])`
+
+---
+### source
 
 > Stability: 0 - Deprecated
 
 * `dependencyTemplates` {DependencyTemplates}
 * `runtimeTemplate` {RuntimeTemplate}
 * `type` {string}
-* Returns: {Source}
+
+* ###Returns: {Source}
 
 Use codeGeneration() instead
 
 #### `updateCacheModule(module)`
 
+---
+### updateCacheModule
+
 * `module` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Assuming this module is in the cache. Update the (cached) module with
 the fresh module from the factory. Usually updates internal references
@@ -768,20 +1182,32 @@ and properties.
 
 #### `updateHash(hash, context)`
 
+---
+### updateHash
+
 * `hash` {Hash}
 * `context` {UpdateHashContextDependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `getCompilationHooks(compilation)`
 
+---
+### getCompilationHooks
+
 * `compilation` {Compilation}
-* Returns: {LoadScriptCompilationHooks}
+
+* ###Returns: {LoadScriptCompilationHooks}
 
 #### Static method: `getSourceBasicTypes(module)`
+
+---
+### getSourceBasicTypes
 
 > Stability: 0 - Deprecated
 
 * `module` {Module}
-* Returns: {ReadonlySet<string>}
+
+* ###Returns: {ReadonlySet<string>}
 
 In webpack 6, call getSourceBasicTypes() directly on the module instance instead of using this static method.

--- a/pages/v5.x/webpack/namespaces/sharing.md
+++ b/pages/v5.x/webpack/namespaces/sharing.md
@@ -1,13 +1,18 @@
 # sharing
 
-## Class: `ConsumeSharedPlugin`
+## 
+### Class: `ConsumeSharedPlugin`
 
 ### Constructors
 
 #### `new ConsumeSharedPlugin(options)`
 
+---
+### ConsumeSharedPlugin
+
 * `options` {ConsumeSharedPluginOptions}
-* Returns: {ConsumeSharedPlugin}
+
+* ###Returns: {ConsumeSharedPlugin}
 
 ### Properties
 
@@ -17,21 +22,30 @@
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `ProvideSharedPlugin`
+## 
+### Class: `ProvideSharedPlugin`
 
 ### Constructors
 
 #### `new ProvideSharedPlugin(options)`
 
+---
+### ProvideSharedPlugin
+
 * `options` {ProvideSharedPluginOptions}
-* Returns: {ProvideSharedPlugin}
+
+* ###Returns: {ProvideSharedPlugin}
 
 ### Properties
 
@@ -41,40 +55,59 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `SharePlugin`
+## 
+### Class: `SharePlugin`
 
 ### Constructors
 
 #### `new SharePlugin(options)`
 
+---
+### SharePlugin
+
 * `options` {SharePluginOptions}
-* Returns: {SharePlugin}
+
+* ###Returns: {SharePlugin}
 
 ### Methods
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## `scope`
+## 
+### `scope`
 
 > `const` **scope**: {object}
+
+---
+### __type
 
 #### T
 
 `T`
+
 * `scope` {string}
 * `options` {ContainerOptionsFormat<T>}
-* Returns: {Record<string, string|string[]|T>}
+
+* ###Returns: {Record<string, string|string[]|T>}

--- a/pages/v5.x/webpack/namespaces/sources.md
+++ b/pages/v5.x/webpack/namespaces/sources.md
@@ -1,6 +1,7 @@
 # sources
 
-## Class: `CachedSource`
+## 
+### Class: `CachedSource`
 
 ### Extends
 
@@ -10,62 +11,101 @@
 
 #### `new CachedSource(source[, cachedData])`
 
+---
+### CachedSource
+
 * `source` {Source|object}
 * `cachedData` {CachedData}
-* Returns: {CachedSource}
+
+* ###Returns: {CachedSource}
 
 ### Methods
 
 #### `buffer()`
 
-* Returns: {Buffer}
+---
+### buffer
+
+* ###Returns: {Buffer}
 
 #### `getCachedData()`
 
-* Returns: {CachedData}
+---
+### getCachedData
+
+* ###Returns: {CachedData}
 
 #### `map([options])`
 
+---
+### map
+
 * `options` {MapOptions}
-* Returns: {RawSourceMap}
+
+* ###Returns: {RawSourceMap}
 
 #### `original()`
 
-* Returns: {Source}
+---
+### original
+
+* ###Returns: {Source}
 
 #### `originalLazy()`
 
-* Returns: {Source|object}
+---
+### originalLazy
+
+* ###Returns: {Source|object}
 
 #### `size()`
 
-* Returns: {number}
+---
+### size
+
+* ###Returns: {number}
 
 #### `source()`
 
-* Returns: {SourceValue}
+---
+### source
+
+* ###Returns: {SourceValue}
 
 #### `sourceAndMap([options])`
 
+---
+### sourceAndMap
+
 * `options` {MapOptions}
-* Returns: {SourceAndMap}
+
+* ###Returns: {SourceAndMap}
 
 #### `streamChunks(options, onChunk, onSource, onName)`
+
+---
+### streamChunks
 
 * `options` {StreamChunksOptions}
 * `onChunk` {object}
 * `onSource` {object}
 * `onName` {object}
-* Returns: {GeneratedSourceInfo}
+
+* ###Returns: {GeneratedSourceInfo}
 
 #### `updateHash(hash)`
 
+---
+### updateHash
+
 * `hash` {HashLike}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## Class: `CompatSource`
+## 
+### Class: `CompatSource`
 
 ### Extends
 
@@ -75,46 +115,76 @@
 
 #### `new CompatSource(sourceLike)`
 
+---
+### CompatSource
+
 * `sourceLike` {SourceLike}
-* Returns: {CompatSource}
+
+* ###Returns: {CompatSource}
 
 ### Methods
 
 #### `buffer()`
 
-* Returns: {Buffer}
+---
+### buffer
+
+* ###Returns: {Buffer}
 
 #### `map([options])`
 
+---
+### map
+
 * `options` {MapOptions}
-* Returns: {RawSourceMap}
+
+* ###Returns: {RawSourceMap}
 
 #### `size()`
 
-* Returns: {number}
+---
+### size
+
+* ###Returns: {number}
 
 #### `source()`
 
-* Returns: {SourceValue}
+---
+### source
+
+* ###Returns: {SourceValue}
 
 #### `sourceAndMap([options])`
 
+---
+### sourceAndMap
+
 * `options` {MapOptions}
-* Returns: {SourceAndMap}
+
+* ###Returns: {SourceAndMap}
 
 #### `updateHash(hash)`
 
+---
+### updateHash
+
 * `hash` {HashLike}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `from(sourceLike)`
 
+---
+### from
+
 * `sourceLike` {SourceLike}
-* Returns: {Source}
+
+* ###Returns: {Source}
 
 ***
 
-## Class: `ConcatSource`
+## 
+### Class: `ConcatSource`
 
 ### Extends
 
@@ -124,63 +194,104 @@
 
 #### `new ConcatSource(args)`
 
+---
+### ConcatSource
+
 * `args` {ConcatSourceChild[]}
-* Returns: {ConcatSource}
+
+* ###Returns: {ConcatSource}
 
 ### Methods
 
 #### `add(item)`
 
+---
+### add
+
 * `item` {ConcatSourceChild}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addAllSkipOptimizing(items)`
 
+---
+### addAllSkipOptimizing
+
 * `items` {ConcatSourceChild[]}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `buffer()`
 
-* Returns: {Buffer}
+---
+### buffer
+
+* ###Returns: {Buffer}
 
 #### `getChildren()`
 
-* Returns: {Source[]}
+---
+### getChildren
+
+* ###Returns: {Source[]}
 
 #### `map([options])`
 
+---
+### map
+
 * `options` {MapOptions}
-* Returns: {RawSourceMap}
+
+* ###Returns: {RawSourceMap}
 
 #### `size()`
 
-* Returns: {number}
+---
+### size
+
+* ###Returns: {number}
 
 #### `source()`
 
-* Returns: {SourceValue}
+---
+### source
+
+* ###Returns: {SourceValue}
 
 #### `sourceAndMap([options])`
 
+---
+### sourceAndMap
+
 * `options` {MapOptions}
-* Returns: {SourceAndMap}
+
+* ###Returns: {SourceAndMap}
 
 #### `streamChunks(options, onChunk, onSource, onName)`
+
+---
+### streamChunks
 
 * `options` {StreamChunksOptions}
 * `onChunk` {object}
 * `onSource` {object}
 * `onName` {object}
-* Returns: {GeneratedSourceInfo}
+
+* ###Returns: {GeneratedSourceInfo}
 
 #### `updateHash(hash)`
 
+---
+### updateHash
+
 * `hash` {HashLike}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## Class: `OriginalSource`
+## 
+### Class: `OriginalSource`
 
 ### Extends
 
@@ -190,54 +301,87 @@
 
 #### `new OriginalSource(value, name)`
 
+---
+### OriginalSource
+
 * `value` {string|Buffer<ArrayBufferLike>}
 * `name` {string}
-* Returns: {OriginalSource}
+
+* ###Returns: {OriginalSource}
 
 ### Methods
 
 #### `buffer()`
 
-* Returns: {Buffer}
+---
+### buffer
+
+* ###Returns: {Buffer}
 
 #### `getName()`
 
-* Returns: {string}
+---
+### getName
+
+* ###Returns: {string}
 
 #### `map([options])`
 
+---
+### map
+
 * `options` {MapOptions}
-* Returns: {RawSourceMap}
+
+* ###Returns: {RawSourceMap}
 
 #### `size()`
 
-* Returns: {number}
+---
+### size
+
+* ###Returns: {number}
 
 #### `source()`
 
-* Returns: {SourceValue}
+---
+### source
+
+* ###Returns: {SourceValue}
 
 #### `sourceAndMap([options])`
 
+---
+### sourceAndMap
+
 * `options` {MapOptions}
-* Returns: {SourceAndMap}
+
+* ###Returns: {SourceAndMap}
 
 #### `streamChunks(options, onChunk, onSource, _onName)`
+
+---
+### streamChunks
 
 * `options` {StreamChunksOptions}
 * `onChunk` {object}
 * `onSource` {object}
 * `_onName` {object}
-* Returns: {GeneratedSourceInfo}
+
+* ###Returns: {GeneratedSourceInfo}
 
 #### `updateHash(hash)`
 
+---
+### updateHash
+
 * `hash` {HashLike}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## Class: `PrefixSource`
+## 
+### Class: `PrefixSource`
 
 ### Extends
 
@@ -247,58 +391,94 @@
 
 #### `new PrefixSource(prefix, source)`
 
+---
+### PrefixSource
+
 * `prefix` {string}
 * `source` {string|Buffer<ArrayBufferLike>|Source}
-* Returns: {PrefixSource}
+
+* ###Returns: {PrefixSource}
 
 ### Methods
 
 #### `buffer()`
 
-* Returns: {Buffer}
+---
+### buffer
+
+* ###Returns: {Buffer}
 
 #### `getPrefix()`
 
-* Returns: {string}
+---
+### getPrefix
+
+* ###Returns: {string}
 
 #### `map([options])`
 
+---
+### map
+
 * `options` {MapOptions}
-* Returns: {RawSourceMap}
+
+* ###Returns: {RawSourceMap}
 
 #### `original()`
 
-* Returns: {Source}
+---
+### original
+
+* ###Returns: {Source}
 
 #### `size()`
 
-* Returns: {number}
+---
+### size
+
+* ###Returns: {number}
 
 #### `source()`
 
-* Returns: {SourceValue}
+---
+### source
+
+* ###Returns: {SourceValue}
 
 #### `sourceAndMap([options])`
 
+---
+### sourceAndMap
+
 * `options` {MapOptions}
-* Returns: {SourceAndMap}
+
+* ###Returns: {SourceAndMap}
 
 #### `streamChunks(options, onChunk, onSource, onName)`
+
+---
+### streamChunks
 
 * `options` {StreamChunksOptions}
 * `onChunk` {object}
 * `onSource` {object}
 * `onName` {object}
-* Returns: {GeneratedSourceInfo}
+
+* ###Returns: {GeneratedSourceInfo}
 
 #### `updateHash(hash)`
 
+---
+### updateHash
+
 * `hash` {HashLike}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## Class: `RawSource`
+## 
+### Class: `RawSource`
 
 ### Extends
 
@@ -308,54 +488,87 @@
 
 #### `new RawSource(value[, convertToString])`
 
+---
+### RawSource
+
 * `value` {string|Buffer<ArrayBufferLike>}
 * `convertToString` {boolean}
-* Returns: {RawSource}
+
+* ###Returns: {RawSource}
 
 ### Methods
 
 #### `buffer()`
 
-* Returns: {Buffer}
+---
+### buffer
+
+* ###Returns: {Buffer}
 
 #### `isBuffer()`
 
-* Returns: {boolean}
+---
+### isBuffer
+
+* ###Returns: {boolean}
 
 #### `map([options])`
 
+---
+### map
+
 * `options` {MapOptions}
-* Returns: {RawSourceMap}
+
+* ###Returns: {RawSourceMap}
 
 #### `size()`
 
-* Returns: {number}
+---
+### size
+
+* ###Returns: {number}
 
 #### `source()`
 
-* Returns: {SourceValue}
+---
+### source
+
+* ###Returns: {SourceValue}
 
 #### `sourceAndMap([options])`
 
+---
+### sourceAndMap
+
 * `options` {MapOptions}
-* Returns: {SourceAndMap}
+
+* ###Returns: {SourceAndMap}
 
 #### `streamChunks(options, onChunk, onSource, onName)`
+
+---
+### streamChunks
 
 * `options` {StreamChunksOptions}
 * `onChunk` {object}
 * `onSource` {object}
 * `onName` {object}
-* Returns: {GeneratedSourceInfo}
+
+* ###Returns: {GeneratedSourceInfo}
 
 #### `updateHash(hash)`
 
+---
+### updateHash
+
 * `hash` {HashLike}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## Class: `ReplaceSource`
+## 
+### Class: `ReplaceSource`
 
 ### Extends
 
@@ -365,9 +578,13 @@
 
 #### `new ReplaceSource(source[, name])`
 
+---
+### ReplaceSource
+
 * `source` {Source}
 * `name` {string}
-* Returns: {ReplaceSource}
+
+* ###Returns: {ReplaceSource}
 
 ### Properties
 
@@ -377,69 +594,112 @@
 
 #### `buffer()`
 
-* Returns: {Buffer}
+---
+### buffer
+
+* ###Returns: {Buffer}
 
 #### `getName()`
 
-* Returns: {string}
+---
+### getName
+
+* ###Returns: {string}
 
 #### `getReplacements()`
 
-* Returns: {Replacement[]}
+---
+### getReplacements
+
+* ###Returns: {Replacement[]}
 
 #### `insert(pos, newValue[, name])`
+
+---
+### insert
 
 * `pos` {number}
 * `newValue` {string}
 * `name` {string}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `map([options])`
 
+---
+### map
+
 * `options` {MapOptions}
-* Returns: {RawSourceMap}
+
+* ###Returns: {RawSourceMap}
 
 #### `original()`
 
-* Returns: {Source}
+---
+### original
+
+* ###Returns: {Source}
 
 #### `replace(start, end, newValue[, name])`
+
+---
+### replace
 
 * `start` {number}
 * `end` {number}
 * `newValue` {string}
 * `name` {string}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `size()`
 
-* Returns: {number}
+---
+### size
+
+* ###Returns: {number}
 
 #### `source()`
 
-* Returns: {SourceValue}
+---
+### source
+
+* ###Returns: {SourceValue}
 
 #### `sourceAndMap([options])`
 
+---
+### sourceAndMap
+
 * `options` {MapOptions}
-* Returns: {SourceAndMap}
+
+* ###Returns: {SourceAndMap}
 
 #### `streamChunks(options, onChunk, onSource, onName)`
+
+---
+### streamChunks
 
 * `options` {StreamChunksOptions}
 * `onChunk` {object}
 * `onSource` {object}
 * `onName` {object}
-* Returns: {GeneratedSourceInfo}
+
+* ###Returns: {GeneratedSourceInfo}
 
 #### `updateHash(hash)`
 
+---
+### updateHash
+
 * `hash` {HashLike}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## Class: `SizeOnlySource`
+## 
+### Class: `SizeOnlySource`
 
 ### Extends
 
@@ -449,41 +709,67 @@
 
 #### `new SizeOnlySource(size)`
 
+---
+### SizeOnlySource
+
 * `size` {number}
-* Returns: {SizeOnlySource}
+
+* ###Returns: {SizeOnlySource}
 
 ### Methods
 
 #### `buffer()`
 
-* Returns: {Buffer}
+---
+### buffer
+
+* ###Returns: {Buffer}
 
 #### `map([options])`
 
+---
+### map
+
 * `options` {MapOptions}
-* Returns: {RawSourceMap}
+
+* ###Returns: {RawSourceMap}
 
 #### `size()`
 
-* Returns: {number}
+---
+### size
+
+* ###Returns: {number}
 
 #### `source()`
 
-* Returns: {SourceValue}
+---
+### source
+
+* ###Returns: {SourceValue}
 
 #### `sourceAndMap([options])`
 
+---
+### sourceAndMap
+
 * `options` {MapOptions}
-* Returns: {SourceAndMap}
+
+* ###Returns: {SourceAndMap}
 
 #### `updateHash(hash)`
 
+---
+### updateHash
+
 * `hash` {HashLike}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## Class: `Source`
+## 
+### Class: `Source`
 
 ### Extended by
 
@@ -501,40 +787,65 @@
 
 #### `new Source()`
 
-* Returns: {Source}
+---
+### Source
+
+* ###Returns: {Source}
 
 ### Methods
 
 #### `buffer()`
 
-* Returns: {Buffer}
+---
+### buffer
+
+* ###Returns: {Buffer}
 
 #### `map([options])`
 
+---
+### map
+
 * `options` {MapOptions}
-* Returns: {RawSourceMap}
+
+* ###Returns: {RawSourceMap}
 
 #### `size()`
 
-* Returns: {number}
+---
+### size
+
+* ###Returns: {number}
 
 #### `source()`
 
-* Returns: {SourceValue}
+---
+### source
+
+* ###Returns: {SourceValue}
 
 #### `sourceAndMap([options])`
 
+---
+### sourceAndMap
+
 * `options` {MapOptions}
-* Returns: {SourceAndMap}
+
+* ###Returns: {SourceAndMap}
 
 #### `updateHash(hash)`
 
+---
+### updateHash
+
 * `hash` {HashLike}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## Class: `SourceMapSource`
+## 
+### Class: `SourceMapSource`
 
 ### Extends
 
@@ -544,51 +855,83 @@
 
 #### `new SourceMapSource(value, name[, sourceMap][, originalSource][, innerSourceMap][, removeOriginalSource])`
 
+---
+### SourceMapSource
+
 * `value` {string|Buffer<ArrayBufferLike>}
 * `name` {string}
 * `sourceMap` {string|Buffer<ArrayBufferLike>|RawSourceMap}
 * `originalSource` {string|Buffer<ArrayBufferLike>}
 * `innerSourceMap` {string|Buffer<ArrayBufferLike>|RawSourceMap}
 * `removeOriginalSource` {boolean}
-* Returns: {SourceMapSource}
+
+* ###Returns: {SourceMapSource}
 
 ### Methods
 
 #### `buffer()`
 
-* Returns: {Buffer}
+---
+### buffer
+
+* ###Returns: {Buffer}
 
 #### `getArgsAsBuffers()`
 
-* Returns: {Tuple<Buffer<ArrayBufferLike>, string, Buffer<ArrayBufferLike>, Buffer<ArrayBufferLike>, Buffer<ArrayBufferLike>, boolean>}
+---
+### getArgsAsBuffers
+
+* ###Returns: {Tuple<Buffer<ArrayBufferLike>, string, Buffer<ArrayBufferLike>, Buffer<ArrayBufferLike>, Buffer<ArrayBufferLike>, boolean>}
 
 #### `map([options])`
 
+---
+### map
+
 * `options` {MapOptions}
-* Returns: {RawSourceMap}
+
+* ###Returns: {RawSourceMap}
 
 #### `size()`
 
-* Returns: {number}
+---
+### size
+
+* ###Returns: {number}
 
 #### `source()`
 
-* Returns: {SourceValue}
+---
+### source
+
+* ###Returns: {SourceValue}
 
 #### `sourceAndMap([options])`
 
+---
+### sourceAndMap
+
 * `options` {MapOptions}
-* Returns: {SourceAndMap}
+
+* ###Returns: {SourceAndMap}
 
 #### `streamChunks(options, onChunk, onSource, onName)`
+
+---
+### streamChunks
 
 * `options` {StreamChunksOptions}
 * `onChunk` {object}
 * `onSource` {object}
 * `onName` {object}
-* Returns: {GeneratedSourceInfo}
+
+* ###Returns: {GeneratedSourceInfo}
 
 #### `updateHash(hash)`
 
+---
+### updateHash
+
 * `hash` {HashLike}
-* Returns: {void}
+
+* ###Returns: {void}

--- a/pages/v5.x/webpack/namespaces/util/index.md
+++ b/pages/v5.x/webpack/namespaces/util/index.md
@@ -7,7 +7,8 @@
 - [runtime](namespaces/runtime.md)
 - [serialization](namespaces/serialization.md)
 
-## Class: `LazySet`
+## 
+### Class: `LazySet`
 
 ### Type Parameters
 
@@ -19,11 +20,16 @@
 
 #### `new LazySet([iterable])`
 
+---
+### LazySet
+
 ###### T
 
 `T`
+
 * `iterable` {Iterable<T>}
-* Returns: {LazySet<T>}
+
+* ###Returns: {LazySet<T>}
 
 ### Properties
 
@@ -33,71 +39,120 @@
 
 #### `[iterator]()`
 
-* Returns: {SetIterator<T>}
+---
+### [iterator]
+
+* ###Returns: {SetIterator<T>}
 
 #### `add(item)`
 
+---
+### add
+
 * `item` {T}
-* Returns: {LazySet<T>}
+
+* ###Returns: {LazySet<T>}
 
 #### `addAll(iterable)`
 
+---
+### addAll
+
 * `iterable` {LazySet<T>|Iterable<T, any, any>}
-* Returns: {LazySet<T>}
+
+* ###Returns: {LazySet<T>}
 
 #### `clear()`
 
-* Returns: {void}
+---
+### clear
+
+* ###Returns: {void}
 
 #### `delete(value)`
 
+---
+### delete
+
 * `value` {T}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `entries()`
 
-* Returns: {SetIterator<Tuple<T, T>>}
+---
+### entries
+
+* ###Returns: {SetIterator<Tuple<T, T>>}
 
 #### `forEach(callbackFn, thisArg)`
+
+---
+### forEach
 
 ###### K
 
 `K`
+
 * `callbackFn` {object}
 * `thisArg` {K}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `has(item)`
 
+---
+### has
+
 * `item` {T}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `keys()`
 
-* Returns: {SetIterator<T>}
+---
+### keys
+
+* ###Returns: {SetIterator<T>}
 
 #### `serialize(__namedParameters)`
 
+---
+### serialize
+
 * `__namedParameters` {ObjectSerializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `values()`
 
-* Returns: {SetIterator<T>}
+---
+### values
+
+* ###Returns: {SetIterator<T>}
 
 #### Static method: `deserialize(__namedParameters)`
+
+---
+### deserialize
 
 ###### T
 
 `T`
+
 * `__namedParameters` {ObjectDeserializerContext}
-* Returns: {LazySet<T>}
+
+* ###Returns: {LazySet<T>}
 
 ***
 
-## `cleverMerge`
+## 
+### `cleverMerge`
 
 > `const` **cleverMerge**: {object}
+
+---
+### __type
 
 #### T
 
@@ -106,22 +161,33 @@
 #### O
 
 `O`
+
 * `first` {null|T}
 * `second` {null|O}
-* Returns: {T|O|T|O}
+
+* ###Returns: {T|O|T|O}
 
 ***
 
-## `createHash`
+## 
+### `createHash`
 
 > `const` **createHash**: {object}
 
+---
+### __type
+
 * `algorithm` {HashFunction}
-* Returns: {Hash}
+
+* ###Returns: {Hash}
 
 ***
 
 ## `compileBooleanMatcher(map)`
 
+---
+### compileBooleanMatcher
+
 * `map` {Record<string|number, boolean>}
-* Returns: {boolean|object}
+
+* ###Returns: {boolean|object}

--- a/pages/v5.x/webpack/namespaces/util/namespaces/comparators.md
+++ b/pages/v5.x/webpack/namespaces/util/namespaces/comparators.md
@@ -1,125 +1,176 @@
 # comparators
 
-## `compareChunkGroupsByIndex`
+## 
+### `compareChunkGroupsByIndex`
 
 > **compareChunkGroupsByIndex**: {object}
 
+---
+### __type
+
 * `a` {ChunkGroup}
 * `b` {ChunkGroup}
-* Returns: {0|1|-1}
+
+* ###Returns: {0|1|-1}
 
 ***
 
-## `compareChunks`
+## 
+### `compareChunks`
 
 > **compareChunks**: {ParameterizedComparator<ChunkGraph, Chunk>}
 
 ***
 
-## `compareChunksById`
+## 
+### `compareChunksById`
 
 > **compareChunksById**: {object}
 
+---
+### __type
+
 * `a` {Chunk}
 * `b` {Chunk}
-* Returns: {0|1|-1}
+
+* ###Returns: {0|1|-1}
 
 ***
 
-## `compareChunksNatural`
+## 
+### `compareChunksNatural`
 
 > **compareChunksNatural**: {object}
 
+---
+### __type
+
 * `chunkGraph` {ChunkGraph}
-* Returns: {Comparator<Chunk>}
+
+* ###Returns: {Comparator<Chunk>}
 
 ***
 
-## `compareIds`
+## 
+### `compareIds`
 
 > **compareIds**: {object}
 
+---
+### __type
+
 * `a` {string|number}
 * `b` {string|number}
-* Returns: {0|1|-1}
+
+* ###Returns: {0|1|-1}
 
 ***
 
-## `compareIterables`
+## 
+### `compareIterables`
 
 > **compareIterables**: {object}
+
+---
+### __type
 
 #### T
 
 `T`
+
 * `elementComparator` {Comparator<T>}
-* Returns: {Comparator<Iterable<T>>}
+
+* ###Returns: {Comparator<Iterable<T>>}
 
 ***
 
-## `compareLocations`
+## 
+### `compareLocations`
 
 > **compareLocations**: {object}
 
+---
+### __type
+
 * `a` {DependencyLocation}
 * `b` {DependencyLocation}
-* Returns: {0|1|-1}
+
+* ###Returns: {0|1|-1}
 
 ***
 
-## `compareModulesByFullName`
+## 
+### `compareModulesByFullName`
 
 > **compareModulesByFullName**: {ParameterizedComparator<Compiler, Module>}
 
 ***
 
-## `compareModulesById`
+## 
+### `compareModulesById`
 
 > **compareModulesById**: {ParameterizedComparator<ChunkGraph, Module>}
 
 ***
 
-## `compareModulesByIdentifier`
+## 
+### `compareModulesByIdentifier`
 
 > **compareModulesByIdentifier**: {object}
 
+---
+### __type
+
 * `a` {Module}
 * `b` {Module}
-* Returns: {0|1|-1}
+
+* ###Returns: {0|1|-1}
 
 ***
 
-## `compareModulesByIdOrIdentifier`
+## 
+### `compareModulesByIdOrIdentifier`
 
 > **compareModulesByIdOrIdentifier**: {ParameterizedComparator<ChunkGraph, Module>}
 
 ***
 
-## `compareModulesByPostOrderIndexOrIdentifier`
+## 
+### `compareModulesByPostOrderIndexOrIdentifier`
 
 > **compareModulesByPostOrderIndexOrIdentifier**: {ParameterizedComparator<ModuleGraph, Module>}
 
 ***
 
-## `compareModulesByPreOrderIndexOrIdentifier`
+## 
+### `compareModulesByPreOrderIndexOrIdentifier`
 
 > **compareModulesByPreOrderIndexOrIdentifier**: {ParameterizedComparator<ModuleGraph, Module>}
 
 ***
 
-## `compareNumbers`
+## 
+### `compareNumbers`
 
 > **compareNumbers**: {object}
 
+---
+### __type
+
 * `a` {number}
 * `b` {number}
-* Returns: {0|1|-1}
+
+* ###Returns: {0|1|-1}
 
 ***
 
-## `compareSelect`
+## 
+### `compareSelect`
 
 > **compareSelect**: {object}
+
+---
+### __type
 
 #### T
 
@@ -128,63 +179,92 @@
 #### R
 
 `R`
+
 * `getter` {Selector<T, R>}
 * `comparator` {Comparator<R>}
-* Returns: {Comparator<T>}
+
+* ###Returns: {Comparator<T>}
 
 ***
 
-## `compareStrings`
+## 
+### `compareStrings`
 
 > **compareStrings**: {object}
 
+---
+### __type
+
 * `a` {string}
 * `b` {string}
-* Returns: {0|1|-1}
+
+* ###Returns: {0|1|-1}
 
 ***
 
-## `compareStringsNumeric`
+## 
+### `compareStringsNumeric`
 
 > **compareStringsNumeric**: {object}
 
+---
+### __type
+
 * `a` {string}
 * `b` {string}
-* Returns: {0|1|-1}
+
+* ###Returns: {0|1|-1}
 
 ***
 
-## `concatComparators`
+## 
+### `concatComparators`
 
 > **concatComparators**: {object}
 
+---
+### __type
+
 #### T
 
 `T`
+
 * `c1` {Comparator<T>}
 * `c2` {Comparator<T>}
 * `cRest` {Comparator<T>[]}
-* Returns: {Comparator<T>}
+
+* ###Returns: {Comparator<T>}
 
 ***
 
-## `keepOriginalOrder`
+## 
+### `keepOriginalOrder`
 
 > **keepOriginalOrder**: {object}
+
+---
+### __type
 
 #### T
 
 `T`
+
 * `iterable` {Iterable<T>}
-* Returns: {Comparator<T>}
+
+* ###Returns: {Comparator<T>}
 
 ***
 
-## `sortWithSourceOrder`
+## 
+### `sortWithSourceOrder`
 
 > **sortWithSourceOrder**: {object}
+
+---
+### __type
 
 * `dependencies` {Dependency[]}
 * `dependencySourceOrderMap` {WeakMap<Dependency, DependencySourceOrder>}
 * `onDependencyReSort` {object}
-* Returns: {void}
+
+* ###Returns: {void}

--- a/pages/v5.x/webpack/namespaces/util/namespaces/compileBooleanMatcher.md
+++ b/pages/v5.x/webpack/namespaces/util/namespaces/compileBooleanMatcher.md
@@ -1,18 +1,28 @@
 # compileBooleanMatcher
 
-## `fromLists`
+## 
+### `fromLists`
 
 > **fromLists**: {object}
 
+---
+### __type
+
 * `positiveItems` {string[]}
 * `negativeItems` {string[]}
-* Returns: {object}
+
+* ###Returns: {object}
 
 ***
 
-## `itemsToRegexp`
+## 
+### `itemsToRegexp`
 
 > **itemsToRegexp**: {object}
 
+---
+### __type
+
 * `itemsArr` {string[]}
-* Returns: {string}
+
+* ###Returns: {string}

--- a/pages/v5.x/webpack/namespaces/util/namespaces/runtime.md
+++ b/pages/v5.x/webpack/namespaces/util/namespaces/runtime.md
@@ -1,6 +1,7 @@
 # runtime
 
-## Class: `RuntimeSpecMap`
+## 
+### Class: `RuntimeSpecMap`
 
 ### Type Parameters
 
@@ -16,6 +17,9 @@
 
 #### `new RuntimeSpecMap([clone])`
 
+---
+### RuntimeSpecMap
+
 ###### T
 
 `T`
@@ -23,8 +27,10 @@
 ###### R
 
 `R` = {T}
+
 * `clone` {RuntimeSpecMap<T, R>}
-* Returns: {RuntimeSpecMap<T, R>}
+
+* ###Returns: {RuntimeSpecMap<T, R>}
 
 ### Properties
 
@@ -34,55 +40,90 @@
 
 #### `delete(runtime)`
 
+---
+### delete
+
 * `runtime` {RuntimeSpec}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `get(runtime)`
 
+---
+### get
+
 * `runtime` {RuntimeSpec}
-* Returns: {R}
+
+* ###Returns: {R}
 
 #### `has(runtime)`
 
+---
+### has
+
 * `runtime` {RuntimeSpec}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `keys()`
 
-* Returns: {RuntimeSpec[]}
+---
+### keys
+
+* ###Returns: {RuntimeSpec[]}
 
 #### `provide(runtime, computer)`
 
+---
+### provide
+
 * `runtime` {RuntimeSpec}
 * `computer` {object}
-* Returns: {R}
+
+* ###Returns: {R}
 
 #### `set(runtime, value)`
 
+---
+### set
+
 * `runtime` {RuntimeSpec}
 * `value` {R}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `update(runtime, fn)`
 
+---
+### update
+
 * `runtime` {RuntimeSpec}
 * `fn` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `values()`
 
-* Returns: {IterableIterator<R>}
+---
+### values
+
+* ###Returns: {IterableIterator<R>}
 
 ***
 
-## Class: `RuntimeSpecSet`
+## 
+### Class: `RuntimeSpecSet`
 
 ### Constructors
 
 #### `new RuntimeSpecSet([iterable])`
 
+---
+### RuntimeSpecSet
+
 * `iterable` {Iterable<RuntimeSpec>}
-* Returns: {RuntimeSpecSet}
+
+* ###Returns: {RuntimeSpecSet}
 
 ### Properties
 
@@ -92,175 +133,266 @@
 
 #### `[iterator]()`
 
-* Returns: {IterableIterator<RuntimeSpec>}
+---
+### [iterator]
+
+* ###Returns: {IterableIterator<RuntimeSpec>}
 
 #### `add(runtime)`
 
+---
+### add
+
 * `runtime` {RuntimeSpec}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `has(runtime)`
 
+---
+### has
+
 * `runtime` {RuntimeSpec}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 ***
 
-## `compareRuntime`
+## 
+### `compareRuntime`
 
 > **compareRuntime**: {object}
 
+---
+### __type
+
 * `a` {RuntimeSpec}
 * `b` {RuntimeSpec}
-* Returns: {0|1|-1}
+
+* ###Returns: {0|1|-1}
 
 ***
 
-## `filterRuntime`
+## 
+### `filterRuntime`
 
 > **filterRuntime**: {object}
 
+---
+### __type
+
 * `runtime` {RuntimeSpec}
 * `filter` {object}
-* Returns: {undefined|string|boolean|SortableSet<string>}
+
+* ###Returns: {undefined|string|boolean|SortableSet<string>}
 
 ***
 
-## `forEachRuntime`
+## 
+### `forEachRuntime`
 
 > **forEachRuntime**: {object}
+
+---
+### __type
 
 * `runtime` {RuntimeSpec}
 * `fn` {object}
 * `deterministicOrder` {boolean}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## `getEntryRuntime`
+## 
+### `getEntryRuntime`
 
 > **getEntryRuntime**: {object}
+
+---
+### __type
 
 * `compilation` {Compilation}
 * `name` {string}
 * `options` {EntryOptions}
-* Returns: {RuntimeSpec}
+
+* ###Returns: {RuntimeSpec}
 
 ***
 
-## `getRuntimeKey`
+## 
+### `getRuntimeKey`
 
 > **getRuntimeKey**: {object}
 
+---
+### __type
+
 * `runtime` {RuntimeSpec}
-* Returns: {string}
+
+* ###Returns: {string}
 
 ***
 
-## `intersectRuntime`
+## 
+### `intersectRuntime`
 
 > **intersectRuntime**: {object}
 
+---
+### __type
+
 * `a` {RuntimeSpec}
 * `b` {RuntimeSpec}
-* Returns: {RuntimeSpec}
+
+* ###Returns: {RuntimeSpec}
 
 ***
 
-## `keyToRuntime`
+## 
+### `keyToRuntime`
 
 > **keyToRuntime**: {object}
 
+---
+### __type
+
 * `key` {string}
-* Returns: {RuntimeSpec}
+
+* ###Returns: {RuntimeSpec}
 
 ***
 
-## `mergeRuntime`
+## 
+### `mergeRuntime`
 
 > **mergeRuntime**: {object}
 
+---
+### __type
+
 * `a` {RuntimeSpec}
 * `b` {RuntimeSpec}
-* Returns: {RuntimeSpec}
+
+* ###Returns: {RuntimeSpec}
 
 ***
 
-## `mergeRuntimeCondition`
+## 
+### `mergeRuntimeCondition`
 
 > **mergeRuntimeCondition**: {object}
+
+---
+### __type
 
 * `a` {RuntimeCondition}
 * `b` {RuntimeCondition}
 * `runtime` {RuntimeSpec}
-* Returns: {RuntimeCondition}
+
+* ###Returns: {RuntimeCondition}
 
 ***
 
-## `mergeRuntimeConditionNonFalse`
+## 
+### `mergeRuntimeConditionNonFalse`
 
 > **mergeRuntimeConditionNonFalse**: {object}
+
+---
+### __type
 
 * `a` {undefined|string|true|SortableSet<string>}
 * `b` {undefined|string|true|SortableSet<string>}
 * `runtime` {RuntimeSpec}
-* Returns: {undefined|string|true|SortableSet<string>}
+
+* ###Returns: {undefined|string|true|SortableSet<string>}
 
 ***
 
-## `mergeRuntimeOwned`
+## 
+### `mergeRuntimeOwned`
 
 > **mergeRuntimeOwned**: {object}
 
+---
+### __type
+
 * `a` {RuntimeSpec}
 * `b` {RuntimeSpec}
-* Returns: {RuntimeSpec}
+
+* ###Returns: {RuntimeSpec}
 
 ***
 
-## `runtimeConditionToString`
+## 
+### `runtimeConditionToString`
 
 > **runtimeConditionToString**: {object}
 
+---
+### __type
+
 * `runtimeCondition` {RuntimeCondition}
-* Returns: {string}
+
+* ###Returns: {string}
 
 ***
 
-## `runtimeEqual`
+## 
+### `runtimeEqual`
 
 > **runtimeEqual**: {object}
 
+---
+### __type
+
 * `a` {RuntimeSpec}
 * `b` {RuntimeSpec}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 ***
 
-## `runtimeToString`
+## 
+### `runtimeToString`
 
 > **runtimeToString**: {object}
 
+---
+### __type
+
 * `runtime` {RuntimeSpec}
-* Returns: {string}
+
+* ###Returns: {string}
 
 ***
 
-## `subtractRuntime`
+## 
+### `subtractRuntime`
 
 > **subtractRuntime**: {object}
 
+---
+### __type
+
 * `a` {RuntimeSpec}
 * `b` {RuntimeSpec}
-* Returns: {RuntimeSpec}
+
+* ###Returns: {RuntimeSpec}
 
 ***
 
-## `subtractRuntimeCondition`
+## 
+### `subtractRuntimeCondition`
 
 > **subtractRuntimeCondition**: {object}
+
+---
+### __type
 
 * `a` {RuntimeCondition}
 * `b` {RuntimeCondition}
 * `runtime` {RuntimeSpec}
-* Returns: {RuntimeCondition}
+
+* ###Returns: {RuntimeCondition}

--- a/pages/v5.x/webpack/namespaces/util/namespaces/serialization.md
+++ b/pages/v5.x/webpack/namespaces/util/namespaces/serialization.md
@@ -1,14 +1,19 @@
 # serialization
 
-## `buffersSerializer`
+## 
+### `buffersSerializer`
 
 > `const` **buffersSerializer**: {Serializer<any, any, any>}
 
 ***
 
-## `createFileSerializer`
+## 
+### `createFileSerializer`
 
 > **createFileSerializer**: {object}
+
+---
+### __type
 
 #### D
 
@@ -21,55 +26,75 @@
 #### C
 
 `C`
+
 * `fs` {IntermediateFileSystem}
 * `hashFunction` {HashFunction}
-* Returns: {Serializer<D, S, C>}
+
+* ###Returns: {Serializer<D, S, C>}
 
 ***
 
-## `MEASURE_END_OPERATION`
+## 
+### `MEASURE_END_OPERATION`
 
 > `const` **MEASURE\_END\_OPERATION**: {symbol}
 
 ***
 
-## `MEASURE_START_OPERATION`
+## 
+### `MEASURE_START_OPERATION`
 
 > `const` **MEASURE\_START\_OPERATION**: {symbol}
 
 ***
 
-## `NOT_SERIALIZABLE`
+## 
+### `NOT_SERIALIZABLE`
 
 > `const` **NOT\_SERIALIZABLE**: {object}
 
 ***
 
-## `register`
+## 
+### `register`
 
 > `const` **register**: {object}
+
+---
+### __type
 
 * `Constructor` {Constructor}
 * `request` {string}
 * `name` {null|string}
 * `serializer` {ObjectSerializer}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## `registerLoader`
+## 
+### `registerLoader`
 
 > `const` **registerLoader**: {object}
 
+---
+### __type
+
 * `regExp` {RegExp}
 * `loader` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 ***
 
-## `registerNotSerializable`
+## 
+### `registerNotSerializable`
 
 > `const` **registerNotSerializable**: {object}
 
+---
+### __type
+
 * `Constructor` {Constructor}
-* Returns: {void}
+
+* ###Returns: {void}

--- a/pages/v5.x/webpack/namespaces/wasm.md
+++ b/pages/v5.x/webpack/namespaces/wasm.md
@@ -1,13 +1,18 @@
 # wasm
 
-## Class: `AsyncWebAssemblyModulesPlugin`
+## 
+### Class: `AsyncWebAssemblyModulesPlugin`
 
 ### Constructors
 
 #### `new AsyncWebAssemblyModulesPlugin(options)`
 
+---
+### AsyncWebAssemblyModulesPlugin
+
 * `options` {AsyncWebAssemblyModulesPluginOptions}
-* Returns: {AsyncWebAssemblyModulesPlugin}
+
+* ###Returns: {AsyncWebAssemblyModulesPlugin}
 
 ### Properties
 
@@ -17,33 +22,50 @@
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 #### `renderModule(module, renderContext, hooks)`
 
+---
+### renderModule
+
 * `module` {Module}
 * `renderContext` {WebAssemblyRenderContext}
 * `hooks` {CompilationHooksAsyncWebAssemblyModulesPlugin}
-* Returns: {Source}
+
+* ###Returns: {Source}
 
 #### Static method: `getCompilationHooks(compilation)`
 
+---
+### getCompilationHooks
+
 * `compilation` {Compilation}
-* Returns: {CompilationHooksAsyncWebAssemblyModulesPlugin}
+
+* ###Returns: {CompilationHooksAsyncWebAssemblyModulesPlugin}
 
 ***
 
-## Class: `EnableWasmLoadingPlugin`
+## 
+### Class: `EnableWasmLoadingPlugin`
 
 ### Constructors
 
 #### `new EnableWasmLoadingPlugin(type)`
 
+---
+### EnableWasmLoadingPlugin
+
 * `type` {string}
-* Returns: {EnableWasmLoadingPlugin}
+
+* ###Returns: {EnableWasmLoadingPlugin}
 
 ### Properties
 
@@ -53,19 +75,31 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 #### Static method: `checkEnabled(compiler, type)`
 
+---
+### checkEnabled
+
 * `compiler` {Compiler}
 * `type` {string}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `setEnabled(compiler, type)`
 
+---
+### setEnabled
+
 * `compiler` {Compiler}
 * `type` {string}
-* Returns: {void}
+
+* ###Returns: {void}

--- a/pages/v5.x/webpack/namespaces/web.md
+++ b/pages/v5.x/webpack/namespaces/web.md
@@ -1,6 +1,7 @@
 # web
 
-## Class: `CssLoadingRuntimeModule`
+## 
+### Class: `CssLoadingRuntimeModule`
 
 ### Extends
 
@@ -10,8 +11,12 @@
 
 #### `new CssLoadingRuntimeModule(runtimeRequirements)`
 
+---
+### CssLoadingRuntimeModule
+
 * `runtimeRequirements` {ReadonlySet<string>}
-* Returns: {CssLoadingRuntimeModule}
+
+* ###Returns: {CssLoadingRuntimeModule}
 
 ### Properties
 
@@ -67,151 +72,251 @@
 
 #### `addBlock(block)`
 
+---
+### addBlock
+
 * `block` {AsyncDependenciesBlock}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Adds a DependencyBlock to DependencyBlock relationship.
 This is used for when a Module has a AsyncDependencyBlock tie (for code-splitting)
 
 #### `addCacheDependencies(fileDependencies, contextDependencies, missingDependencies, buildDependencies)`
 
+---
+### addCacheDependencies
+
 * `fileDependencies` {LazySet<string>}
 * `contextDependencies` {LazySet<string>}
 * `missingDependencies` {LazySet<string>}
 * `buildDependencies` {LazySet<string>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addChunk(chunk)`
 
+---
+### addChunk
+
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `addCodeGenerationDependency(codeGenerationDependency)`
 
+---
+### addCodeGenerationDependency
+
 * `codeGenerationDependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addDependency(dependency)`
 
+---
+### addDependency
+
 * `dependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addError(error)`
 
+---
+### addError
+
 * `error` {WebpackError}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addPresentationalDependency(presentationalDependency)`
 
+---
+### addPresentationalDependency
+
 * `presentationalDependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addWarning(warning)`
 
+---
+### addWarning
+
 * `warning` {WebpackError}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `attach(compilation, chunk[, chunkGraph])`
+
+---
+### attach
 
 * `compilation` {Compilation}
 * `chunk` {Chunk}
 * `chunkGraph` {ChunkGraph}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `build(options, compilation, resolver, fs, callback)`
+
+---
+### build
 
 * `options` {WebpackOptionsNormalizedWithDefaults}
 * `compilation` {Compilation}
 * `resolver` {ResolverWithOptions}
 * `fs` {InputFileSystem}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `chunkCondition(chunk, compilation)`
 
+---
+### chunkCondition
+
 * `chunk` {Chunk}
 * `compilation` {Compilation}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `cleanupForCache()`
 
-* Returns: {void}
+---
+### cleanupForCache
+
+* ###Returns: {void}
 
 Assuming this module is in the cache. Remove internal references to allow freeing some memory.
 
 #### `clearDependenciesAndBlocks()`
 
-* Returns: {void}
+---
+### clearDependenciesAndBlocks
+
+* ###Returns: {void}
 
 Removes all dependencies and blocks
 
 #### `clearWarningsAndErrors()`
 
-* Returns: {void}
+---
+### clearWarningsAndErrors
+
+* ###Returns: {void}
 
 removes all warnings and errors
 
 #### `codeGeneration(context)`
 
+---
+### codeGeneration
+
 * `context` {CodeGenerationContext}
-* Returns: {CodeGenerationResult}
+
+* ###Returns: {CodeGenerationResult}
 
 #### `deserialize(__namedParameters)`
 
+---
+### deserialize
+
 * `__namedParameters` {ObjectDeserializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `generate()`
 
-* Returns: {string}
+---
+### generate
+
+* ###Returns: {string}
 
 #### `getChunks()`
 
-* Returns: {Chunk[]}
+---
+### getChunks
+
+* ###Returns: {Chunk[]}
 
 #### `getConcatenationBailoutReason(context)`
 
+---
+### getConcatenationBailoutReason
+
 * `context` {ConcatenationBailoutReasonContext}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `getErrors()`
 
-* Returns: {Iterable<WebpackError, any, any>}
+---
+### getErrors
+
+* ###Returns: {Iterable<WebpackError, any, any>}
 
 #### `getExportsType(moduleGraph[, strict])`
 
+---
+### getExportsType
+
 * `moduleGraph` {ModuleGraph}
 * `strict` {boolean}
-* Returns: {ExportsType}
+
+* ###Returns: {ExportsType}
 
 #### `getGeneratedCode()`
 
-* Returns: {string}
+---
+### getGeneratedCode
+
+* ###Returns: {string}
 
 #### `getNumberOfChunks()`
 
-* Returns: {number}
+---
+### getNumberOfChunks
+
+* ###Returns: {number}
 
 #### `getNumberOfErrors()`
 
-* Returns: {number}
+---
+### getNumberOfErrors
+
+* ###Returns: {number}
 
 #### `getNumberOfWarnings()`
 
-* Returns: {number}
+---
+### getNumberOfWarnings
+
+* ###Returns: {number}
 
 #### `getRootBlock()`
 
-* Returns: {DependenciesBlock}
+---
+### getRootBlock
+
+* ###Returns: {DependenciesBlock}
 
 #### `getSideEffectsConnectionState(moduleGraph)`
 
+---
+### getSideEffectsConnectionState
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {ConnectionState}
+
+* ###Returns: {ConnectionState}
 
 #### `getSourceBasicTypes()`
 
-* Returns: {ReadonlySet<string>}
+---
+### getSourceBasicTypes
+
+* ###Returns: {ReadonlySet<string>}
 
 Basic source types are high-level categories like javascript, css, webassembly, etc.
 We only have built-in knowledge about the javascript basic type here; other basic types may be
@@ -221,150 +326,248 @@ from getSourceTypes(), but their generated output is still JavaScript, i.e. thei
 
 #### `getSourceTypes()`
 
-* Returns: {ReadonlySet<string>}
+---
+### getSourceTypes
+
+* ###Returns: {ReadonlySet<string>}
 
 #### `getUnsafeCacheData()`
 
-* Returns: {UnsafeCacheData}
+---
+### getUnsafeCacheData
+
+* ###Returns: {UnsafeCacheData}
 
 Module should be unsafe cached. Get data that's needed for that.
 This data will be passed to restoreFromUnsafeCache later.
 
 #### `getWarnings()`
 
-* Returns: {Iterable<WebpackError, any, any>}
+---
+### getWarnings
+
+* ###Returns: {Iterable<WebpackError, any, any>}
 
 #### `hasChunkCondition()`
 
-* Returns: {boolean}
+---
+### hasChunkCondition
+
+* ###Returns: {boolean}
 
 #### `hasReasonForChunk(chunk, moduleGraph, chunkGraph)`
+
+---
+### hasReasonForChunk
 
 * `chunk` {Chunk}
 * `moduleGraph` {ModuleGraph}
 * `chunkGraph` {ChunkGraph}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `hasReasons(moduleGraph, runtime)`
 
+---
+### hasReasons
+
 * `moduleGraph` {ModuleGraph}
 * `runtime` {RuntimeSpec}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `identifier()`
 
-* Returns: {string}
+---
+### identifier
+
+* ###Returns: {string}
 
 #### `invalidateBuild()`
 
-* Returns: {void}
+---
+### invalidateBuild
+
+* ###Returns: {void}
 
 #### `isAccessibleInChunk(chunkGraph, chunk[, ignoreChunk])`
+
+---
+### isAccessibleInChunk
 
 * `chunkGraph` {ChunkGraph}
 * `chunk` {Chunk}
 * `ignoreChunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isAccessibleInChunkGroup(chunkGraph, chunkGroup[, ignoreChunk])`
+
+---
+### isAccessibleInChunkGroup
 
 * `chunkGraph` {ChunkGraph}
 * `chunkGroup` {ChunkGroup}
 * `ignoreChunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isEntryModule()`
 
-* Returns: {boolean}
+---
+### isEntryModule
+
+* ###Returns: {boolean}
 
 #### `isInChunk(chunk)`
 
+---
+### isInChunk
+
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isOptional(moduleGraph)`
 
+---
+### isOptional
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isProvided(exportName)`
 
+---
+### isProvided
+
 * `exportName` {string}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `libIdent(options)`
 
+---
+### libIdent
+
 * `options` {LibIdentOptions}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `nameForCondition()`
 
-* Returns: {string}
+---
+### nameForCondition
+
+* ###Returns: {string}
 
 #### `needBuild(context, callback)`
 
+---
+### needBuild
+
 * `context` {NeedBuildContext}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `needRebuild(fileTimestamps, contextTimestamps)`
+
+---
+### needRebuild
 
 > Stability: 0 - Deprecated
 
 * `fileTimestamps` {Map<string, number>}
 * `contextTimestamps` {Map<string, number>}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 Use needBuild instead
 
 #### `originalSource()`
 
-* Returns: {Source}
+---
+### originalSource
+
+* ###Returns: {Source}
 
 #### `readableIdentifier(requestShortener)`
 
+---
+### readableIdentifier
+
 * `requestShortener` {RequestShortener}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `removeChunk(chunk)`
 
+---
+### removeChunk
+
 * `chunk` {Chunk}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `removeDependency(dependency)`
 
+---
+### removeDependency
+
 * `dependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `serialize(__namedParameters)`
 
+---
+### serialize
+
 * `__namedParameters` {ObjectSerializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `shouldIsolate()`
 
-* Returns: {boolean}
+---
+### shouldIsolate
+
+* ###Returns: {boolean}
 
 #### `size([type])`
 
+---
+### size
+
 * `type` {string}
-* Returns: {number}
+
+* ###Returns: {number}
 
 #### `source(dependencyTemplates, runtimeTemplate[, type])`
+
+---
+### source
 
 > Stability: 0 - Deprecated
 
 * `dependencyTemplates` {DependencyTemplates}
 * `runtimeTemplate` {RuntimeTemplate}
 * `type` {string}
-* Returns: {Source}
+
+* ###Returns: {Source}
 
 Use codeGeneration() instead
 
 #### `updateCacheModule(module)`
 
+---
+### updateCacheModule
+
 * `module` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Assuming this module is in the cache. Update the (cached) module with
 the fresh module from the factory. Usually updates internal references
@@ -372,53 +575,78 @@ and properties.
 
 #### `updateHash(hash, context)`
 
+---
+### updateHash
+
 * `hash` {Hash}
 * `context` {UpdateHashContextDependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `getCompilationHooks(compilation)`
 
+---
+### getCompilationHooks
+
 * `compilation` {Compilation}
-* Returns: {CssLoadingRuntimeModulePluginHooks}
+
+* ###Returns: {CssLoadingRuntimeModulePluginHooks}
 
 #### Static method: `getSourceBasicTypes(module)`
+
+---
+### getSourceBasicTypes
 
 > Stability: 0 - Deprecated
 
 * `module` {Module}
-* Returns: {ReadonlySet<string>}
+
+* ###Returns: {ReadonlySet<string>}
 
 In webpack 6, call getSourceBasicTypes() directly on the module instance instead of using this static method.
 
 ***
 
-## Class: `FetchCompileAsyncWasmPlugin`
+## 
+### Class: `FetchCompileAsyncWasmPlugin`
 
 ### Constructors
 
 #### `new FetchCompileAsyncWasmPlugin()`
 
-* Returns: {FetchCompileAsyncWasmPlugin}
+---
+### FetchCompileAsyncWasmPlugin
+
+* ###Returns: {FetchCompileAsyncWasmPlugin}
 
 ### Methods
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `FetchCompileWasmPlugin`
+## 
+### Class: `FetchCompileWasmPlugin`
 
 ### Constructors
 
 #### `new FetchCompileWasmPlugin([options])`
 
+---
+### FetchCompileWasmPlugin
+
 * `options` {FetchCompileWasmPluginOptions}
-* Returns: {FetchCompileWasmPlugin}
+
+* ###Returns: {FetchCompileWasmPlugin}
 
 ### Properties
 
@@ -428,14 +656,19 @@ Apply the plugin
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 ***
 
-## Class: `JsonpChunkLoadingRuntimeModule`
+## 
+### Class: `JsonpChunkLoadingRuntimeModule`
 
 ### Extends
 
@@ -445,8 +678,12 @@ Apply the plugin
 
 #### `new JsonpChunkLoadingRuntimeModule(runtimeRequirements)`
 
+---
+### JsonpChunkLoadingRuntimeModule
+
 * `runtimeRequirements` {ReadonlySet<string>}
-* Returns: {JsonpChunkLoadingRuntimeModule}
+
+* ###Returns: {JsonpChunkLoadingRuntimeModule}
 
 ### Properties
 
@@ -502,151 +739,251 @@ Apply the plugin
 
 #### `addBlock(block)`
 
+---
+### addBlock
+
 * `block` {AsyncDependenciesBlock}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Adds a DependencyBlock to DependencyBlock relationship.
 This is used for when a Module has a AsyncDependencyBlock tie (for code-splitting)
 
 #### `addCacheDependencies(fileDependencies, contextDependencies, missingDependencies, buildDependencies)`
 
+---
+### addCacheDependencies
+
 * `fileDependencies` {LazySet<string>}
 * `contextDependencies` {LazySet<string>}
 * `missingDependencies` {LazySet<string>}
 * `buildDependencies` {LazySet<string>}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addChunk(chunk)`
 
+---
+### addChunk
+
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `addCodeGenerationDependency(codeGenerationDependency)`
 
+---
+### addCodeGenerationDependency
+
 * `codeGenerationDependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addDependency(dependency)`
 
+---
+### addDependency
+
 * `dependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addError(error)`
 
+---
+### addError
+
 * `error` {WebpackError}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addPresentationalDependency(presentationalDependency)`
 
+---
+### addPresentationalDependency
+
 * `presentationalDependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `addWarning(warning)`
 
+---
+### addWarning
+
 * `warning` {WebpackError}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `attach(compilation, chunk[, chunkGraph])`
+
+---
+### attach
 
 * `compilation` {Compilation}
 * `chunk` {Chunk}
 * `chunkGraph` {ChunkGraph}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `build(options, compilation, resolver, fs, callback)`
+
+---
+### build
 
 * `options` {WebpackOptionsNormalizedWithDefaults}
 * `compilation` {Compilation}
 * `resolver` {ResolverWithOptions}
 * `fs` {InputFileSystem}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `chunkCondition(chunk, compilation)`
 
+---
+### chunkCondition
+
 * `chunk` {Chunk}
 * `compilation` {Compilation}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `cleanupForCache()`
 
-* Returns: {void}
+---
+### cleanupForCache
+
+* ###Returns: {void}
 
 Assuming this module is in the cache. Remove internal references to allow freeing some memory.
 
 #### `clearDependenciesAndBlocks()`
 
-* Returns: {void}
+---
+### clearDependenciesAndBlocks
+
+* ###Returns: {void}
 
 Removes all dependencies and blocks
 
 #### `clearWarningsAndErrors()`
 
-* Returns: {void}
+---
+### clearWarningsAndErrors
+
+* ###Returns: {void}
 
 removes all warnings and errors
 
 #### `codeGeneration(context)`
 
+---
+### codeGeneration
+
 * `context` {CodeGenerationContext}
-* Returns: {CodeGenerationResult}
+
+* ###Returns: {CodeGenerationResult}
 
 #### `deserialize(__namedParameters)`
 
+---
+### deserialize
+
 * `__namedParameters` {ObjectDeserializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `generate()`
 
-* Returns: {string}
+---
+### generate
+
+* ###Returns: {string}
 
 #### `getChunks()`
 
-* Returns: {Chunk[]}
+---
+### getChunks
+
+* ###Returns: {Chunk[]}
 
 #### `getConcatenationBailoutReason(context)`
 
+---
+### getConcatenationBailoutReason
+
 * `context` {ConcatenationBailoutReasonContext}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `getErrors()`
 
-* Returns: {Iterable<WebpackError, any, any>}
+---
+### getErrors
+
+* ###Returns: {Iterable<WebpackError, any, any>}
 
 #### `getExportsType(moduleGraph[, strict])`
 
+---
+### getExportsType
+
 * `moduleGraph` {ModuleGraph}
 * `strict` {boolean}
-* Returns: {ExportsType}
+
+* ###Returns: {ExportsType}
 
 #### `getGeneratedCode()`
 
-* Returns: {string}
+---
+### getGeneratedCode
+
+* ###Returns: {string}
 
 #### `getNumberOfChunks()`
 
-* Returns: {number}
+---
+### getNumberOfChunks
+
+* ###Returns: {number}
 
 #### `getNumberOfErrors()`
 
-* Returns: {number}
+---
+### getNumberOfErrors
+
+* ###Returns: {number}
 
 #### `getNumberOfWarnings()`
 
-* Returns: {number}
+---
+### getNumberOfWarnings
+
+* ###Returns: {number}
 
 #### `getRootBlock()`
 
-* Returns: {DependenciesBlock}
+---
+### getRootBlock
+
+* ###Returns: {DependenciesBlock}
 
 #### `getSideEffectsConnectionState(moduleGraph)`
 
+---
+### getSideEffectsConnectionState
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {ConnectionState}
+
+* ###Returns: {ConnectionState}
 
 #### `getSourceBasicTypes()`
 
-* Returns: {ReadonlySet<string>}
+---
+### getSourceBasicTypes
+
+* ###Returns: {ReadonlySet<string>}
 
 Basic source types are high-level categories like javascript, css, webassembly, etc.
 We only have built-in knowledge about the javascript basic type here; other basic types may be
@@ -656,150 +993,248 @@ from getSourceTypes(), but their generated output is still JavaScript, i.e. thei
 
 #### `getSourceTypes()`
 
-* Returns: {ReadonlySet<string>}
+---
+### getSourceTypes
+
+* ###Returns: {ReadonlySet<string>}
 
 #### `getUnsafeCacheData()`
 
-* Returns: {UnsafeCacheData}
+---
+### getUnsafeCacheData
+
+* ###Returns: {UnsafeCacheData}
 
 Module should be unsafe cached. Get data that's needed for that.
 This data will be passed to restoreFromUnsafeCache later.
 
 #### `getWarnings()`
 
-* Returns: {Iterable<WebpackError, any, any>}
+---
+### getWarnings
+
+* ###Returns: {Iterable<WebpackError, any, any>}
 
 #### `hasChunkCondition()`
 
-* Returns: {boolean}
+---
+### hasChunkCondition
+
+* ###Returns: {boolean}
 
 #### `hasReasonForChunk(chunk, moduleGraph, chunkGraph)`
+
+---
+### hasReasonForChunk
 
 * `chunk` {Chunk}
 * `moduleGraph` {ModuleGraph}
 * `chunkGraph` {ChunkGraph}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `hasReasons(moduleGraph, runtime)`
 
+---
+### hasReasons
+
 * `moduleGraph` {ModuleGraph}
 * `runtime` {RuntimeSpec}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `identifier()`
 
-* Returns: {string}
+---
+### identifier
+
+* ###Returns: {string}
 
 #### `invalidateBuild()`
 
-* Returns: {void}
+---
+### invalidateBuild
+
+* ###Returns: {void}
 
 #### `isAccessibleInChunk(chunkGraph, chunk[, ignoreChunk])`
+
+---
+### isAccessibleInChunk
 
 * `chunkGraph` {ChunkGraph}
 * `chunk` {Chunk}
 * `ignoreChunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isAccessibleInChunkGroup(chunkGraph, chunkGroup[, ignoreChunk])`
+
+---
+### isAccessibleInChunkGroup
 
 * `chunkGraph` {ChunkGraph}
 * `chunkGroup` {ChunkGroup}
 * `ignoreChunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isEntryModule()`
 
-* Returns: {boolean}
+---
+### isEntryModule
+
+* ###Returns: {boolean}
 
 #### `isInChunk(chunk)`
 
+---
+### isInChunk
+
 * `chunk` {Chunk}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isOptional(moduleGraph)`
 
+---
+### isOptional
+
 * `moduleGraph` {ModuleGraph}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `isProvided(exportName)`
 
+---
+### isProvided
+
 * `exportName` {string}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 #### `libIdent(options)`
 
+---
+### libIdent
+
 * `options` {LibIdentOptions}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `nameForCondition()`
 
-* Returns: {string}
+---
+### nameForCondition
+
+* ###Returns: {string}
 
 #### `needBuild(context, callback)`
 
+---
+### needBuild
+
 * `context` {NeedBuildContext}
 * `callback` {object}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `needRebuild(fileTimestamps, contextTimestamps)`
+
+---
+### needRebuild
 
 > Stability: 0 - Deprecated
 
 * `fileTimestamps` {Map<string, number>}
 * `contextTimestamps` {Map<string, number>}
-* Returns: {boolean}
+
+* ###Returns: {boolean}
 
 Use needBuild instead
 
 #### `originalSource()`
 
-* Returns: {Source}
+---
+### originalSource
+
+* ###Returns: {Source}
 
 #### `readableIdentifier(requestShortener)`
 
+---
+### readableIdentifier
+
 * `requestShortener` {RequestShortener}
-* Returns: {string}
+
+* ###Returns: {string}
 
 #### `removeChunk(chunk)`
 
+---
+### removeChunk
+
 * `chunk` {Chunk}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `removeDependency(dependency)`
 
+---
+### removeDependency
+
 * `dependency` {Dependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `serialize(__namedParameters)`
 
+---
+### serialize
+
 * `__namedParameters` {ObjectSerializerContext}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### `shouldIsolate()`
 
-* Returns: {boolean}
+---
+### shouldIsolate
+
+* ###Returns: {boolean}
 
 #### `size([type])`
 
+---
+### size
+
 * `type` {string}
-* Returns: {number}
+
+* ###Returns: {number}
 
 #### `source(dependencyTemplates, runtimeTemplate[, type])`
+
+---
+### source
 
 > Stability: 0 - Deprecated
 
 * `dependencyTemplates` {DependencyTemplates}
 * `runtimeTemplate` {RuntimeTemplate}
 * `type` {string}
-* Returns: {Source}
+
+* ###Returns: {Source}
 
 Use codeGeneration() instead
 
 #### `updateCacheModule(module)`
 
+---
+### updateCacheModule
+
 * `module` {Module}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Assuming this module is in the cache. Update the (cached) module with
 the fresh module from the factory. Usually updates internal references
@@ -807,48 +1242,72 @@ and properties.
 
 #### `updateHash(hash, context)`
 
+---
+### updateHash
+
 * `hash` {Hash}
 * `context` {UpdateHashContextDependency}
-* Returns: {void}
+
+* ###Returns: {void}
 
 #### Static method: `getCompilationHooks(compilation)`
 
+---
+### getCompilationHooks
+
 * `compilation` {Compilation}
-* Returns: {JsonpCompilationPluginHooks}
+
+* ###Returns: {JsonpCompilationPluginHooks}
 
 #### Static method: `getSourceBasicTypes(module)`
+
+---
+### getSourceBasicTypes
 
 > Stability: 0 - Deprecated
 
 * `module` {Module}
-* Returns: {ReadonlySet<string>}
+
+* ###Returns: {ReadonlySet<string>}
 
 In webpack 6, call getSourceBasicTypes() directly on the module instance instead of using this static method.
 
 ***
 
-## Class: `JsonpTemplatePlugin`
+## 
+### Class: `JsonpTemplatePlugin`
 
 ### Constructors
 
 #### `new JsonpTemplatePlugin()`
 
-* Returns: {JsonpTemplatePlugin}
+---
+### JsonpTemplatePlugin
+
+* ###Returns: {JsonpTemplatePlugin}
 
 ### Methods
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin
 
 #### Static method: `getCompilationHooks(compilation)`
 
+---
+### getCompilationHooks
+
 > Stability: 0 - Deprecated
 
 * `compilation` {Compilation}
-* Returns: {JsonpCompilationPluginHooks}
+
+* ###Returns: {JsonpCompilationPluginHooks}
 
 use JsonpChunkLoadingRuntimeModule.getCompilationHooks instead

--- a/pages/v5.x/webpack/namespaces/webworker.md
+++ b/pages/v5.x/webpack/namespaces/webworker.md
@@ -1,18 +1,26 @@
 # webworker
 
-## Class: `WebWorkerTemplatePlugin`
+## 
+### Class: `WebWorkerTemplatePlugin`
 
 ### Constructors
 
 #### `new WebWorkerTemplatePlugin()`
 
-* Returns: {WebWorkerTemplatePlugin}
+---
+### WebWorkerTemplatePlugin
+
+* ###Returns: {WebWorkerTemplatePlugin}
 
 ### Methods
 
 #### `apply(compiler)`
 
+---
+### apply
+
 * `compiler` {Compiler}
-* Returns: {void}
+
+* ###Returns: {void}
 
 Apply the plugin

--- a/plugins/theme/partials/index.mjs
+++ b/plugins/theme/partials/index.mjs
@@ -51,6 +51,7 @@ export default ctx => ({
     const stability = ctx.helpers.stabilityBlockquote(comment);
 
     return [
+      model.name ? `\n---\n### ${model.name}\n` : '',
       stability,
       stability && '',
       model.typeParameters?.length &&
@@ -62,7 +63,7 @@ export default ctx => ({
           headingLevel: options.headingLevel,
         }),
       ctx.helpers.typedListItem({
-        label: 'Returns',
+        label: '###Returns',
         type: model.type ?? 'void',
         comment: model.comment?.getTag('@returns'),
       }),
@@ -75,7 +76,7 @@ export default ctx => ({
       ctx.helpers.examples(comment, options),
     ]
       .filter(x => typeof x === 'string' || Boolean(x))
-      .join('\n');
+      .join('\n\n');
   },
 
   memberTitle(model) {
@@ -83,7 +84,7 @@ export default ctx => ({
     const params = model.signatures?.[0]?.parameters;
 
     if (!params) {
-      return `${prefix}\`${model.name}\``;
+      return `\n### ${prefix}\`${model.name}\`\n`;
     }
 
     return `${prefix}\`${model.name}(${formatParams(params)})\``;


### PR DESCRIPTION
This PR improves the readability of generated documentation by introducing visual separation between sections and clearer headings for members.

Currently, sections are densely packed, making it harder to scan large API documentation. This change improves structure and navigation by adding separators and better visual hierarchy.

Closes #53 