### PR TITLE
fix(theme): preserve syntax in multi-line stability indicators

### DIFF
--- a/plugins/theme/helpers/index.mjs
+++ b/plugins/theme/helpers/index.mjs
@@ -11,7 +11,7 @@ const formatStability = (ctx, level, tag) => {
     ? ctx.helpers.getCommentParts(tag.content).trim()
     : '';
   return message
-    ? `> Stability: ${level}: ${message}`
+    ? `> Stability: ${level}: ${message.replace(/\n/g, '\n> ')}`
     : `> Stability: ${level}`;
 };
 


### PR DESCRIPTION
**Summary**

According to the `doc-kit` [specification](https://github.com/nodejs/doc-kit/blob/75e291ab45e33e1ab8767a5ab00db9412a2fcd53/docs/specification.md?plain=1#L803) for Stability Indicators (**Section 7.4. Multi-Line Indicators**):

**The description MAY continue on subsequent blockquote lines.**

This PR fixes a markdown generation issue where multi-line JSDoc tags (such as `@deprecated` or `@legacy`) would break the formatting when rendered as stability indicators.
