### PR TITLE
feat(processor): auto-map type aliases dynamically

### DIFF
--- a/plugins/processor/typeMap.mjs
+++ b/plugins/processor/typeMap.mjs
@@ -22,9 +22,15 @@ export const createTypeMap = router => {
   for (const target of router.getLinkTargets()) {
     if (!isTypeMapTarget(target)) continue;
 
-    const { name } = target;
+    const { name, escapedName } = target;
+    const url = normalizeLink(router.getAnchoredURL(target));
+
     if (!typeMap.has(name)) {
-      typeMap.set(name, normalizeLink(router.getAnchoredURL(target)));
+      typeMap.set(name, url);
+    }
+
+    if (escapedName && !typeMap.has(escapedName)) {
+      typeMap.set(escapedName, url);
     }
   }
 


### PR DESCRIPTION
**Summary**

This PR resolves mismatches for aliased exports (e.g., `export { CacheClass as Cache }`) issue mentioned in #132.

Implementing dynamic alias resolution in the `typeMap.mjs` by updating `createTypeMap` to use the `escapedName` property from TypeDoc reflections that holds the aliased name (e.g., `CacheClass`), As this property will exist in the exported type if it was aliased.

**Before:**
<img width="1086" height="430" alt="image" src="https://github.com/user-attachments/assets/6523bf9e-1d13-471f-867a-fa0147ea290d" />

**After:**
<img width="1057" height="396" alt="image" src="https://github.com/user-attachments/assets/f41d5b22-9dec-4ee0-ac56-09b81d045774" />
