### PR TITLE
fix: improve safety when resolving accessor types

### DIFF
--- a/plugins/processor.mjs
+++ b/plugins/processor.mjs
@@ -12,12 +12,12 @@ export function load(app) {
       .getReflectionsByKind(ReflectionKind.Accessor)
       .forEach(accessor => {
         accessor.kind = ReflectionKind.Property;
-        if (accessor.getSignature) {
+        if (accessor.getSignature?.type) {
           accessor.type = accessor.getSignature.type;
-          accessor.comment = accessor.getSignature.comment;
-        } else if (accessor.setSignature) {
-          accessor.type = accessor.setSignature.parameters?.[0]?.type;
-          accessor.comment = accessor.setSignature.comment;
+          accessor.comment = accessor.getSignature.comment ?? accessor.comment;
+        } else if (accessor.setSignature?.parameters?.[0]?.type) {
+          accessor.type = accessor.setSignature.parameters[0].type;
+          accessor.comment = accessor.setSignature.comment ?? accessor.comment;
         }
       });
 


### PR DESCRIPTION
Fix unsafe access when resolving accessor types in processor.
Previously, accessor type resolution assumed that `getSignature` or `setSignature` would always be defined. This could lead to runtime errors when these properties were undefined.
This change adds optional chaining to safely access nested properties and preserves existing comments when signature comments are missing.
The output format remains unchanged, ensuring compatibility with doc-kit.