### PR TITLE
docs: update README to reflect Vercel deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Automated TypeScript API documentation generator for [webpack](https://github.co
 2. Custom plugins process the output (namespace merging, type mapping, themed rendering)
 3. **@node-core/doc-kit** converts Markdown to HTML
 4. GitHub Actions deploys the result to GitHub Pages
+5. Vercel provides live preview deployments for every pull request
 
 ### Webpack Version Tracking
 
@@ -33,6 +34,7 @@ This ensures documentation stays in sync with upstream webpack without manual in
 │   ├── deploy.yml            # Build HTML + deploy to GitHub Pages
 │   └── sync.yml              # Daily webpack sync
 └── package.json
+├── vercel.json              # Vercel deployment configuration
 ```
 
 ## Scripts


### PR DESCRIPTION
**Summary**
PR #79 adds vercel.json for Vercel deployment support.
This PR updates the README to:
- Mention Vercel preview deployments in "How It Works"
- Add vercel.json to the Project Structure tree

**What kind of change does this PR introduce?**
Documentation update

**Did you add tests for your changes?**
No — documentation only

**Does this PR introduce a breaking change?**
No

**Use of AI**
No AI was used for this change