### PR TITLE
feat: sponsorship & sidebar improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,8 @@ node_modules
 out
 *.generated.*
 /.cache
-/pages/api
-/pages/loaders
-/pages/plugins
+/pages/docs/api
+/pages/docs/loaders
+/pages/docs/plugins
 /generated
 /pages/about/governance

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,8 @@ node_modules
 out
 *.generated.*
 /.cache
-/pages/api
+/pages/docs/api
+/pages/docs/loaders
+/pages/docs/plugins
 versions.json
 /generated

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -2,6 +2,8 @@ node_modules
 out
 *.generated.*
 /.cache
-/pages/api
+/pages/docs/api
+/pages/docs/loaders
+/pages/docs/plugins
 versions.json
 /generated

--- a/components/MetaBar/index.jsx
+++ b/components/MetaBar/index.jsx
@@ -1,0 +1,60 @@
+import MetaBar from '@node-core/ui-components/Containers/MetaBar';
+import AvatarGroup from '@node-core/ui-components/Common/AvatarGroup';
+import GitHubIcon from '@node-core/ui-components/Icons/Social/GitHub';
+
+import { editURL } from '#theme/config';
+import sponsors from '#theme/sponsors' with { type: 'json' };
+import SponsorCard from '../Sponsors/Card/index.jsx';
+
+// Active recurring platinum-tier sponsors, ranked by monthly amount. There are
+// only ever a handful, so the MetaBar features them as full expanded cards.
+const platinumSponsors = sponsors.sponsors.filter(
+  sponsor => sponsor.monthly.tier === 'platinum'
+);
+
+export default ({ metadata, headings = [], readingTime }) => {
+  const editThisPage =
+    metadata.source ?? editURL.replace('{path}', metadata.path);
+  const authors = metadata.authors?.split(',').map(id => ({
+    image: `https://avatars.githubusercontent.com/${id.trim()}`,
+    url: `https://github.com/${id.trim()}`,
+    nickname: id,
+  }));
+
+  return (
+    <MetaBar
+      heading="Table of Contents"
+      headings={{ items: headings }}
+      items={{
+        'Reading Time': readingTime,
+        ...(CLIENT && authors?.length
+          ? {
+              Authors: <AvatarGroup avatars={authors} as="a" limit={5} />,
+            }
+          : {}),
+        Contribute: (
+          <>
+            <GitHubIcon className="fill-neutral-700 dark:fill-neutral-100" />
+            <a href={editThisPage}>Edit this page</a>
+          </>
+        ),
+        ...(platinumSponsors.length
+          ? {
+              'Webpack is proudly supported by': (
+                <div className="flex flex-col gap-3">
+                  {platinumSponsors.map(sponsor => (
+                    <SponsorCard
+                      key={sponsor.slug}
+                      sponsor={sponsor}
+                      size="sm"
+                      metric="monthly"
+                    />
+                  ))}
+                </div>
+              ),
+            }
+          : {}),
+      }}
+    />
+  );
+};

--- a/components/MetaBar/index.jsx
+++ b/components/MetaBar/index.jsx
@@ -55,20 +55,19 @@ export default ({ metadata, headings = [], readingTime }) => {
                       showAmount={false}
                     />
                   ))}
+                  <BaseButton
+                    href={OC_URL}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    kind="primary"
+                    className="no-underline!"
+                  >
+                    Become a sponsor
+                  </BaseButton>
                 </div>
               ),
             }
           : {}),
-        'Support webpack': (
-          <BaseButton
-            href={OC_URL}
-            target="_blank"
-            rel="noreferrer noopener"
-            kind="primary"
-          >
-            Become a sponsor
-          </BaseButton>
-        ),
       }}
     />
   );

--- a/components/MetaBar/index.jsx
+++ b/components/MetaBar/index.jsx
@@ -8,9 +8,9 @@ import SponsorCard from '../Sponsors/Card/index.jsx';
 
 // Active recurring platinum-tier sponsors, ranked by monthly amount. There are
 // only ever a handful, so the MetaBar features them as full expanded cards.
-const platinumSponsors = sponsors.sponsors.filter(
-  sponsor => sponsor.monthly.tier === 'platinum'
-);
+const platinumSponsors = sponsors.sponsors
+  .filter(sponsor => sponsor.monthly.tier === 'platinum')
+  .sort((a, b) => b.monthly.value - a.monthly.value);
 
 export default ({ metadata, headings = [], readingTime }) => {
   const editThisPage =
@@ -40,14 +40,16 @@ export default ({ metadata, headings = [], readingTime }) => {
         ),
         ...(platinumSponsors.length
           ? {
-              'Webpack is proudly supported by': (
-                <div className="flex flex-col gap-3">
+              [platinumSponsors.length > 1
+                ? 'Featured Sponsors'
+                : 'Featured Sponsor']: (
+                <div className="flex w-full flex-col gap-3">
                   {platinumSponsors.map(sponsor => (
                     <SponsorCard
                       key={sponsor.slug}
                       sponsor={sponsor}
                       size="sm"
-                      metric="monthly"
+                      showAmount={false}
                     />
                   ))}
                 </div>

--- a/components/MetaBar/index.jsx
+++ b/components/MetaBar/index.jsx
@@ -7,6 +7,8 @@ import { editURL } from '#theme/config';
 import sponsors from '#theme/sponsors' with { type: 'json' };
 import SponsorCard from '../Sponsors/Card/index.jsx';
 
+import styles from './index.module.css';
+
 const OC_URL = 'https://opencollective.com/webpack';
 
 // Active recurring platinum-tier sponsors, ranked by monthly amount. There are
@@ -46,7 +48,7 @@ export default ({ metadata, headings = [], readingTime }) => {
               [platinumSponsors.length > 1
                 ? 'Featured Sponsors'
                 : 'Featured Sponsor']: (
-                <div className="flex w-full flex-col gap-3">
+                <div className={styles.sponsors}>
                   {platinumSponsors.map(sponsor => (
                     <SponsorCard
                       key={sponsor.slug}
@@ -60,7 +62,7 @@ export default ({ metadata, headings = [], readingTime }) => {
                     target="_blank"
                     rel="noreferrer noopener"
                     kind="primary"
-                    className="no-underline!"
+                    className={styles.becomeSponsor}
                   >
                     Become a sponsor
                   </BaseButton>

--- a/components/MetaBar/index.jsx
+++ b/components/MetaBar/index.jsx
@@ -1,10 +1,13 @@
 import MetaBar from '@node-core/ui-components/Containers/MetaBar';
 import AvatarGroup from '@node-core/ui-components/Common/AvatarGroup';
+import BaseButton from '@node-core/ui-components/Common/BaseButton';
 import GitHubIcon from '@node-core/ui-components/Icons/Social/GitHub';
 
 import { editURL } from '#theme/config';
 import sponsors from '#theme/sponsors' with { type: 'json' };
 import SponsorCard from '../Sponsors/Card/index.jsx';
+
+const OC_URL = 'https://opencollective.com/webpack';
 
 // Active recurring platinum-tier sponsors, ranked by monthly amount. There are
 // only ever a handful, so the MetaBar features them as full expanded cards.
@@ -56,6 +59,16 @@ export default ({ metadata, headings = [], readingTime }) => {
               ),
             }
           : {}),
+        'Support webpack': (
+          <BaseButton
+            href={OC_URL}
+            target="_blank"
+            rel="noreferrer noopener"
+            kind="primary"
+          >
+            Become a sponsor
+          </BaseButton>
+        ),
       }}
     />
   );

--- a/components/MetaBar/index.module.css
+++ b/components/MetaBar/index.module.css
@@ -1,0 +1,12 @@
+@reference "../../styles/index.css";
+
+.sponsors {
+  @apply flex
+    w-full
+    flex-col
+    gap-3;
+}
+
+.becomeSponsor {
+  @apply no-underline!;
+}

--- a/components/SideBar.jsx
+++ b/components/SideBar.jsx
@@ -6,26 +6,28 @@ const redirect = url => (window.location.href = url);
 
 const PrefetchLink = props => <a {...props} rel="prefetch" />;
 
-const pathnameFor = path => path.replace(/\/index$/, '') || '/';
+const pathnameFor = path => {
+  const clean = path.replace(/\/index$/, '');
+  if (!clean) return '/';
+  return clean.startsWith('/') ? clean : `/${clean}`;
+};
 
 const groupsFor = path => {
+  if (Array.isArray(sidebar)) return sidebar;
+
   const segment = path.split('/').filter(Boolean)[0];
-  const matched = sidebar.filter(g => g.groupName.toLowerCase() === segment);
-  return matched.length > 0 ? matched : sidebar;
+  return sidebar[segment] ?? [];
 };
 
 /**
  * Sidebar component for MDX documentation with page navigation.
  */
-export default ({ metadata }) => {
-  const path = pathnameFor(metadata.path);
-  return (
-    <SideBar
-      pathname={path}
-      groups={groupsFor(path)}
-      onSelect={redirect}
-      as={PrefetchLink}
-      title="Navigation"
-    />
-  );
-};
+export default ({ metadata }) => (
+  <SideBar
+    pathname={pathnameFor(metadata.path)}
+    groups={groupsFor(metadata.path)}
+    onSelect={redirect}
+    as={PrefetchLink}
+    title="Navigation"
+  />
+);

--- a/components/Sponsors/Card/index.jsx
+++ b/components/Sponsors/Card/index.jsx
@@ -19,12 +19,14 @@ const amountLabel = (sponsor, metric) =>
  *   sponsor: { name: string, slug: string, imageUrl: string|null, url: string, monthly: { value: number, tier: string|null }, allTime: { value: number, tier: string|null }, description?: string },
  *   size?: 'lg'|'md'|'sm'|'xs',
  *   metric?: 'monthly'|'allTime',
+ *   showAmount?: boolean,
  * }} props
  */
 export default function SponsorCard({
   sponsor,
   size = 'md',
   metric = 'monthly',
+  showAmount = true,
   className,
   ...props
 }) {
@@ -53,7 +55,11 @@ export default function SponsorCard({
           <p className={styles.description}>{sponsor.description}</p>
         )}
         <div className={styles.footer}>
-          <span className={styles.amount}>{amountLabel(sponsor, metric)}</span>
+          {showAmount && (
+            <span className={styles.amount}>
+              {amountLabel(sponsor, metric)}
+            </span>
+          )}
           <span className={styles.visit}>Visit &rarr;</span>
         </div>
       </a>
@@ -72,7 +78,7 @@ export default function SponsorCard({
       </div>
       <span className={styles.body}>
         <span className={styles.name}>{sponsor.name}</span>
-        {size !== 'xs' && (
+        {size !== 'xs' && showAmount && (
           <span className={styles.amount}>{amountLabel(sponsor, metric)}</span>
         )}
       </span>

--- a/components/Sponsors/Card/index.module.css
+++ b/components/Sponsors/Card/index.module.css
@@ -6,7 +6,7 @@
     border
     border-neutral-200
     bg-white
-    no-underline
+    no-underline!
     transition-colors
     duration-150
     hover:border-blue-300
@@ -96,6 +96,7 @@
   @apply ml-auto
     text-xl
     leading-none
+    font-normal
     text-neutral-300
     dark:text-neutral-600;
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,14 @@ export default [
     },
   },
   {
-    ignores: ['node_modules/', 'out/', '.cache/', 'webpack/', 'pages/api'],
+    ignores: [
+      'node_modules/',
+      'out/',
+      '.cache/',
+      'webpack/',
+      'pages/docs/api',
+      'pages/docs/loaders',
+      'pages/docs/plugins',
+    ],
   },
 ];

--- a/layouts/PartialArticle/index.jsx
+++ b/layouts/PartialArticle/index.jsx
@@ -1,0 +1,30 @@
+import NavBar from '../../components/NavBar.jsx';
+import Footer from '../../components/Footer/index.jsx';
+import SideBar from '../../components/SideBar.jsx';
+
+import styles from './index.module.css';
+
+/**
+ * Article shell with a sidebar but no metabar. Mirrors the default Layout's
+ * navigation/sidebar/footer chrome while leaving the main column free for
+ * custom page content (e.g. the Sponsors page).
+ *
+ * @param {{ metadata: object, children: import('preact').ComponentChildren }} props
+ */
+export default function PartialArticle({ metadata, children }) {
+  return (
+    <>
+      <NavBar metadata={metadata} />
+
+      <div className={styles.shell}>
+        <aside className={styles.sidebar}>
+          <SideBar metadata={metadata} />
+        </aside>
+
+        <main className={styles.page}>{children}</main>
+      </div>
+
+      <Footer />
+    </>
+  );
+}

--- a/layouts/PartialArticle/index.module.css
+++ b/layouts/PartialArticle/index.module.css
@@ -1,0 +1,24 @@
+@reference "../../styles/index.css";
+
+.shell {
+  @apply block
+    w-full
+    min-[896px]:grid
+    min-[896px]:grid-cols-[--spacing(56)_1fr];
+}
+
+.sidebar {
+  @apply min-[896px]:sticky
+    min-[896px]:top-0
+    min-[896px]:grid
+    min-[896px]:h-svh
+    min-[896px]:overflow-y-auto;
+}
+
+.page {
+  @apply min-w-0
+    bg-white
+    text-neutral-900
+    dark:bg-neutral-950
+    dark:text-white;
+}

--- a/layouts/Sponsors/index.jsx
+++ b/layouts/Sponsors/index.jsx
@@ -84,7 +84,7 @@ export default function SponsorsLayout({ metadata }) {
             <div className={styles.container}>
               <SectionHeader
                 eyebrow="Our sponsors"
-                title="The organizations behind webpack"
+                title="The organizations supporting webpack"
               />
               <div className={styles.actions}>
                 <BaseButton

--- a/layouts/Sponsors/index.jsx
+++ b/layouts/Sponsors/index.jsx
@@ -2,9 +2,7 @@ import { useState } from 'react';
 
 import BaseButton from '@node-core/ui-components/Common/BaseButton';
 
-import NavBar from '../../components/NavBar.jsx';
-import Footer from '../../components/Footer/index.jsx';
-import SideBar from '../../components/SideBar.jsx';
+import PartialArticle from '../PartialArticle/index.jsx';
 import SectionHeader from '../../components/SectionHeader/index.jsx';
 import SponsorTier from '../../components/Sponsors/Tier/index.jsx';
 import BackerWall from '../../components/Sponsors/BackerWall/index.jsx';
@@ -71,65 +69,53 @@ export default function SponsorsLayout({ metadata }) {
   const buckets = bucketSponsors(data.sponsors, metric);
 
   return (
-    <>
-      <NavBar metadata={metadata} />
-
-      <div className={styles.shell}>
-        <aside className={styles.sidebar}>
-          <SideBar metadata={metadata} />
-        </aside>
-
-        <main className={styles.page}>
-          <section className={styles.sponsorsSection}>
-            <div className={styles.container}>
-              <SectionHeader
-                eyebrow="Our sponsors"
-                title="The organizations supporting webpack"
+    <PartialArticle metadata={metadata}>
+      <section className={styles.sponsorsSection}>
+        <div className={styles.container}>
+          <SectionHeader
+            eyebrow="Our sponsors"
+            title="The organizations supporting webpack"
+          />
+          <div className={styles.actions}>
+            <BaseButton
+              href={OC_URL}
+              target="_blank"
+              rel="noreferrer noopener"
+              kind="primary"
+            >
+              View on Open Collective
+            </BaseButton>
+          </div>
+          <div className={styles.toolbar}>
+            <SortToggle value={metric} onChange={setMetric} />
+          </div>
+          <div className={styles.tiers}>
+            {TIERS.map(tier => (
+              <SponsorTier
+                key={tier.tier}
+                tier={tier.tier}
+                label={tier.label}
+                price={tier.price[metric]}
+                cardSize={tier.cardSize}
+                sponsors={buckets[tier.tier]}
+                metric={metric}
               />
-              <div className={styles.actions}>
-                <BaseButton
-                  href={OC_URL}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                  kind="primary"
-                >
-                  View on Open Collective
-                </BaseButton>
-              </div>
-              <div className={styles.toolbar}>
-                <SortToggle value={metric} onChange={setMetric} />
-              </div>
-              <div className={styles.tiers}>
-                {TIERS.map(tier => (
-                  <SponsorTier
-                    key={tier.tier}
-                    tier={tier.tier}
-                    label={tier.label}
-                    price={tier.price[metric]}
-                    cardSize={tier.cardSize}
-                    sponsors={buckets[tier.tier]}
-                    metric={metric}
-                  />
-                ))}
-              </div>
-            </div>
-          </section>
+            ))}
+          </div>
+        </div>
+      </section>
 
-          <section className={styles.backersSection}>
-            <div className={styles.container}>
-              <SectionHeader
-                eyebrow="Our backers"
-                title="And the people who chip in"
-              />
-              <div className={styles.backersBody}>
-                <BackerWall backers={data.backers} />
-              </div>
-            </div>
-          </section>
-        </main>
-      </div>
-
-      <Footer />
-    </>
+      <section className={styles.backersSection}>
+        <div className={styles.container}>
+          <SectionHeader
+            eyebrow="Our backers"
+            title="And the people who chip in"
+          />
+          <div className={styles.backersBody}>
+            <BackerWall backers={data.backers} />
+          </div>
+        </div>
+      </section>
+    </PartialArticle>
   );
 }

--- a/layouts/Sponsors/index.jsx
+++ b/layouts/Sponsors/index.jsx
@@ -4,6 +4,7 @@ import BaseButton from '@node-core/ui-components/Common/BaseButton';
 
 import NavBar from '../../components/NavBar.jsx';
 import Footer from '../../components/Footer/index.jsx';
+import SideBar from '../../components/SideBar.jsx';
 import SectionHeader from '../../components/SectionHeader/index.jsx';
 import SponsorTier from '../../components/Sponsors/Tier/index.jsx';
 import BackerWall from '../../components/Sponsors/BackerWall/index.jsx';
@@ -73,54 +74,60 @@ export default function SponsorsLayout({ metadata }) {
     <>
       <NavBar metadata={metadata} />
 
-      <main className={styles.page}>
-        <section className={styles.sponsorsSection}>
-          <div className={styles.container}>
-            <SectionHeader
-              eyebrow="Our sponsors"
-              title="The organizations behind webpack"
-            />
-            <div className={styles.actions}>
-              <BaseButton
-                href={OC_URL}
-                target="_blank"
-                rel="noreferrer noopener"
-                kind="primary"
-              >
-                View on Open Collective
-              </BaseButton>
-            </div>
-            <div className={styles.toolbar}>
-              <SortToggle value={metric} onChange={setMetric} />
-            </div>
-            <div className={styles.tiers}>
-              {TIERS.map(tier => (
-                <SponsorTier
-                  key={tier.tier}
-                  tier={tier.tier}
-                  label={tier.label}
-                  price={tier.price[metric]}
-                  cardSize={tier.cardSize}
-                  sponsors={buckets[tier.tier]}
-                  metric={metric}
-                />
-              ))}
-            </div>
-          </div>
-        </section>
+      <div className={styles.shell}>
+        <aside className={styles.sidebar}>
+          <SideBar metadata={metadata} />
+        </aside>
 
-        <section className={styles.backersSection}>
-          <div className={styles.container}>
-            <SectionHeader
-              eyebrow="Our backers"
-              title="And the people who chip in"
-            />
-            <div className={styles.backersBody}>
-              <BackerWall backers={data.backers} />
+        <main className={styles.page}>
+          <section className={styles.sponsorsSection}>
+            <div className={styles.container}>
+              <SectionHeader
+                eyebrow="Our sponsors"
+                title="The organizations behind webpack"
+              />
+              <div className={styles.actions}>
+                <BaseButton
+                  href={OC_URL}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  kind="primary"
+                >
+                  View on Open Collective
+                </BaseButton>
+              </div>
+              <div className={styles.toolbar}>
+                <SortToggle value={metric} onChange={setMetric} />
+              </div>
+              <div className={styles.tiers}>
+                {TIERS.map(tier => (
+                  <SponsorTier
+                    key={tier.tier}
+                    tier={tier.tier}
+                    label={tier.label}
+                    price={tier.price[metric]}
+                    cardSize={tier.cardSize}
+                    sponsors={buckets[tier.tier]}
+                    metric={metric}
+                  />
+                ))}
+              </div>
             </div>
-          </div>
-        </section>
-      </main>
+          </section>
+
+          <section className={styles.backersSection}>
+            <div className={styles.container}>
+              <SectionHeader
+                eyebrow="Our backers"
+                title="And the people who chip in"
+              />
+              <div className={styles.backersBody}>
+                <BackerWall backers={data.backers} />
+              </div>
+            </div>
+          </section>
+        </main>
+      </div>
 
       <Footer />
     </>

--- a/layouts/Sponsors/index.module.css
+++ b/layouts/Sponsors/index.module.css
@@ -1,7 +1,22 @@
 @reference "../../styles/index.css";
 
+.shell {
+  @apply block
+    w-full
+    min-[896px]:grid
+    min-[896px]:grid-cols-[--spacing(56)_1fr];
+}
+
+.sidebar {
+  @apply min-[896px]:sticky
+    min-[896px]:top-0
+    min-[896px]:h-svh
+    min-[896px]:overflow-y-auto;
+}
+
 .page {
-  @apply bg-white
+  @apply min-w-0
+    bg-white
     text-neutral-900
     dark:bg-neutral-950
     dark:text-white;

--- a/layouts/Sponsors/index.module.css
+++ b/layouts/Sponsors/index.module.css
@@ -1,28 +1,5 @@
 @reference "../../styles/index.css";
 
-.shell {
-  @apply block
-    w-full
-    min-[896px]:grid
-    min-[896px]:grid-cols-[--spacing(56)_1fr];
-}
-
-.sidebar {
-  @apply min-[896px]:sticky
-    min-[896px]:top-0
-    min-[896px]:grid
-    min-[896px]:h-svh
-    min-[896px]:overflow-y-auto;
-}
-
-.page {
-  @apply min-w-0
-    bg-white
-    text-neutral-900
-    dark:bg-neutral-950
-    dark:text-white;
-}
-
 .container {
   @apply mx-auto
     max-w-7xl

--- a/layouts/Sponsors/index.module.css
+++ b/layouts/Sponsors/index.module.css
@@ -10,6 +10,7 @@
 .sidebar {
   @apply min-[896px]:sticky
     min-[896px]:top-0
+    min-[896px]:grid
     min-[896px]:h-svh
     min-[896px]:overflow-y-auto;
 }

--- a/pages/about/branding.md
+++ b/pages/about/branding.md
@@ -1,3 +1,7 @@
+---
+authors: avivkeller
+---
+
 # Branding of webpack
 
 Here you can find **webpack** project brand guidelines and assets. Official artwork is maintained in the OpenJS Foundation [artwork repository](https://github.com/openjs-foundation/artwork/tree/main/projects/webpack).

--- a/pages/about/index.md
+++ b/pages/about/index.md
@@ -1,0 +1,3 @@
+# About webpack
+
+STUB

--- a/pages/docs/index.md
+++ b/pages/docs/index.md
@@ -1,0 +1,3 @@
+# Documentation
+
+STUB

--- a/pages/site.json
+++ b/pages/site.json
@@ -13,8 +13,8 @@
       "text": "Blog"
     },
     {
-      "link": "/api/v5.x",
-      "text": "API"
+      "link": "/docs",
+      "text": "Docs"
     },
     {
       "link": "/about/sponsors",
@@ -26,7 +26,6 @@
       "target": "_blank"
     }
   ],
-  "sidebar": [],
   "footer": {
     "socialLinks": [
       {
@@ -55,20 +54,16 @@
             "link": "/guides/getting-started"
           },
           {
+            "text": "Concepts",
+            "link": "/guides/getting-started/concepts"
+          },
+          {
             "text": "Guides",
             "link": "/guides"
           },
           {
-            "text": "Concepts",
-            "link": "/concepts"
-          },
-          {
-            "text": "Configuration",
-            "link": "/configuration"
-          },
-          {
             "text": "API",
-            "link": "/api/v5.x"
+            "link": "/docs/api/v5.x"
           }
         ]
       },
@@ -77,11 +72,11 @@
         "links": [
           {
             "text": "Loaders",
-            "link": "/loaders"
+            "link": "/docs/loaders"
           },
           {
             "text": "Plugins",
-            "link": "/plugins"
+            "link": "/docs/plugins"
           },
           {
             "text": "Awesome webpack",

--- a/pages/site.mjs
+++ b/pages/site.mjs
@@ -1,18 +1,40 @@
-import { sidebar as _sidebar } from './site.json' with { type: 'json' };
-import loaders from './loaders/site.json' with { type: 'json' };
-import plugins from './plugins/site.json' with { type: 'json' };
-import contribute from './about/governance/site.json' with { type: 'json' };
+import loaders from './docs/loaders/site.json' with { type: 'json' };
+import plugins from './docs/plugins/site.json' with { type: 'json' };
+import governance from './about/governance/site.json' with { type: 'json' };
+import versions from '../versions.json' with { type: 'json' };
+import { major } from 'semver';
 
 export * from './site.json' with { type: 'json' };
 
-export const sidebar = [
-  ..._sidebar,
-  {
-    groupName: 'Loaders & Plugins',
-    items: [...loaders.sidebar, ...plugins.sidebar],
-  },
-  {
-    groupName: 'About',
-    items: contribute.sidebar,
-  },
-];
+export const sidebar = {
+  about: [
+    {
+      groupName: 'Get Involved',
+      items: [
+        { link: '/about/branding', label: 'Branding' },
+        { link: '/about/sponsors', label: 'Sponsors' },
+        {
+          link: 'https://github.com/webpack/webpack/blob/main/CONTRIBUTING.md',
+          label: 'Contribute',
+        },
+      ],
+    },
+    ...governance.sidebar,
+  ],
+  docs: [
+    {
+      groupName: 'Main Packages',
+      items: [
+        {
+          label: 'webpack',
+          items: versions.map(v => ({
+            label: `webpack ${v}`,
+            link: `/docs/api/v${major(v)}.x`,
+          })),
+        },
+      ],
+    },
+    ...loaders.sidebar,
+    ...plugins.sidebar,
+  ],
+};

--- a/scripts/html/doc-kit.config.mjs
+++ b/scripts/html/doc-kit.config.mjs
@@ -8,7 +8,7 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
 const VERSION = process.env.VERSION;
 const MAJOR_VERSION = VERSION ? `v${major(VERSION)}.x` : undefined;
-const URL_PATH = VERSION ? `/api/${MAJOR_VERSION}` : '/';
+const URL_PATH = VERSION ? `/docs/api/${MAJOR_VERSION}` : '/';
 
 const ORIGIN = process.env.VERCEL_URL
   ? `https://${process.env.VERCEL_URL}`
@@ -29,8 +29,8 @@ export default {
     repository: 'webpack/webpack',
     version: VERSION,
     input: [`${INPUT_DIR}/**/*.md`],
-    ignore: VERSION ? [] : ['./pages/api/**/*.md'],
-    output: VERSION ? `./out/api/${MAJOR_VERSION}` : './out',
+    ignore: VERSION ? [] : ['./pages/docs/api/**/*.md'],
+    output: VERSION ? `./out/docs/api/${MAJOR_VERSION}` : './out',
     baseURL: BASE_URL,
   },
   threads: 1,
@@ -46,6 +46,8 @@ export default {
     useAbsoluteURLs: true,
     remoteConfigUrl: null,
     title: VERSION ? `Webpack ${MAJOR_VERSION} Documentation` : 'Webpack',
+    editURL:
+      'https://github.com/webpack/webpack-doc-kit/blob/main/pages/{path}.md',
     head: {
       meta: [
         {
@@ -72,6 +74,7 @@ export default {
       '#theme/site': SITE_MODULE,
 
       '#theme/Sidebar': join(ROOT, 'components/SideBar.jsx'),
+      '#theme/Metabar': join(ROOT, 'components/MetaBar/index.jsx'),
       '#theme/sponsors': join(ROOT, 'generated/sponsors.json'),
       '#theme/Layout': join(ROOT, 'components/Layout.jsx'),
       '#theme/Navigation': join(ROOT, 'components/NavBar.jsx'),

--- a/scripts/markdown/api.mjs
+++ b/scripts/markdown/api.mjs
@@ -12,7 +12,7 @@ const generate = async packageDir => {
 
   const app = await Application.bootstrapWithPlugins({
     entryPoints: [join(packageDir, 'types.d.ts')],
-    out: join('pages', 'api', `v${major(version)}.x`),
+    out: join('pages', 'docs', 'api', `v${major(version)}.x`),
     publicPath: `/api/v${major(version)}.x/`,
 
     plugin: [

--- a/scripts/markdown/governance.mjs
+++ b/scripts/markdown/governance.mjs
@@ -10,7 +10,7 @@ const BASE_HEADERS = {
 // Maps source filenames in webpack/governance repo to their output slug and sidebar label.
 // Insertion order determines sidebar order, this could be changed as per need.
 const FILE_MAP = {
-  'README.md': { output: 'index', label: 'Governance Overview' },
+  'README.md': { output: 'index', label: 'Overview' },
   'CHARTER.md': { output: 'charter', label: 'Charter' },
   'MEMBER_EXPECTATIONS.md': {
     output: 'member-expectations',
@@ -64,7 +64,13 @@ const results = await Promise.all(
       return null;
     }
 
-    const content = `---\nsource: ${url}\n---\n\n${rewriteLinks(await res.text())}`;
+    let body = rewriteLinks(await res.text());
+
+    // Some governance docs (e.g. MEMBER_EXPECTATIONS.md) have no H1, which the
+    // site derives the page title from — fall back to the sidebar label.
+    if (!/^# /m.test(body)) body = `# ${label}\n\n${body}`;
+
+    const content = `---\nsource: ${url}\n---\n\n${body}`;
     await writeFile(join(outputDir, `${output}.md`), content, 'utf8');
     console.log(`Fetched: ${source} -> ${output}.md`);
     return { output, label };

--- a/scripts/markdown/governance.mjs
+++ b/scripts/markdown/governance.mjs
@@ -76,7 +76,7 @@ const fetched = results.filter(Boolean);
 const siteJson = {
   sidebar: [
     {
-      label: 'Governance',
+      groupName: 'Governance',
       items: fetched.map(({ output, label }) => ({
         link: `/about/governance/${output}`,
         label,

--- a/scripts/markdown/readmes.mjs
+++ b/scripts/markdown/readmes.mjs
@@ -75,10 +75,10 @@ const processRepos = async (repos, { label, basePath, outputDir }) => {
   const siteJson = {
     sidebar: [
       {
-        label,
+        groupName: label,
         items: fetched.map(name => ({
           link: `${basePath}/${name}`,
-          label: name.replace(/-(?:loader|plugin)$/, ''),
+          label: name.replace(/-(?:webpack-)?(?:loader|plugin)$/, ''),
         })),
       },
     ],
@@ -102,14 +102,14 @@ await Promise.all(
     runLoaders &&
       processRepos(loaders, {
         label: 'Loaders',
-        basePath: '/loaders',
-        outputDir: join(root, 'pages/loaders'),
+        basePath: '/docs/loaders',
+        outputDir: join(root, 'pages/docs/loaders'),
       }),
     runPlugins &&
       processRepos(plugins, {
         label: 'Plugins',
-        basePath: '/plugins',
-        outputDir: join(root, 'pages/plugins'),
+        basePath: '/docs/plugins',
+        outputDir: join(root, 'pages/docs/plugins'),
       }),
   ].filter(Boolean)
 );


### PR DESCRIPTION
This PR covers three related areas of navigation/UI work:

### MetaBar

- Adds a custom MetaBar (`#theme/Metabar`) showing the table of contents,
  reading time, authors, a **fixed** "Edit this page" link, and a "Featured Sponsor" card for active platinum-tier sponsors, ranked by monthly contribution.

### Sidebar

- Sidebars are now defined per top-level section (`about`, `docs`) in
  `pages/site.mjs` instead of a single global list; `SideBar` picks the group
  set from the first path segment. (As discussed on Discord)
- The sponsors page now renders the sidebar, full-height alongside the content.
- Generated `site.json` files (governance, loaders, plugins) use `groupName`
  to match the sidebar schema, and loader/plugin labels strip
  `-webpack-loader`/`-webpack-plugin` suffixes.
- Governance pages: the overview is labeled "Overview", and docs without an
  H1 (e.g. `MEMBER_EXPECTATIONS.md`) get one derived from their sidebar label.

### Docs

- Generated API/loader/plugin docs move from `/api`, `/loaders`, `/plugins`
  to `/docs/api`, `/docs/loaders`, `/docs/plugins`; the navbar "API" link
  becomes "Docs". Ignore files and lint configs updated to match.

cc @webpack/TSC for the sponsorship UI
