### PR TITLE
fix(processor): preserve existing comment as fallback for accessor signatures

### DIFF
--- a/plugins/processor.mjs
+++ b/plugins/processor.mjs
@@ -13,12 +13,12 @@ export function load(app) {
       .forEach(accessor => {
         accessor.kind = ReflectionKind.Property;
         if (accessor.getSignature) {
-          accessor.type = accessor.getSignature.type;
-          accessor.comment = accessor.getSignature.comment;
-        } else if (accessor.setSignature) {
-          accessor.type = accessor.setSignature.parameters?.[0]?.type;
-          accessor.comment = accessor.setSignature.comment;
-        }
+  accessor.type = accessor.getSignature.type;
+  accessor.comment = accessor.getSignature.comment ?? accessor.comment;
+} else if (accessor.setSignature) {
+  accessor.type = accessor.setSignature.parameters?.[0]?.type;
+  accessor.comment = accessor.setSignature.comment ?? accessor.comment;
+}
       });
 
     // Remove re-exports

--- a/plugins/processor.mjs
+++ b/plugins/processor.mjs
@@ -13,12 +13,12 @@ export function load(app) {
       .forEach(accessor => {
         accessor.kind = ReflectionKind.Property;
         if (accessor.getSignature) {
-  accessor.type = accessor.getSignature.type;
-  accessor.comment = accessor.getSignature.comment ?? accessor.comment;
-} else if (accessor.setSignature) {
-  accessor.type = accessor.setSignature.parameters?.[0]?.type;
-  accessor.comment = accessor.setSignature.comment ?? accessor.comment;
-}
+          accessor.type = accessor.getSignature.type;
+          accessor.comment = accessor.getSignature.comment ?? accessor.comment;
+        } else if (accessor.setSignature) {
+          accessor.type = accessor.setSignature.parameters?.[0]?.type;
+          accessor.comment = accessor.setSignature.comment ?? accessor.comment;
+        }
       });
 
     // Remove re-exports


### PR DESCRIPTION
**Summary**

When resolving accessor types in processor.mjs, the existing 
comment on the accessor was being unconditionally overwritten 
by the signature comment — even when the signature comment 
was undefined or empty.

This PR uses nullish coalescing (`??`) to fall back to the 
existing `accessor.comment` when the signature comment is 
missing, preserving any previously set comment.

This is a minimal, targeted improvement that avoids adding 
unnecessary optional chaining on `getSignature` or 
`setSignature` themselves — since as noted in #71, these 
will always be defined when the reflection kind is Accessor.

Relates to: #71

**What kind of change does this PR introduce?**
Bug fix — prevents accidental comment loss during 
accessor type resolution

**Did you add tests for your changes?**
No

**Does this PR introduce a breaking change?**
No

**Use of AI**
No AI was used for this change