### PR TITLE
fix(typedoc): add spaces in generics to prevent markdown HTML parsing

### DIFF
--- a/plugins/theme/partials/types.mjs
+++ b/plugins/theme/partials/types.mjs
@@ -8,7 +8,7 @@ const resolve = type => {
     case 'intrinsic':
     case 'reference': {
       const args = type.typeArguments?.length
-        ? `<${type.typeArguments.map(resolve).join(', ')}>`
+        ? `< ${type.typeArguments.map(resolve).join(', ')} >`
         : '';
       return type.name + args;
     }
@@ -22,7 +22,7 @@ const resolve = type => {
       return resolve(type.elementType) + '[]';
 
     case 'tuple':
-      return `Tuple<${union(type.elements, ', ')}>`;
+      return `Tuple< ${union(type.elements, ', ')} >`;
 
     case 'union':
     case 'intersection':


### PR DESCRIPTION
Added spaces inside angle brackets for generic types (e.g., `< Type >`), and the `doc-kit` will remove them. This standard workaround prevents markdown parsers (remark from `doc-kit`) from falsely interpreting these types as raw HTML tags and stripping them from the AST.

**Before**:
<img width="1023" height="62" alt="Screenshot from 2026-05-30 15-34-09" src="https://github.com/user-attachments/assets/ffe06bf5-4b62-46ad-ba06-f07d73b6b54c" />

**After**:
<img width="1022" height="48" alt="Screenshot from 2026-05-30 15-36-15" src="https://github.com/user-attachments/assets/19aae135-a64b-4ed3-b2f0-f12023938c4b" />
