### PR TITLE
chore: lint jsx components and add ci concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,5 +1,5 @@
 {
-  "**/*.{js,mjs,ts,tsx,md,mdx,json.yml}": [
+  "**/*.{js,mjs,jsx,ts,tsx,md,mdx,json,yml}": [
     "eslint --fix",
     "prettier --check --write"
   ],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,14 @@ export default [
     },
   },
   {
+    files: ['**/*.jsx'],
+    languageOptions: {
+      parserOptions: { ecmaFeatures: { jsx: true } },
+      // SERVER/CLIENT are compile-time defines from doc-kit, not real globals.
+      globals: { ...globals.browser, SERVER: 'readonly', CLIENT: 'readonly' },
+    },
+  },
+  {
     ignores: ['node_modules/', 'out/', '.cache/', 'webpack/', 'pages/api'],
   },
 ];


### PR DESCRIPTION
Summary
Our .jsx components were silently skipped by ESLint, so this lints them and also adds CI concurrency to cancel stale runs.

What kind of change does this PR introduce?
Chore 

Did you add tests for your changes?
No, it's just a tooling config.

Does this PR introduce a breaking change?
No.

If relevant, what needs to be documented once your changes are merged or what have you already documented?
Nothing 

Use of AI
No