### PR TITLE
chore(url): normalize links

### DIFF
--- a/plugins/processor/router.mjs
+++ b/plugins/processor/router.mjs
@@ -5,6 +5,7 @@ import { categoryForReflection } from '../shared/categories.mjs';
 import { getConstructorTitle, getMemberTitle } from '../shared/titles.mjs';
 import { getSourceMetadata, isTypePage } from './metadata.mjs';
 import { createTypePages, TYPE_PAGE_HEADING_KINDS } from './synthetic.mjs';
+import { normalizeLink } from '../shared/urls.mjs';
 
 /**
  * The router owns the public Markdown shape. It keeps one class per file,
@@ -210,7 +211,7 @@ export class DocKitRouter extends MemberRouter {
     const [page, routedAnchor] = fullUrl.split('#');
     const anchor =
       sourceAnchorName(target) ?? routedAnchor ?? this.getAnchor(target);
-    const pageUrl = page.replace(/\.md$/, '.html');
+    const pageUrl = normalizeLink(page);
 
     return anchor ? `${pageUrl}#${anchor}` : pageUrl;
   }
@@ -242,7 +243,7 @@ export class DocKitRouter extends MemberRouter {
     const title = anchorTitle(target, pageTarget);
     const anchor = this.getSlugger(pageTarget).slug(title);
 
-    this.fullUrls.set(target, `${pageUrl.replace(/\.md$/, '.html')}#${anchor}`);
+    this.fullUrls.set(target, `${normalizeLink(pageUrl)}#${anchor}`);
     this.anchors.set(target, anchor);
 
     if (!includeChildren) {

--- a/plugins/processor/site.mjs
+++ b/plugins/processor/site.mjs
@@ -1,20 +1,15 @@
 import { ReflectionKind } from 'typedoc';
 import { CATEGORY_RULES } from '../shared/categories.mjs';
+import { toPublicLink } from '../shared/urls.mjs';
 
 const SIDEBAR_KINDS =
   ReflectionKind.Project | ReflectionKind.Namespace | ReflectionKind.Class;
 
-const SIDEBAR_GROUP_NAME = 'API Documentation';
+const SIDEBAR_GROUP_NAME = 'API';
 
 const getFirstAtxHeading = text => text.match(/^#\s+(.+)$/m)?.[1]?.trim();
 
 const getFirstPathSegment = url => url.replace(/^\//, '').split('/')[0];
-
-const toSidebarLink = (url, basePath) => {
-  const path = url.replace(/\.md$/, '').replace(/\/index$/, '');
-  const prefix = basePath ? `/${basePath.replace(/^\/|\/$/g, '')}` : '';
-  return path ? `${prefix}/${path}` : prefix || '/';
-};
 
 const defaultLabelFor = (target, url) => {
   if (url.endsWith('/index.md')) return 'Overview';
@@ -59,7 +54,7 @@ export const sidebar = (router, basePath) => {
     };
 
     group.items.push({
-      link: toSidebarLink(url, basePath),
+      link: toPublicLink(url, basePath),
       label,
     });
 

--- a/plugins/processor/typeMap.mjs
+++ b/plugins/processor/typeMap.mjs
@@ -1,5 +1,6 @@
 import { ReflectionKind } from 'typedoc';
 import { isTypePage } from './metadata.mjs';
+import { normalizeLink } from '../shared/urls.mjs';
 
 const TYPE_MAP_KINDS =
   ReflectionKind.Class |
@@ -23,7 +24,7 @@ export const createTypeMap = router => {
 
     const { name } = target;
     if (!typeMap.has(name)) {
-      typeMap.set(name, router.getAnchoredURL(target));
+      typeMap.set(name, normalizeLink(router.getAnchoredURL(target)));
     }
   }
 

--- a/plugins/shared/urls.mjs
+++ b/plugins/shared/urls.mjs
@@ -1,0 +1,11 @@
+export const normalizeLink = url => {
+  if (!url) return '/';
+
+  return url.replace(/\.(md|html)$/, '').replace(/\/index$/, '') || '/';
+};
+
+export const toPublicLink = (url, publicPath) => {
+  const path = normalizeLink(url);
+  const prefix = publicPath ? `/${publicPath.replace(/^\/|\/$/g, '')}` : '';
+  return path ? `${prefix}/${path}` : prefix || '/';
+};


### PR DESCRIPTION
**Summary**

**Created shared URL utilities (`plugins/shared/urls.mjs`):** 
* Introduced `normalizeLink` to consistently strip extensions (`.md`, `.html`), trailing `/index`, and normalize leading slashes.
* Introduced a unified function `toPublicLink`  that safely merges the `publicPath` with the normalized path.