### PR TITLE
feat: add governance docs fetcher under pages/contribute/governance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ out
 /pages/loaders
 /pages/plugins
 /generated
-/pages/contribute/governance
+/pages/about/governance

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ out
 /pages/loaders
 /pages/plugins
 /generated
+/pages/contribute/governance

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build:md": "npm-run-all build:md:*",
     "build:md:api": "node scripts/markdown/api.mjs",
     "build:md:readmes": "node scripts/markdown/readmes.mjs",
+    "build:md:governance": "node scripts/markdown/governance.mjs",
     "build:html": "node scripts/html/index.mjs",
     "build": "npm-run-all build:*",
     "lint": "npm-run-all \"lint:!(fix)\"",

--- a/pages/site.mjs
+++ b/pages/site.mjs
@@ -1,7 +1,7 @@
 import { sidebar as _sidebar } from './site.json' with { type: 'json' };
 import loaders from './loaders/site.json' with { type: 'json' };
 import plugins from './plugins/site.json' with { type: 'json' };
-import contribute from './contribute/governance/site.json' with { type: 'json' };
+import contribute from './about/governance/site.json' with { type: 'json' };
 
 export * from './site.json' with { type: 'json' };
 
@@ -11,5 +11,8 @@ export const sidebar = [
     groupName: 'Loaders & Plugins',
     items: [...loaders.sidebar, ...plugins.sidebar],
   },
-  ...contribute.sidebar,
+  {
+    groupName: 'About',
+    items: contribute.sidebar,
+  },
 ];

--- a/pages/site.mjs
+++ b/pages/site.mjs
@@ -1,6 +1,7 @@
 import { sidebar as _sidebar } from './site.json' with { type: 'json' };
 import loaders from './loaders/site.json' with { type: 'json' };
 import plugins from './plugins/site.json' with { type: 'json' };
+import contribute from './contribute/governance/site.json' with { type: 'json' };
 
 export * from './site.json' with { type: 'json' };
 
@@ -10,4 +11,5 @@ export const sidebar = [
     groupName: 'Loaders & Plugins',
     items: [...loaders.sidebar, ...plugins.sidebar],
   },
+  ...contribute.sidebar,
 ];

--- a/scripts/markdown/governance.mjs
+++ b/scripts/markdown/governance.mjs
@@ -76,7 +76,7 @@ const fetched = results.filter(Boolean);
 const siteJson = {
   sidebar: [
     {
-      groupName: 'Governance',
+      label: 'Governance',
       items: fetched.map(({ output, label }) => ({
         link: `/about/governance/${output}`,
         label,

--- a/scripts/markdown/governance.mjs
+++ b/scripts/markdown/governance.mjs
@@ -1,0 +1,95 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const { GH_TOKEN } = process.env;
+
+const BASE_HEADERS = {
+  ...(GH_TOKEN && { Authorization: `Bearer ${GH_TOKEN}` }),
+};
+
+// Maps source filenames in webpack/governance repo to their output slug and sidebar label.
+// Insertion order determines sidebar order, this could be changed as per need.
+const FILE_MAP = {
+  'README.md': { output: 'governance-overview', label: 'Governance Overview' },
+  'CHARTER.md': { output: 'charter', label: 'Charter' },
+  'MEMBER_EXPECTATIONS.md': {
+    output: 'member-expectations',
+    label: 'Member Expectations',
+  },
+  'MODERATION_POLICY.md': {
+    output: 'moderation-policy',
+    label: 'Moderation Policy',
+  },
+  'WORKING_GROUPS.md': { output: 'working-groups', label: 'Working Groups' },
+  'AI_POLICY.md': { output: 'ai-policy', label: 'AI Policy' },
+};
+
+// Derived from FILE_MAP - stays in sync automatically if entries are added/removed.
+const LINK_REWRITE_MAP = Object.fromEntries(
+  Object.entries(FILE_MAP).map(([source, { output }]) => [
+    source,
+    `/contribute/governance/${output}`,
+  ])
+);
+
+// Rewrites relative cross-references between governance docs.
+// Covers both inline [text](./FILE.md) and reference-style [label]: ./FILE.md.
+// Negative lookaheads prevent rewriting absolute URLs that happen to end in a known filename.
+const rewriteLinks = content =>
+  content.replace(
+    /(\]\(|\]:\s*)(?!https?:\/\/)(?!\/)(\.\/)?([A-Z_]+\.md)/g,
+    (match, prefix, _dot, filename) =>
+      LINK_REWRITE_MAP[filename]
+        ? `${prefix}${LINK_REWRITE_MAP[filename]}`
+        : match
+  );
+
+const outputDir = join(
+  import.meta.dirname,
+  '..',
+  '..',
+  'pages',
+  'contribute',
+  'governance'
+);
+await mkdir(outputDir, { recursive: true });
+
+const results = await Promise.all(
+  Object.entries(FILE_MAP).map(async ([source, { output, label }]) => {
+    const url = `https://raw.githubusercontent.com/webpack/governance/HEAD/${source}`;
+    const res = await fetch(url, { headers: BASE_HEADERS });
+
+    if (!res.ok) {
+      console.error(`Failed: ${source} -> ${res.status} ${res.statusText}`);
+      return null;
+    }
+
+    const content = `---\nsource: ${url}\n---\n\n${rewriteLinks(await res.text())}`;
+    await writeFile(join(outputDir, `${output}.md`), content, 'utf8');
+    console.log(`Fetched: ${source} -> ${output}.md`);
+    return { output, label };
+  })
+);
+
+const fetched = results.filter(Boolean);
+
+const siteJson = {
+  sidebar: [
+    {
+      groupName: 'Governance',
+      items: fetched.map(({ output, label }) => ({
+        link: `/contribute/governance/${output}`,
+        label,
+      })),
+    },
+  ],
+};
+
+await writeFile(
+  join(outputDir, 'site.json'),
+  JSON.stringify(siteJson, null, 2) + '\n',
+  'utf8'
+);
+console.log(
+  `Written: pages/contribute/governance/site.json (${fetched.length} pages)`
+);

--- a/scripts/markdown/governance.mjs
+++ b/scripts/markdown/governance.mjs
@@ -10,7 +10,7 @@ const BASE_HEADERS = {
 // Maps source filenames in webpack/governance repo to their output slug and sidebar label.
 // Insertion order determines sidebar order, this could be changed as per need.
 const FILE_MAP = {
-  'README.md': { output: 'governance-overview', label: 'Governance Overview' },
+  'README.md': { output: 'index', label: 'Governance Overview' },
   'CHARTER.md': { output: 'charter', label: 'Charter' },
   'MEMBER_EXPECTATIONS.md': {
     output: 'member-expectations',

--- a/scripts/markdown/governance.mjs
+++ b/scripts/markdown/governance.mjs
@@ -28,7 +28,7 @@ const FILE_MAP = {
 const LINK_REWRITE_MAP = Object.fromEntries(
   Object.entries(FILE_MAP).map(([source, { output }]) => [
     source,
-    `/contribute/governance/${output}`,
+    `/about/governance/${output}`,
   ])
 );
 
@@ -49,7 +49,7 @@ const outputDir = join(
   '..',
   '..',
   'pages',
-  'contribute',
+  'about',
   'governance'
 );
 await mkdir(outputDir, { recursive: true });
@@ -78,7 +78,7 @@ const siteJson = {
     {
       groupName: 'Governance',
       items: fetched.map(({ output, label }) => ({
-        link: `/contribute/governance/${output}`,
+        link: `/about/governance/${output}`,
         label,
       })),
     },
@@ -91,5 +91,5 @@ await writeFile(
   'utf8'
 );
 console.log(
-  `Written: pages/contribute/governance/site.json (${fetched.length} pages)`
+  `Written: pages/about/governance/site.json (${fetched.length} pages)`
 );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
Adds a script `scripts/markdown/governance.mjs`  that fetches the webpack governance repository's markdown files.

**What kind of change does this PR introduce?**
Automated governance docs fetching.

**Did you add tests for your changes?**
No
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
None
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**
For  Regex  logic and lookaheads 
<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->