### PR TITLE
feat: add webpack theming (logo, footer, CSS brand overrides) for #6

### DIFF
--- a/doc-kit.config.mjs
+++ b/doc-kit.config.mjs
@@ -1,3 +1,8 @@
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
 /**
  * Configuration for @node-core/doc-kit when generating webpack API docs.
  *
@@ -18,6 +23,13 @@ export default {
   web: {
     // Use "webpack" as the product name in navbar and sidebar labels
     title: 'webpack',
+
+    // Override the default Node.js theming components with webpack-specific
+    // ones. These aliases are resolved by the bundler at build time.
+    imports: {
+      '#theme/Logo': resolve(__dirname, './ui/WebpackLogo.jsx'),
+      '#theme/Footer': resolve(__dirname, './ui/WebpackFooter.jsx'),
+    },
   },
   'jsx-ast': {
     // Disable the "Edit this page" link — webpack API docs are generated from

--- a/ui/WebpackFooter.jsx
+++ b/ui/WebpackFooter.jsx
@@ -1,0 +1,68 @@
+/**
+ * Webpack footer component for use as the #theme/Footer override.
+ * Displays copyright, license, and community links.
+ */
+const WebpackFooter = () => {
+  const year = new Date().getFullYear();
+
+  return (
+    <footer
+      style={{
+        borderTop: '1px solid var(--color-neutral-200, #e9edf0)',
+        padding: '2rem',
+        textAlign: 'center',
+        fontSize: '0.875rem',
+        color: 'var(--color-neutral-600, #929fa5)',
+      }}
+    >
+      <p>
+        Copyright &copy; 2012&ndash;{year}{' '}
+        <a
+          href="https://github.com/webpack/webpack/graphs/contributors"
+          style={{ color: 'var(--color-webpack-primary, #1C78C0)' }}
+        >
+          webpack contributors
+        </a>
+        . Licensed under{' '}
+        <a
+          href="https://github.com/webpack/webpack/blob/main/LICENSE"
+          style={{ color: 'var(--color-webpack-primary, #1C78C0)' }}
+        >
+          MIT
+        </a>
+        .
+      </p>
+      <p style={{ marginTop: '0.5rem' }}>
+        <a
+          href="https://github.com/webpack/webpack"
+          style={{
+            marginInline: '0.5rem',
+            color: 'var(--color-webpack-primary, #1C78C0)',
+          }}
+        >
+          GitHub
+        </a>
+        <a
+          href="https://opencollective.com/webpack"
+          style={{
+            marginInline: '0.5rem',
+            color: 'var(--color-webpack-primary, #1C78C0)',
+          }}
+        >
+          OpenCollective
+        </a>
+        <a
+          href="https://webpack.js.org"
+          style={{
+            marginInline: '0.5rem',
+            color: 'var(--color-webpack-primary, #1C78C0)',
+          }}
+        >
+          webpack.js.org
+        </a>
+      </p>
+    </footer>
+  );
+};
+
+export default WebpackFooter;

--- a/ui/WebpackLogo.jsx
+++ b/ui/WebpackLogo.jsx
@@ -1,0 +1,39 @@
+// Import webpack brand color overrides — this file is always rendered
+// as part of the NavBar, so its CSS import is reliably included in every page.
+import './theme.css';
+
+/**
+ * Webpack logo component for use as the #theme/Logo override.
+ * Based on the official webpack brand assets.
+ * @see https://webpack.js.org/branding
+ */
+const WebpackLogo = props => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 1200 1200"
+    width="32"
+    height="32"
+    aria-label="webpack"
+    role="img"
+    {...props}
+  >
+    <path
+      fill="#fff"
+      d="M600 60 L1110 340 L1110 860 L600 1140 L90 860 L90 340 Z"
+    />
+    <path
+      fill="#8ED6FB"
+      d="M600 143 L1051 400 L1051 800 L600 1057 L149 800 L149 400 Z"
+    />
+    <path
+      fill="#1C78C0"
+      d="M600 233 L992 460 L992 740 L600 967 L208 740 L208 460 Z"
+    />
+    <path
+      fill="#fff"
+      d="M382 480 L470 480 L530 680 L600 480 L670 480 L740 680 L800 480 L888 480 L780 760 L710 760 L640 560 L560 760 L490 760 Z"
+    />
+  </svg>
+);
+
+export default WebpackLogo;

--- a/ui/theme.css
+++ b/ui/theme.css
@@ -1,0 +1,29 @@
+/**
+ * Webpack brand theme overrides for @node-core/doc-kit.
+ *
+ * These CSS custom property overrides replace Node.js's green color palette
+ * with webpack's blue palette (#8ED6FB light, #1C78C0 dark).
+ *
+ * The --color-green-* variables are used by @node-core/ui-components for
+ * active navigation items, links, and interactive highlights. Overriding them
+ * here re-themes the entire site without modifying upstream components.
+ *
+ * @see https://webpack.js.org/branding
+ */
+
+:root {
+  /* webpack primary brand colors */
+  --color-webpack-primary: #1c78c0;
+  --color-webpack-light: #8ed6fb;
+
+  /* Override Node.js green palette with webpack blues */
+  --color-green-100: #e8f4fd;
+  --color-green-200: #c2e0f7;
+  --color-green-300: #8ed6fb;
+  --color-green-400: #5bbef5;
+  --color-green-500: #2ea3e8;
+  --color-green-600: #1c78c0;
+  --color-green-700: #155d96;
+  --color-green-800: #0e4370;
+  --color-green-900: #082d4d;
+}


### PR DESCRIPTION
Summary     
                                                                
  Closes #6 .                                       
                                                        
  The existing doc-kit.config.mjs only set a title and disabled the edit URL. This PR adds
  webpack-specific theming so the generated documentation site reflects webpack's brand    
  identity instead of the default Node.js appearance.
                                                                                           
  Three new files are added under ui/:                                                   

  - WebpackLogo.jsx — replaces the Node.js logo in the navbar with webpack's brand icon
  (using official colors #8ED6FB and #1C78C0)
  - WebpackFooter.jsx — adds a webpack-branded footer with copyright notice, MIT license
  link, and links to GitHub, OpenCollective, and webpack.js.org
  - theme.css — overrides --color-green-* CSS custom properties (used by
  @node-core/ui-components for active nav items and interactive highlights) with webpack's
  blue palette, re-theming the entire site without modifying upstream components

  doc-kit.config.mjs is updated to register these via the web.imports map (#theme/Logo,
  #theme/Footer), which the doc-kit bundler resolves as aliases at build time.

  ---
  What kind of change does this PR introduce?

  feat

  ---
  Did you add tests for your changes?

  No. These are UI/CSS changes — correctness is verified visually by running npm run
  build-html.

  ---
  Does this PR introduce a breaking change?

  No. The web.imports overrides are additive. #theme/Navigation, #theme/Sidebar,
  #theme/Metabar, and #theme/Layout continue to use their built-in defaults and can be
  customized in a follow-up once the full webpack design direction is confirmed.

  ---
  If relevant, what needs to be documented once your changes are merged or what have you
  already documented?

  No documentation changes required. The ui/ directory and the web.imports pattern in
  doc-kit.config.mjs serve as self-documenting examples for future theme contributors.

  ---
  Use of AI

  Claude (claude-sonnet-4-6 via Claude Code CLI) was used to assist with exploring the
  doc-kit component and CSS architecture, understanding which CSS custom properties to
  override, and generating the initial implementations. All generated code was reviewed and
   verified against the installed source before committing, in accordance with the webpack 
  AI policy.