### PR TITLE
feat(processor): manually inject frontmatter with source tag

### DIFF
--- a/plugins/processor/index.mjs
+++ b/plugins/processor/index.mjs
@@ -1,4 +1,6 @@
 import { Converter, ReflectionKind, Renderer } from 'typedoc';
+import { MarkdownPageEvent } from 'typedoc-plugin-markdown';
+import { getSourceMetadata } from './metadata.mjs';
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { applyExportEqualsReflections } from './exportEquals.mjs';
@@ -59,6 +61,17 @@ export function load(app) {
 
       internalModule.children = importantTypes;
       project.mergeReflections(internalModule, project);
+    }
+  });
+
+  app.renderer.on(MarkdownPageEvent.END, page => {
+    const sourceMeta = getSourceMetadata(page.model);
+
+    if (sourceMeta && sourceMeta.sourceRelativePath) {
+      const source = `https://github.com/webpack/webpack/blob/main/lib/${sourceMeta.sourceRelativePath}`;
+      const frontmatter = `---\n` + `source: ${source}\n` + `---\n\n`;
+
+      page.contents = frontmatter + page.contents;
     }
   });
 

--- a/plugins/processor/index.mjs
+++ b/plugins/processor/index.mjs
@@ -68,7 +68,7 @@ export function load(app) {
     const sourceMeta = getSourceMetadata(page.model);
 
     if (sourceMeta && sourceMeta.sourceRelativePath) {
-      const source = `https://github.com/webpack/webpack/blob/main/lib/${sourceMeta.sourceRelativePath}`;
+      const source = `https://github.com/webpack/webpack/edit/main/lib/${sourceMeta.sourceRelativePath}`;
       const frontmatter = `---\n` + `source: ${source}\n` + `---\n\n`;
 
       page.contents = frontmatter + page.contents;


### PR DESCRIPTION
**Summary**

This PR adds `source` frontmatter in the API documentation pages, which is a blocker for the "Edit Page" button (#131) as mentioned in #132.

Instead of relying on the `typedoc-plugin-frontmatter`, this implementation manually injects the frontmatter block as a string at the beginning of the markdown content. By using `MarkdownPageEvent.END` hook to access the final markdown string and `sourceRelativePath` to construct the full GitHub repository URL. This approach provides more control over the output and prevents conflicts with `doc-kit`.

**After:**
<img width="779" height="269" alt="image" src="https://github.com/user-attachments/assets/bd86cba0-7963-4ecc-a055-c73255f4fdff" />
