### PR TITLE
feat: adopt upstream doc-kit prerequisites for webpack integration (#13)

### DIFF
--- a/doc-kit.config.mjs
+++ b/doc-kit.config.mjs
@@ -1,3 +1,8 @@
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
 /**
  * Configuration for @node-core/doc-kit when generating webpack API docs.
  *
@@ -18,6 +23,13 @@ export default {
   web: {
     // Use "webpack" as the product name in navbar and sidebar labels
     title: 'webpack',
+
+    // Override the default Node.js theming components with webpack-specific ones.
+    // These aliases are resolved by the bundler during the doc-kit build step.
+    // @see https://github.com/nodejs/doc-kit/issues/665
+    imports: {
+      '#theme/Logo': resolve(__dirname, './ui/WebpackLogo.jsx'),
+    },
   },
   'jsx-ast': {
     // Disable the "Edit this page" link — webpack API docs are generated from

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@node-core/doc-kit": "^1.2.0",
+    "@node-core/doc-kit": "^1.2.1",
     "semver": "^7.7.4",
     "typedoc": "^0.28.18",
     "typedoc-plugin-markdown": "^4.11.0",

--- a/ui/WebpackLogo.jsx
+++ b/ui/WebpackLogo.jsx
@@ -1,0 +1,35 @@
+/**
+ * Webpack logo component for use as the #theme/Logo override.
+ * Based on the official webpack brand assets.
+ * @see https://webpack.js.org
+ */
+const WebpackLogo = props => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 1200 1200"
+    width="32"
+    height="32"
+    aria-label="webpack"
+    role="img"
+    {...props}
+  >
+    <path
+      fill="#fff"
+      d="M600 60 L1110 340 L1110 860 L600 1140 L90 860 L90 340 Z"
+    />
+    <path
+      fill="#8ED6FB"
+      d="M600 143 L1051 400 L1051 800 L600 1057 L149 800 L149 400 Z"
+    />
+    <path
+      fill="#1C78C0"
+      d="M600 233 L992 460 L992 740 L600 967 L208 740 L208 460 Z"
+    />
+    <path
+      fill="#fff"
+      d="M382 480 L470 480 L530 680 L600 480 L670 480 L740 680 L800 480 L888 480 L780 760 L710 760 L640 560 L560 760 L490 760 Z"
+    />
+  </svg>
+);
+
+export default WebpackLogo;


### PR DESCRIPTION
Summary                                                                                  
   
  Resolves #13  — three of the four upstream nodejs/doc-kit prerequisites for webpack's     
  production adoption have now been merged and released. This PR updates the dependency and
   wires up the newly available capabilities.

  - nodejs/doc-kit#666 (TypeScript generics) — merged in @node-core/doc-kit@1.2.0 via PR 
  #668. Generic types like {Set<string>}, {Map<string, RegExp>}, {Iterable<Module, any,
  any>} (which appear extensively in the generated webpack API pages) now resolve to
  properly linked Markdown.
  - nodejs/doc-kit#665 (Custom theming components) — merged in @node-core/doc-kit@1.2.0 via
   PR #677. Introduces #theme/Logo, #theme/Navigation, #theme/Sidebar, #theme/Footer, and
  #theme/Layout aliases that consuming projects can override via web.imports in their
  config.
  - nodejs/doc-kit#662 (Preserve directory structure) — merged in @node-core/doc-kit@1.2.0
  via PR #672. Output files now mirror the input glob's directory hierarchy instead of
  being flattened.

  nodejs/doc-kit#332 (Generification) remains open as a long-term goal and is not addressed
   here.

  ---
  What kind of change does this PR introduce?

  feat — dependency update + new webpack-specific Logo component + configuration of the
  custom theming layer.

  ---
  Did you add tests for your changes?

  No. The changes are a dependency bump, a config update, and a UI component. The theming
  override can be validated visually by running npm run build-html.

  ---
  Does this PR introduce a breaking change?

  No. The web.imports block is additive and only affects the #theme/Logo alias. All other
  theme components continue to use their built-in defaults.

  ---
  If relevant, what needs to be documented once your changes are merged or what have you
  already documented?

  The web.imports keys (#theme/Navigation, #theme/Sidebar, #theme/Footer, #theme/Layout)
  remain available for future customization in Milestone 2, when the webpack visual design
  is finalized. No additional documentation is required at this stage.

  ---
  Use of AI

  Claude (claude-sonnet-4-6 via Claude Code CLI) was used to assist with researching the
  upstream PRs, understanding the doc-kit configuration schema, and generating the initial
  implementation. All generated code was reviewed, verified against the installed source,
  and formatted with Prettier before committing, in accordance with the webpack AI policy https://github.com/webpack/governance/blob/main/AI_POLICY.md). 