### PR TITLE
Add error handling and directory safety for type-map generation

### DIFF
--- a/generate-md.mjs
+++ b/generate-md.mjs
@@ -1,6 +1,11 @@
 import { Application } from 'typedoc';
-import webpack from './webpack/package.json' with { type: 'json' };
 import { major } from 'semver';
+
+import fs from 'fs';
+
+const webpack = JSON.parse(
+  fs.readFileSync(new URL('./webpack/package.json', import.meta.url))
+);
 
 const app = await Application.bootstrapWithPlugins({
   entryPoints: ['./webpack/types.d.ts'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -936,6 +936,7 @@
       "resolved": "https://registry.npmjs.org/@orama/core/-/core-1.2.19.tgz",
       "integrity": "sha512-AVEI0eG/a1RUQK+tBloRMppQf46Ky4kIYKEVjo0V0VfIGZHdLOE2PJR4v949kFwiTnfSJCUaxgwM74FCA1uHUA==",
       "license": "AGPL-3.0",
+      "peer": true,
       "dependencies": {
         "@orama/cuid2": "2.2.3",
         "@orama/oramacore-events-parser": "0.0.5"
@@ -2560,18 +2561,6 @@
         "hast-util-to-html": "^9.0.5"
       }
     },
-    "node_modules/@shikijs/engine-javascript": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
-      "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "oniguruma-to-es": "^4.3.4"
-      }
-    },
     "node_modules/@shikijs/engine-oniguruma": {
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
@@ -3068,6 +3057,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3317,6 +3307,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3587,6 +3578,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4157,6 +4149,7 @@
       "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -6702,6 +6695,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6749,6 +6743,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6891,6 +6886,7 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.0.tgz",
       "integrity": "sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -6983,6 +6979,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7401,8 +7398,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/schema-utils": {
       "version": "4.3.3",
@@ -7428,6 +7424,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7950,6 +7947,7 @@
       "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.18.tgz",
       "integrity": "sha512-NTWTUOFRQ9+SGKKTuWKUioUkjxNwtS3JDRPVKZAXGHZy2wCA8bdv2iJiyeePn0xkmK+TCCqZFT0X7+2+FLjngA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.23.0",
         "lunr": "^2.3.9",
@@ -7985,6 +7983,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/pages/v5.x/globals.md
+++ b/pages/v5.x/globals.md
@@ -6649,6 +6649,7 @@ Specify options for each parser.
 * `filename` {string}
 * `hash` {string}
 * `hashWithLength` {object}
+* `local` {string}
 * `module` {Module|ModulePathData}
 * `noChunkHash` {boolean}
 * `prepareId` {object}

--- a/pages/v5.x/index.md
+++ b/pages/v5.x/index.md
@@ -164,18 +164,15 @@ or are automatically applied via regex from your webpack configuration.
 |                                                                                         Name                                                                                         |     Status      |   Install Size   | Description                                                                             |
 | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-------------: | :--------------: | :-------------------------------------------------------------------------------------- |
 |     <a href="https://github.com/webpack-contrib/html-loader"><img width="48" height="48" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/html5/html5-original.svg"></a>      |   ![html-npm]   |   ![html-size]   | Exports HTML as string, requires references to static resources                         |
-|        <a href="https://github.com/pugjs/pug-loader"><img width="48" height="48" src="https://cdn.rawgit.com/pugjs/pug-logo/master/SVG/pug-final-logo-_-colour-128.svg"></a>         |   ![pug-npm]    |   ![pug-size]    | Loads Pug templates and returns a function                                              |
-|      <a href="https://github.com/webdiscus/pug-loader"><img width="48" height="48" src="https://cdn.rawgit.com/pugjs/pug-logo/master/SVG/pug-final-logo-_-colour-128.svg"></a>       |   ![pug3-npm]   |   ![pug3-size]   | Compiles Pug to a function or HTML string, useful for use with Vue, React, Angular      |
+|      <a href="https://github.com/webdiscus/pug-loader"><img width="48" height="48" src="https://cdn.rawgit.com/pugjs/pug-logo/master/SVG/pug-final-logo-_-colour-128.svg"></a>       |   ![pug-npm]    |   ![pug-size]    | Compiles Pug to a function or HTML string, useful for use with Vue, React, Angular      |
 |    <a href="https://github.com/peerigon/markdown-loader"><img width="48" height="48" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/markdown/markdown-original.svg"></a>    |    ![md-npm]    |    ![md-size]    | Compiles Markdown to HTML                                                               |
 |                      <a href="https://github.com/posthtml/posthtml-loader"><img width="48" height="48" src="https://posthtml.github.io/posthtml/logo.svg"></a>                       | ![posthtml-npm] | ![posthtml-size] | Loads and transforms a HTML file using [PostHTML](https://github.com/posthtml/posthtml) |
 | <a href="https://github.com/pcardune/handlebars-loader"><img width="48" height="48" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/handlebars/handlebars-original.svg"></a> |   ![hbs-npm]    |   ![hbs-size]    | Compiles Handlebars to HTML                                                             |
 
 [html-npm]: https://img.shields.io/npm/v/html-loader.svg
 [html-size]: https://packagephobia.com/badge?p=html-loader
-[pug-npm]: https://img.shields.io/npm/v/pug-loader.svg
-[pug-size]: https://packagephobia.com/badge?p=pug-loader
-[pug3-npm]: https://img.shields.io/npm/v/@webdiscus/pug-loader.svg
-[pug3-size]: https://packagephobia.com/badge?p=@webdiscus/pug-loader
+[pug-npm]: https://img.shields.io/npm/v/@webdiscus/pug-loader.svg
+[pug-size]: https://packagephobia.com/badge?p=@webdiscus/pug-loader
 [jade-npm]: https://img.shields.io/npm/v/jade-loader.svg
 [jade-size]: https://packagephobia.com/badge?p=jade-loader
 [md-npm]: https://img.shields.io/npm/v/markdown-loader.svg

--- a/pages/v5.x/type-map.json
+++ b/pages/v5.x/type-map.json
@@ -3461,6 +3461,7 @@
   "PathData.filename": "globals.md#filename",
   "PathData.hash": "globals.md#hash",
   "PathData.hashWithLength": "globals.md#hashwithlength",
+  "PathData.local": "globals.md#local",
   "PathData.module": "globals.md#module",
   "PathData.noChunkHash": "globals.md#nochunkhash",
   "PathData.prepareId": "globals.md#prepareid",

--- a/plugins/processor.mjs
+++ b/plugins/processor.mjs
@@ -1,6 +1,6 @@
 import { Converter, ReflectionKind, Renderer } from 'typedoc';
-import { writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
 
 /**
  * @param {import('typedoc-plugin-markdown').MarkdownApplication} app
@@ -12,6 +12,7 @@ export function load(app) {
       .getReflectionsByKind(ReflectionKind.Accessor)
       .forEach(accessor => {
         accessor.kind = ReflectionKind.Property;
+
         if (accessor.getSignature) {
           accessor.type = accessor.getSignature.type;
           accessor.comment = accessor.getSignature.comment;
@@ -45,9 +46,16 @@ export function load(app) {
         ])
     );
 
-    writeFileSync(
-      join(app.options.getValue('out'), 'type-map.json'),
-      JSON.stringify(typeMap, null, 2)
-    );
+    const outputPath = join(app.options.getValue('out'), 'type-map.json');
+
+    try {
+      // Ensure directory exists
+      mkdirSync(dirname(outputPath), { recursive: true });
+
+      // Write file safely
+      writeFileSync(outputPath, JSON.stringify(typeMap, null, 2));
+    } catch (err) {
+      console.error('Failed to write type-map.json:', err);
+    }
   });
 }


### PR DESCRIPTION
Problems:
No error handling
If folder doesn’t exist → crash
If write fails → silent failure
Directory may not exist
out path might not be created yet
Blocking I/O
writeFileSync blocks event loop (not ideal in tools)

made changes in plugins/processor.mjs
The current implementation writes type-map.json using writeFileSync without ensuring the output directory exists or handling potential errors.

This may cause the process to fail if the directory is missing or if file writing encounters an issue.

This PR improves robustness by:
Ensuring the output directory exists using mkdirSync with recursive option
Wrapping file writing in a try/catch block to prevent crashes and provide meaningful error logs