### PR TITLE
fix(theme): format Extends to match doc-kit specification

### DIFF
--- a/plugins/theme/partials/index.mjs
+++ b/plugins/theme/partials/index.mjs
@@ -202,10 +202,11 @@ export default ctx => {
         );
       }
 
-      if (model.typeHierarchy?.next) {
+      if (model.typeHierarchy?.next && !model.typeHierarchy.isTarget) {
         md.push(
-          ctx.partials.hierarchy(model.typeHierarchy, {
-            headingLevel: options.headingLevel,
+          ctx.helpers.typedListItem({
+            label: 'Extends',
+            type: model.typeHierarchy.types[0],
           })
         );
       }


### PR DESCRIPTION
**Summary**

This PR resolves the `Extends` formatting issue mentioned in #132.

The check for `model.typeHierarchy?.next` to ensure that an actual inheritance tree (with at least two levels) exists before attempting to render it, and the `isTarget` flag (the indicator used by TypeDoc to identify the current node being documented) that prevents base classes without parents from incorrectly appearing to inherit from themselves (e.g., preventing `Chunk extends Chunk`).

**Before:**
<img width="1023" height="266" alt="Screenshot from 2026-06-13 07-55-17" src="https://github.com/user-attachments/assets/db514951-bddf-4994-b7aa-1046df9040e8" />

**After:**
<img width="1029" height="224" alt="Screenshot from 2026-06-13 07-54-52" src="https://github.com/user-attachments/assets/e8611a6f-49b7-4113-8894-46e5e86026da" />
