### PR TITLE
feat(blog): implement new blog layout, custom card component, and markdown data pipeline

### DIFF
--- a/assets/blog/cover-1.svg
+++ b/assets/blog/cover-1.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 750" fill="none">
+  <defs>
+    <pattern id="hatch1" width="16" height="16" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+      <line x1="0" y1="0" x2="0" y2="16" stroke="#8ED6FB" stroke-opacity=".10" stroke-width="1" />
+    </pattern>
+  </defs>
+  <rect width="1200" height="750" fill="#0D121C" />
+  <rect width="1200" height="750" fill="url(#hatch1)" />
+  <polygon points="0,750 360,750 0,470" fill="#1C78C0" fill-opacity=".14" />
+  <g transform="translate(560 60) scale(.66)" opacity=".55">
+    <path fill="#8ED6FB" d="M704.9 641.7L399.8 814.3V679.9l190.1-104.6 115 66.4zm20.9-18.9V261.9l-111.6 64.5v232l111.6 64.4zM67.9 641.7L373 814.3V679.9L182.8 575.3 67.9 641.7zM47 622.8V261.9l111.6 64.5v232L47 622.8zm13.1-384.3L373 61.5v129.9L172.5 301.7l-1.6.9-110.8-64.1zm652.6 0l-312.9-177v129.9l200.5 110.2 1.6.9 110.8-64z" />
+    <path fill="#1C78C0" d="M373 649.3L185.4 546.1V341.8L373 450.1v199.2zm26.8 0l187.6-103.1V341.8L399.8 450.1v199.2zm-13.4-207zM198.1 318.2l188.3-103.5 188.3 103.5-188.3 108.7-188.3-108.7z" />
+  </g>
+</svg>

--- a/assets/blog/cover-2.svg
+++ b/assets/blog/cover-2.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 750" fill="none">
+  <defs>
+    <pattern id="hatch2" width="18" height="18" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+      <line x1="0" y1="0" x2="0" y2="18" stroke="#1C78C0" stroke-opacity=".16" stroke-width="1" />
+    </pattern>
+  </defs>
+  <rect width="1200" height="750" fill="#0D121C" />
+  <rect width="1200" height="750" fill="url(#hatch2)" />
+  <polygon points="1200,0 1200,300 980,0" fill="#8ED6FB" fill-opacity=".10" />
+  <g transform="translate(720 120) scale(.5)" opacity=".5">
+    <path fill="#8ED6FB" d="M704.9 641.7L399.8 814.3V679.9l190.1-104.6 115 66.4zm20.9-18.9V261.9l-111.6 64.5v232l111.6 64.4zM67.9 641.7L373 814.3V679.9L182.8 575.3 67.9 641.7zM47 622.8V261.9l111.6 64.5v232L47 622.8zm13.1-384.3L373 61.5v129.9L172.5 301.7l-1.6.9-110.8-64.1zm652.6 0l-312.9-177v129.9l200.5 110.2 1.6.9 110.8-64z" />
+    <path fill="#1C78C0" d="M373 649.3L185.4 546.1V341.8L373 450.1v199.2zm26.8 0l187.6-103.1V341.8L399.8 450.1v199.2zm-13.4-207zM198.1 318.2l188.3-103.5 188.3 103.5-188.3 108.7-188.3-108.7z" />
+  </g>
+</svg>

--- a/assets/blog/cover-3.svg
+++ b/assets/blog/cover-3.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 750" fill="none">
+  <defs>
+    <pattern id="hatch3" width="16" height="16" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+      <line x1="0" y1="0" x2="0" y2="16" stroke="#8ED6FB" stroke-opacity=".09" stroke-width="1" />
+    </pattern>
+  </defs>
+  <rect width="1200" height="750" fill="#0D121C" />
+  <rect width="1200" height="750" fill="#0A2C47" opacity=".3" />
+  <rect width="1200" height="750" fill="url(#hatch3)" />
+  <polygon points="0,0 280,0 0,220" fill="#1C78C0" fill-opacity=".18" />
+  <g transform="translate(520 30) scale(.78)" opacity=".5">
+    <path fill="#8ED6FB" d="M704.9 641.7L399.8 814.3V679.9l190.1-104.6 115 66.4zm20.9-18.9V261.9l-111.6 64.5v232l111.6 64.4zM67.9 641.7L373 814.3V679.9L182.8 575.3 67.9 641.7zM47 622.8V261.9l111.6 64.5v232L47 622.8zm13.1-384.3L373 61.5v129.9L172.5 301.7l-1.6.9-110.8-64.1zm652.6 0l-312.9-177v129.9l200.5 110.2 1.6.9 110.8-64z" />
+    <path fill="#1C78C0" d="M373 649.3L185.4 546.1V341.8L373 450.1v199.2zm26.8 0l187.6-103.1V341.8L399.8 450.1v199.2zm-13.4-207zM198.1 318.2l188.3-103.5 188.3 103.5-188.3 108.7-188.3-108.7z" />
+  </g>
+</svg>

--- a/assets/blog/cover-4.svg
+++ b/assets/blog/cover-4.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 750" fill="none">
+  <defs>
+    <pattern id="hatch4" width="18" height="18" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+      <line x1="0" y1="0" x2="0" y2="18" stroke="#8ED6FB" stroke-opacity=".11" stroke-width="1" />
+    </pattern>
+  </defs>
+  <rect width="1200" height="750" fill="#0D121C" />
+  <rect width="1200" height="750" fill="url(#hatch4)" />
+  <polygon points="0,750 320,750 0,520" fill="#8ED6FB" fill-opacity=".08" />
+  <polygon points="1200,750 1200,540 1020,750" fill="#1C78C0" fill-opacity=".18" />
+  <g transform="translate(800 210) scale(.46)" opacity=".6">
+    <path fill="#8ED6FB" d="M704.9 641.7L399.8 814.3V679.9l190.1-104.6 115 66.4zm20.9-18.9V261.9l-111.6 64.5v232l111.6 64.4zM67.9 641.7L373 814.3V679.9L182.8 575.3 67.9 641.7zM47 622.8V261.9l111.6 64.5v232L47 622.8zm13.1-384.3L373 61.5v129.9L172.5 301.7l-1.6.9-110.8-64.1zm652.6 0l-312.9-177v129.9l200.5 110.2 1.6.9 110.8-64z" />
+    <path fill="#1C78C0" d="M373 649.3L185.4 546.1V341.8L373 450.1v199.2zm26.8 0l187.6-103.1V341.8L399.8 450.1v199.2zm-13.4-207zM198.1 318.2l188.3-103.5 188.3 103.5-188.3 108.7-188.3-108.7z" />
+  </g>
+</svg>

--- a/components/Blog/Byline/index.jsx
+++ b/components/Blog/Byline/index.jsx
@@ -1,0 +1,83 @@
+import classNames from 'classnames';
+import AvatarGroup from '@node-core/ui-components/Common/AvatarGroup';
+import Avatar from '@node-core/ui-components/Common/AvatarGroup/Avatar';
+
+import styles from './index.module.css';
+
+const fullDate = new Intl.DateTimeFormat('en-US', {
+  day: 'numeric',
+  month: 'short',
+  timeZone: 'UTC',
+  year: 'numeric',
+});
+
+const shortDate = new Intl.DateTimeFormat('en-US', {
+  day: 'numeric',
+  month: 'short',
+  timeZone: 'UTC',
+});
+
+/**
+ * ui-components avatar descriptor for a GitHub username. `image` pulls the
+ * profile picture straight from GitHub; `url` is omitted on purpose so the
+ * Avatar renders as a `<div>` rather than an `<a>` (a post card already wraps
+ * the byline in a link, and nested anchors are invalid).
+ */
+const toAvatar = username => ({
+  nickname: username,
+  name: username,
+  image: `https://github.com/${username}.png`,
+  fallback: username.slice(0, 2).toUpperCase(),
+});
+
+/** Readable author label: one name, "A & B", or "A & N others". */
+const authorLabel = authors => {
+  if (authors.length <= 1) return authors[0] ?? 'webpack';
+  if (authors.length === 2) return `${authors[0]} & ${authors[1]}`;
+  return `${authors[0]} & ${authors.length - 1} others`;
+};
+
+/**
+ * GitHub avatar(s) of the post author(s) beside the author name(s) and the
+ * publish date. A single author renders one {@link Avatar}; several render an
+ * {@link AvatarGroup}. `size="md"` stacks the name above the date (featured
+ * card); `size="sm"` is a compact inline row (grid card).
+ *
+ * @param {{
+ *   authors: string[],
+ *   date: string,
+ *   size?: 'sm'|'md',
+ *   className?: string,
+ * }} props
+ */
+export default function Byline({ authors, date, size = 'sm', className }) {
+  const format = size === 'md' ? fullDate : shortDate;
+  const avatarSize = size === 'md' ? 'medium' : 'small';
+
+  return (
+    <div className={classNames(styles.byline, styles[size], className)}>
+      {CLIENT && authors.length > 0 && (
+        <span className={styles.avatars}>
+          {authors.length === 1 ? (
+            <Avatar {...toAvatar(authors[0])} size={avatarSize} />
+          ) : (
+            <AvatarGroup
+              avatars={authors.map(toAvatar)}
+              size={avatarSize}
+              as="div"
+            />
+          )}
+        </span>
+      )}
+      <span className={styles.meta}>
+        <span className={styles.who}>{authorLabel(authors)}</span>
+        <span className={styles.sep} aria-hidden="true">
+          &middot;
+        </span>
+        <time className={styles.date} dateTime={date}>
+          {format.format(new Date(date))}
+        </time>
+      </span>
+    </div>
+  );
+}

--- a/components/Blog/Byline/index.module.css
+++ b/components/Blog/Byline/index.module.css
@@ -1,0 +1,66 @@
+@reference "../../../styles/index.css";
+
+.byline {
+  @apply flex
+    items-center
+    gap-3;
+}
+
+.avatars {
+  @apply inline-flex
+    shrink-0
+    items-center;
+}
+
+.meta {
+  @apply flex
+    min-w-0
+    items-center
+    gap-1.5;
+}
+
+.who {
+  @apply truncate
+    font-semibold
+    text-neutral-900
+    dark:text-white;
+}
+
+.date {
+  @apply shrink-0
+    font-mono
+    text-neutral-500
+    dark:text-neutral-400;
+}
+
+.sep {
+  @apply text-neutral-300
+    dark:text-neutral-600;
+}
+
+.sm {
+  @apply gap-2.5;
+}
+
+.sm .who,
+.sm .date {
+  @apply text-[13px];
+}
+
+.md .meta {
+  @apply flex-col
+    items-start
+    gap-0.5;
+}
+
+.md .sep {
+  @apply hidden;
+}
+
+.md .who {
+  @apply text-sm;
+}
+
+.md .date {
+  @apply text-[13px];
+}

--- a/components/Blog/CategoryFilter/index.jsx
+++ b/components/Blog/CategoryFilter/index.jsx
@@ -1,0 +1,37 @@
+import classNames from 'classnames';
+
+import styles from './index.module.css';
+
+const ALL = 'all';
+
+/**
+ * Category chips rendered as links. Selecting one navigates to `?category=…`
+ * (and back to `/blog` for "All posts"), which the layout reads from the URL.
+ *
+ * @param {{
+ *   categories: string[],
+ *   active: string,
+ *   hrefFor: (category: string) => string,
+ * }} props
+ */
+export default function CategoryFilter({ categories, active, hrefFor }) {
+  const chips = [
+    { key: ALL, label: 'All posts' },
+    ...categories.map(category => ({ key: category, label: category })),
+  ];
+
+  return (
+    <div className={styles.filters}>
+      {chips.map(({ key, label }) => (
+        <a
+          key={key}
+          href={hrefFor(key)}
+          className={classNames(styles.chip, key === active && styles.active)}
+          {...(key === active && { 'aria-current': 'true' })}
+        >
+          {label}
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/components/Blog/CategoryFilter/index.module.css
+++ b/components/Blog/CategoryFilter/index.module.css
@@ -1,0 +1,43 @@
+@reference "../../../styles/index.css";
+
+.filters {
+  @apply flex
+    flex-wrap
+    gap-2
+    pt-7;
+}
+
+.chip {
+  @apply cursor-pointer
+    rounded-full
+    border
+    border-transparent
+    bg-neutral-100
+    px-3.5
+    py-1.5
+    text-[13px]
+    font-semibold
+    text-neutral-600
+    no-underline
+    transition-colors
+    duration-150
+    hover:bg-neutral-200
+    hover:text-neutral-900
+    dark:bg-neutral-900
+    dark:text-neutral-300
+    dark:hover:bg-neutral-800
+    dark:hover:text-white;
+}
+
+.active {
+  @apply border-blue-200
+    bg-blue-100
+    text-blue-700
+    hover:bg-blue-100
+    hover:text-blue-700
+    dark:border-blue-900
+    dark:bg-blue-950
+    dark:text-blue-300
+    dark:hover:bg-blue-950
+    dark:hover:text-blue-300;
+}

--- a/components/Blog/Cover/index.jsx
+++ b/components/Blog/Cover/index.jsx
@@ -1,0 +1,31 @@
+import classNames from 'classnames';
+
+import Cube from '../../Icons/Webpack.jsx';
+
+import styles from './index.module.css';
+
+/**
+ * Geometric brand cover for a post. Draws the hairline pattern and the cube
+ * placeholder, layering the hero `image` over it when present. `tag` renders
+ * the category chip.
+ *
+ * @param {{
+ *   image?: string|null,
+ *   tag?: string|null,
+ *   alt?: string,
+ *   className?: string,
+ * }} props
+ */
+export default function Cover({ image, tag, alt = '', className }) {
+  return (
+    <span className={classNames(styles.cover, className)}>
+      {tag && <span className={styles.tag}>{tag}</span>}
+      <span className={styles.cube} aria-hidden="true">
+        <Cube />
+      </span>
+      {image && (
+        <img className={styles.image} src={image} alt={alt} loading="lazy" />
+      )}
+    </span>
+  );
+}

--- a/components/Blog/Cover/index.module.css
+++ b/components/Blog/Cover/index.module.css
@@ -1,0 +1,68 @@
+@reference "../../../styles/index.css";
+
+.cover {
+  @apply relative
+    flex
+    items-end
+    overflow-hidden
+    rounded-lg
+    border
+    border-neutral-200
+    bg-neutral-100
+    dark:border-neutral-800
+    dark:bg-neutral-900;
+}
+
+.cover::before {
+  background-image: repeating-linear-gradient(
+    135deg,
+    rgb(28 120 192 / 7%) 0 1px,
+    transparent 1px 14px
+  );
+  content: '';
+  inset: 0;
+  position: absolute;
+}
+
+.tag {
+  @apply absolute
+    left-3.5
+    top-3.5
+    z-20
+    inline-flex
+    items-center
+    rounded-full
+    bg-white
+    px-2.5
+    py-1
+    text-xs
+    font-bold
+    text-blue-700
+    shadow-sm
+    dark:bg-neutral-900
+    dark:text-blue-300;
+}
+
+.cube {
+  @apply pointer-events-none
+    absolute
+    -bottom-7
+    -right-7
+    z-0
+    block
+    w-36
+    opacity-[0.14];
+}
+
+.cube svg {
+  height: auto;
+  width: 100%;
+}
+
+.image {
+  @apply absolute
+    inset-0
+    z-10
+    size-full
+    object-cover;
+}

--- a/components/Blog/PostCard/index.jsx
+++ b/components/Blog/PostCard/index.jsx
@@ -1,0 +1,34 @@
+import Byline from '../Byline/index.jsx';
+import Cover from '../Cover/index.jsx';
+
+import styles from './index.module.css';
+
+/**
+ * A post tile for the recent-posts grid: cover, category, title, optional
+ * excerpt, and a compact byline.
+ *
+ * @param {{ post: object }} props
+ */
+export default function PostCard({ post }) {
+  return (
+    <a className={styles.card} href={`/blog/posts/${post.slug}`}>
+      <Cover
+        className={styles.cover}
+        image={post.image}
+        tag={post.category}
+        alt={post.title}
+      />
+      {post.category && (
+        <span className={styles.category}>{post.category}</span>
+      )}
+      <h3 className={styles.title}>{post.title}</h3>
+      {post.description && <p className={styles.excerpt}>{post.description}</p>}
+      <Byline
+        authors={post.authors}
+        date={post.date}
+        size="sm"
+        className={styles.foot}
+      />
+    </a>
+  );
+}

--- a/components/Blog/PostCard/index.module.css
+++ b/components/Blog/PostCard/index.module.css
@@ -1,0 +1,59 @@
+@reference "../../../styles/index.css";
+
+.card {
+  @apply flex
+    h-full
+    flex-col
+    no-underline;
+}
+
+.cover {
+  @apply mb-4
+    aspect-[16/10]
+    transition-shadow
+    duration-150;
+}
+
+.card:hover .cover {
+  @apply shadow-md;
+}
+
+.category {
+  @apply mb-2
+    text-xs
+    font-bold
+    tracking-wide
+    uppercase
+    text-blue-600
+    dark:text-blue-400;
+}
+
+.title {
+  @apply m-0
+    mb-2
+    text-lg
+    font-semibold
+    leading-snug
+    tracking-tight
+    text-neutral-900
+    dark:text-white;
+}
+
+.card:hover .title {
+  @apply text-blue-700
+    dark:text-blue-300;
+}
+
+.excerpt {
+  @apply m-0
+    mb-4
+    text-sm
+    leading-relaxed
+    text-neutral-600
+    dark:text-neutral-300;
+}
+
+.foot {
+  @apply mt-auto
+    pt-1;
+}

--- a/components/Layout.jsx
+++ b/components/Layout.jsx
@@ -1,11 +1,15 @@
 import DefaultLayout from '@node-core/doc-kit/src/generators/web/ui/components/Layout/index.jsx';
 import HomeLayout from '../layouts/Home/index.jsx';
 import SponsorsLayout from '../layouts/Sponsors/index.jsx';
+import BlogLayout from '../layouts/Blog/index.jsx';
+import PostLayout from '../layouts/Post/index.jsx';
 import '../styles/index.css';
 
 const LAYOUTS = {
   home: HomeLayout,
   sponsors: SponsorsLayout,
+  blog: BlogLayout,
+  post: PostLayout,
 };
 
 export default function Layout(props) {

--- a/layouts/Blog/index.jsx
+++ b/layouts/Blog/index.jsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from 'react';
+
+import BasePagination from '@node-core/ui-components/Common/BasePagination';
+
+import NavBar from '../../components/NavBar.jsx';
+import Footer from '../../components/Footer/index.jsx';
+import CategoryFilter from '../../components/Blog/CategoryFilter/index.jsx';
+import PostCard from '../../components/Blog/PostCard/index.jsx';
+import data from '#theme/blog' with { type: 'json' };
+
+import styles from './index.module.css';
+
+const ALL = 'all';
+const PAGE_SIZE = 6;
+
+// Unique categories in first-appearance order (data is sorted newest-first).
+const CATEGORIES = [
+  ...new Set(data.map(post => post.category).filter(Boolean)),
+];
+
+const PAGINATION_LABELS = {
+  aria: 'Blog pages',
+  next: 'Next',
+  nextAriaLabel: 'Next page',
+  previous: 'Previous',
+  previousAriaLabel: 'Previous page',
+};
+
+/** Build a `/blog` URL carrying the active category and page (defaults omitted). */
+const hrefFor = ({ category, page }) => {
+  const params = new URLSearchParams();
+  if (category && category !== ALL) params.set('category', category);
+  if (page && page > 1) params.set('page', String(page));
+  const query = params.toString();
+  return query ? `/blog?${query}` : '/blog';
+};
+
+/**
+ * @param {{ metadata: object }} props
+ */
+export default function BlogLayout({ metadata }) {
+  const [{ category, page }, setView] = useState({ category: ALL, page: 1 });
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const requested = Number.parseInt(params.get('page'), 10);
+    setView({
+      category: params.get('category') ?? ALL,
+      page: Number.isInteger(requested) && requested > 1 ? requested : 1,
+    });
+  }, []);
+
+  const pool =
+    category === ALL ? data : data.filter(post => post.category === category);
+
+  const pageCount = Math.max(1, Math.ceil(pool.length / PAGE_SIZE));
+  const current = Math.min(Math.max(page, 1), pageCount);
+  const start = (current - 1) * PAGE_SIZE;
+  const visible = pool.slice(start, start + PAGE_SIZE);
+
+  const pages = Array.from({ length: pageCount }, (_, index) => ({
+    url: hrefFor({ category, page: index + 1 }),
+  }));
+
+  return (
+    <>
+      <NavBar metadata={metadata} />
+
+      <main className={styles.page}>
+        <div className={styles.wrap}>
+          <header className={styles.head}>
+            <p className={styles.eyebrow}>
+              <span className={styles.dot} />
+              The webpack blog
+            </p>
+            <h1 className={styles.title}>Notes from the bundler.</h1>
+            <p className={styles.deck}>
+              Release notes, deep dives into the chunk graph, and engineering
+              write-ups from the webpack core team and the wider community.
+            </p>
+            <CategoryFilter
+              categories={CATEGORIES}
+              active={category}
+              hrefFor={key => hrefFor({ category: key, page: 1 })}
+            />
+          </header>
+
+          <section className={styles.recent}>
+            <h2 className={styles.recentHead}>Recent posts</h2>
+
+            {visible.length > 0 ? (
+              <div className={styles.grid}>
+                {visible.map(post => (
+                  <PostCard key={post.slug} post={post} />
+                ))}
+              </div>
+            ) : (
+              <p className={styles.empty}>No posts in this category yet.</p>
+            )}
+
+            {pageCount > 1 && (
+              <div className={styles.pagination}>
+                <BasePagination
+                  currentPage={current}
+                  pages={pages}
+                  getPageLabel={number => `Page ${number}`}
+                  labels={PAGINATION_LABELS}
+                />
+              </div>
+            )}
+          </section>
+        </div>
+      </main>
+
+      <Footer />
+    </>
+  );
+}

--- a/layouts/Blog/index.module.css
+++ b/layouts/Blog/index.module.css
@@ -1,0 +1,101 @@
+@reference "../../styles/index.css";
+
+.page {
+  @apply bg-white
+    text-neutral-900
+    dark:bg-neutral-950
+    dark:text-white;
+}
+
+.wrap {
+  @apply mx-auto
+    max-w-[1200px]
+    px-8
+    max-md:px-5;
+}
+
+.head {
+  @apply border-b
+    border-neutral-200
+    pb-10
+    pt-16
+    dark:border-neutral-800;
+}
+
+.eyebrow {
+  @apply m-0
+    mb-3.5
+    inline-flex
+    items-center
+    gap-2
+    text-sm
+    font-bold
+    tracking-wide
+    uppercase
+    text-blue-600
+    dark:text-blue-400;
+}
+
+.dot {
+  @apply inline-block
+    size-1.5
+    rounded-full
+    bg-blue-600
+    dark:bg-blue-400;
+}
+
+.title {
+  @apply m-0
+    mb-4
+    text-5xl
+    font-semibold
+    tracking-tight
+    text-neutral-900
+    max-sm:text-4xl
+    dark:text-white;
+}
+
+.deck {
+  @apply m-0
+    max-w-xl
+    text-lg
+    leading-relaxed
+    text-neutral-600
+    dark:text-neutral-300;
+}
+
+.recent {
+  @apply pb-20
+    pt-12;
+}
+
+.recentHead {
+  @apply m-0
+    mb-6
+    text-sm
+    font-bold
+    tracking-wider
+    uppercase
+    text-neutral-500
+    dark:text-neutral-400;
+}
+
+.grid {
+  @apply grid
+    grid-cols-1
+    gap-x-6
+    gap-y-7
+    sm:grid-cols-2
+    lg:grid-cols-3;
+}
+
+.empty {
+  @apply m-0
+    py-8
+    text-neutral-500
+    dark:text-neutral-400;
+}
+
+.pagination {
+  @apply mt-12;
+}

--- a/layouts/Post/index.jsx
+++ b/layouts/Post/index.jsx
@@ -1,0 +1,105 @@
+import Article from '@node-core/ui-components/Containers/Article';
+import BaseCrossLink from '@node-core/ui-components/Common/BaseCrossLink';
+
+import NavBar from '../../components/NavBar.jsx';
+import Footer from '../../components/Footer/index.jsx';
+import Byline from '../../components/Blog/Byline/index.jsx';
+import Cover from '../../components/Blog/Cover/index.jsx';
+import MetaBar from '#theme/Metabar';
+import posts from '#theme/blog' with { type: 'json' };
+
+import styles from './index.module.css';
+
+/**
+ * Article layout for a single blog post, mirroring the nodejs.org `Post` layout:
+ * navigation, a three-column shell (empty rail · article · meta bar), and the
+ * footer. The shell reuses doc-kit's {@link Article} container so the rendered
+ * markdown body gets the same grid, spacing, and typography as the API docs.
+ *
+ * A cover image opens the post; the header reuses {@link Byline} for the author
+ * avatars and publish date; the body (including its `# ` title) arrives as
+ * `children`. The right rail reuses doc-kit's MetaBar for the table of contents,
+ * reading time, and edit link. Previous/next cross-links close the article,
+ * walking the listing order (newest-first, so "previous" is the newer post).
+ *
+ * @param {{
+ *   metadata: import('@node-core/doc-kit/src/generators/web/ui/types').SerializedMetadata
+ *     & { authors?: string[], date?: string, category?: string },
+ *   headings: Array<object>,
+ *   readingTime: string,
+ *   children: import('react').ReactNode,
+ * }} props
+ */
+export default function PostLayout({
+  metadata,
+  headings,
+  readingTime,
+  children,
+}) {
+  const { authors = [], date, category } = metadata;
+
+  // `basename` is the slug (filename without extension), matching the listing.
+  const index = posts.findIndex(post => post.slug === metadata.basename);
+  const current = posts[index];
+  const next = index > 0 ? posts[index - 1] : undefined;
+  const previous = index >= 0 ? posts[index + 1] : undefined;
+
+  return (
+    <>
+      <NavBar metadata={metadata} />
+
+      <Article>
+        <div />
+
+        <div>
+          <main id="main" tabIndex={-1}>
+            <Cover
+              className={styles.cover}
+              image={metadata.image}
+              alt={current?.title}
+            />
+
+            <header className={styles.header}>
+              {category && <p className={styles.category}>{category}</p>}
+              {date && <Byline authors={authors} date={date} size="md" />}
+            </header>
+
+            {children}
+
+            {(previous || next) && (
+              <nav className={styles.crossLinks} aria-label="More posts">
+                {previous ? (
+                  <BaseCrossLink
+                    type="previous"
+                    label="Previous"
+                    text={previous.title}
+                    link={`/blog/posts/${previous.slug}`}
+                  />
+                ) : (
+                  <div />
+                )}
+
+                {next && (
+                  <BaseCrossLink
+                    type="next"
+                    label="Next"
+                    text={next.title}
+                    link={`/blog/posts/${next.slug}`}
+                  />
+                )}
+              </nav>
+            )}
+          </main>
+
+          <MetaBar
+            metadata={metadata}
+            headings={headings}
+            readingTime={readingTime}
+          />
+        </div>
+      </Article>
+
+      <Footer />
+    </>
+  );
+}

--- a/layouts/Post/index.module.css
+++ b/layouts/Post/index.module.css
@@ -1,0 +1,44 @@
+@reference "../../styles/index.css";
+
+/*
+ * The Article container owns the page grid, padding, and markdown typography;
+ * this module styles the cover image, post header, and cross-links around it.
+ */
+.cover {
+  @apply mb-8
+    aspect-[16/7]
+    w-full;
+}
+
+.header {
+  @apply mb-8
+    flex
+    flex-col
+    gap-4
+    border-b
+    border-neutral-200
+    pb-6
+    dark:border-neutral-800;
+}
+
+.category {
+  @apply m-0
+    text-sm
+    font-bold
+    tracking-wide
+    uppercase
+    text-blue-600
+    dark:text-blue-400;
+}
+
+.crossLinks {
+  @apply mt-12
+    grid
+    grid-cols-1
+    gap-4
+    border-t
+    border-neutral-200
+    pt-8
+    sm:grid-cols-2
+    dark:border-neutral-800;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
         "@node-core/doc-kit": "^1.3.9",
         "@tailwindcss/node": "^4.3.0",
         "classnames": "^2.5.1",
+        "gray-matter": "^4.0.3",
         "npm-run-all": "^4.1.5",
         "semver": "^7.8.1",
         "typedoc": "^0.28.19",
@@ -4679,6 +4680,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -4796,6 +4810,18 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5287,6 +5313,43 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -5902,6 +5965,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -6342,7 +6414,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9472,6 +9543,19 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
@@ -9790,6 +9874,12 @@
       "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "license": "CC0-1.0"
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -9942,6 +10032,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/style-to-js": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "scripts": {
     "build:prepare": "node scripts/prepare/index.mjs",
     "build:data": "npm-run-all build:data:*",
+    "build:data:blog": "node scripts/data/blog.mjs",
     "build:data:sponsors": "node scripts/data/sponsors.mjs",
     "build:md": "npm-run-all build:md:*",
     "build:md:api": "node scripts/markdown/api.mjs",
@@ -23,6 +24,7 @@
     "@node-core/doc-kit": "^1.3.9",
     "@tailwindcss/node": "^4.3.0",
     "classnames": "^2.5.1",
+    "gray-matter": "^4.0.3",
     "npm-run-all": "^4.1.5",
     "semver": "^7.8.1",
     "typedoc": "^0.28.19",

--- a/pages/blog/index.md
+++ b/pages/blog/index.md
@@ -1,0 +1,3 @@
+---
+layout: blog
+---

--- a/pages/blog/posts/2020-10-10-webpack-5-release.md
+++ b/pages/blog/posts/2020-10-10-webpack-5-release.md
@@ -1,0 +1,1447 @@
+---
+layout: post
+date: 2020-10-10T00:00:00Z
+authors:
+  - sokra
+  - chenxsan
+category: Release
+image: /assets/blog/cover-1.svg
+description: Webpack 5.0.0 is officially released! This major version brings huge architectural improvements, persistent caching, deterministic chunk IDs, and Module Federation.
+---
+
+# Webpack 5 release
+
+Webpack 4 was released in February 2018.
+Since then we shipped a lot of features without breaking changes.
+We know that people dislike major changes with breaking changes.
+Especially with webpack, which people usually only touch twice a year, and the remaining time it "just works".
+But shipping features without breaking changes also has a cost:
+We can't do major API or architectural improvements.
+
+So from time to time, there is a point where the difficulties pile up and we are forced to do breaking changes to not mess everything up.
+That's the time for a new major version.
+So webpack 5 contains these architectural improvements and the features that were not possible to implement without them.
+
+The major version was also the chance to revise some of the defaults and to align with proposals and specifications that come up in the meantime.
+
+So today (2020-10-10) webpack 5.0.0 is released, but this doesn't mean it's done, bugfree or even feature-complete.
+As with webpack 4 we continue development by fixing problems and adding features.
+In the next days there will probably be a lot bugfixes. Features will come later.
+
+## Common Questions
+
+### So what does the release mean?
+
+It means we finished doing breaking changes.
+Many refactorings have been done to up-level the architecture and create a good base for future features (and current features).
+
+### So when is the time to upgrade?
+
+It depends. There is a good chance that upgrading fails and you would need to give it a second or 3rd try.
+If you are open to that, try to upgrade now and provide feedback to webpack, plugins and loaders.
+We are eager to fix those problems. Someone has to start and you would be one of the first ones benefiting from it.
+
+## Sponsoring Update
+
+Webpack is fully based upon [sponsoring](https://opencollective.com/webpack).
+It's not tied to (and paid by) a big company like some other Open Source projects.
+99% of the earnings from sponsoring are distributed towards contributors and maintainers based on the contributions they do.
+We believe in investing the money towards making webpack better.
+
+But there is a pandemic, and companies ain't that much open to sponsoring anymore.
+Webpack is suffering under these circumstances too (like many other companies and people).
+
+We were never able to pay our contributors the amount we think they deserve, but now we only have half of the money available, so we need to make a more serious cut.
+Until the situation improves we will only pay contributors and maintainers the first 10 days of each month.
+The remaining days they could work voluntarily, paid by their employer, work on something else, or take some days off.
+This allows us to pay for their work in the first 10 days more equivalent to the invested time.
+
+The biggest "Thank You" goes to [trivago](https://tech.trivago.com/opensource) which has been sponsoring webpack a huge amount for the last 3 years.
+Sadly they are unable to continue their sponsorship this year, as they have been hit hard by Covid-19.
+I hope some other company steps up and follows these (gigantic) footsteps.
+
+Thanks to [all the sponsors](/#sponsors).
+
+## General direction
+
+This release focus on the following:
+
+- Improve build performance with Persistent Caching.
+- Improve Long Term Caching with better algorithms and defaults.
+- Improve bundle size with better Tree Shaking and Code Generation.
+- Improve compatibility with the web platform.
+- Clean up internal structures that were left in a weird state while implementing features in v4 without introducing any breaking changes.
+- Prepare for future features by introducing breaking changes now, allowing us to stay on v5 for as long as possible.
+
+## **Migration** Guide
+
+[See here for a **migration** guide](/migrate/5)
+
+## Major Changes: Removals
+
+### Removed Deprecated Items
+
+All items deprecated in v4 were removed.
+
+**MIGRATION**: Make sure that your webpack 4 build does not print deprecation warnings.
+
+Here are a few things that were removed but did not have deprecation warnings in v4:
+
+- IgnorePlugin and BannerPlugin must now be passed only one argument that can be an object, string or function.
+
+### Deprecation codes
+
+New deprecations include a deprecation code so they are easier to reference.
+
+### Syntax deprecated
+
+`require.include` has been deprecated and will emit a warning by default when used.
+
+Behavior can be changed with `Rule.parser.requireInclude` to allowed, deprecated or disabled.
+
+### Automatic Node.js Polyfills Removed
+
+In the early days, webpack's aim was to allow running most Node.js modules in the browser, but the module landscape changed and many module uses are now written mainly for frontend purposes. Webpack &lt;= 4 ships with polyfills for many of the Node.js core modules, which are automatically applied once a module uses any of the core modules (i.e. the `crypto` module).
+
+While this makes using modules written for Node.js easier, it adds these huge polyfills to the bundle. In many cases these polyfills are unnecessary.
+
+Webpack 5 stops automatically polyfilling these core modules and focus on frontend-compatible modules. Our goal is to improve compatibility with the web platform, where Node.js core modules are not available.
+
+**MIGRATION**:
+
+- Try to use frontend-compatible modules whenever possible.
+- It's possible to manually add a polyfill for a Node.js core module. An error message will give a hint on how to achieve that.
+- Package authors: Use the `browser` field in `package.json` to make a package frontend-compatible. Provide alternative implementations/dependencies for the browser.
+
+## Major Changes: Long Term Caching
+
+### Deterministic Chunk, Module IDs and Export names
+
+New algorithms were added for long term caching. These are enabled by default in production mode.
+
+`chunkIds: "deterministic"`
+`moduleIds: "deterministic"`
+`mangleExports: "deterministic"`
+
+The algorithms assign short (3 or 5 digits) numeric IDs to modules and chunks and short (2 characters) names to exports in a deterministic way.
+This is a trade-off between bundle size and long term caching.
+
+`moduleIds/chunkIds/mangleExports: false` disables the default behavior and one can provide a custom algorithm via plugin. Note that in webpack 4 `moduleIds/chunkIds: false` without custom plugin resulted in a working build, while in webpack 5 you must provide a custom plugin.
+
+**MIGRATION**: Best use the default values for `chunkIds`, `moduleIds` and `mangleExports`. You can also opt-in to the old defaults `chunkIds: "size", moduleIds: "size", mangleExports: "size"`, this will generate smaller bundles, but invalidate them more often for caching.
+
+Note: In webpack 4 hashed module ids yielded reduced gzip performance. This was related to changed module order and has been fixed.
+
+Note: In webpack 5, `deterministic` Ids are enabled by default in production mode
+
+### Real Content Hash
+
+Webpack 5 will use a real hash of the file content when using `[contenthash]` now. Before it "only" used a hash of the internal structure.
+This can be positive impact on long term caching when only comments are changed or variables are renamed. These changes are not visible after minimizing.
+
+## Major Changes: Development Support
+
+### Named Chunk IDs
+
+A new named chunk id algorithm enabled by default in development mode gives chunks (and filenames) human-readable names.
+A Module ID is determined by its path, relative to the `context`.
+A Chunk ID is determined by the chunk's content.
+
+So you no longer need to use `import(/* webpackChunkName: "name" */ "module")` for debugging.
+But it would still make sense if you want to control the filenames for production environments.
+
+It's possible to use `chunkIds: "named"` in production, but make sure not to accidentally expose sensitive information about module names.
+
+**MIGRATION**: If you dislike the filenames being changed in development, you can pass `chunkIds: "natural"` to use the old numeric mode.
+
+### Module Federation
+
+Webpack 5 adds a new feature called "Module Federation", which allows multiple webpack builds to work together.
+From runtime perspective modules from multiple builds will behave like a huge connected module graph.
+From developer perspective modules can be imported from specified remote builds and used with minimal restrictions.
+
+For more details see [this separate guide](/concepts/module-federation).
+
+## Major Changes: New Web Platform Features
+
+### JSON modules
+
+JSON modules now align with the proposal and emit a warning when a non-default export is used.
+JSON modules no longer have named exports when importing from a strict ECMAScript module.
+
+**MIGRATION**: Use the default export.
+
+Even when using the default export, unused properties are dropped by the `optimization.usedExports` optimization and properties are mangled by the `optimization.mangleExports` optimization.
+
+It's possible to specify a custom JSON parser in `Rule.parser.parse` to import JSON-like files (e.g. for toml, yaml, json5, etc.).
+
+### import.meta
+
+- `import.meta.webpackHot` is an alias for `module.hot` which is also available in strict ESM
+- `import.meta.webpack` is the webpack major version as number
+- `import.meta.url` is the `file:` url of the current file (similar to `__filename` but as file url)
+
+### Asset modules
+
+Webpack 5 has now native support for modules representing assets.
+These modules will either emit a file into the output folder or inject a DataURI into the javascript bundle.
+Either way they give a URL to work with.
+
+They can be used via multiple ways:
+
+- `import url from "./image.png"` and setting `type: "asset"` in `module.rules` when matching such import. (old way)
+- `new URL("./image.png", import.meta.url)` (new way)
+
+The "new way" syntax was chosen to allow running code without bundler too. This syntax is also available in native ECMAScript modules in the browser.
+
+### Native Worker support
+
+When combining `new URL` for assets with `new Worker`/`new SharedWorker`/`navigator.serviceWorker.register` webpack will automatically create a new entrypoint for a web worker.
+
+`new Worker(new URL("./worker.js", import.meta.url))`
+
+The syntax was chosen to allow running code without bundler too. This syntax is also available in native ECMAScript modules in the browser.
+
+### URIs
+
+Webpack 5 supports handling of protocols in requests.
+
+- `data:` is supported. Base64 or raw encoding is supported. Mimetype can be mapped to loaders and module type in `module.rules`. Example: `import x from "data:text/javascript,export default 42"`
+- `file:` is supported.
+- `http(s):` is supported, but requires opt-in via `new webpack.experiments.schemesHttp(s)UriPlugin()`
+  - By default when targeting "web", these URIs result in requests to external resource (they are externals)
+
+Fragments in requests are supported: Example: `./file.js#fragment`
+
+### Async modules
+
+Webpack 5 supports so called "async modules".
+That are modules that do not evaluate synchronously, but are async and Promise-based instead.
+
+Importing them via `import` is automatically handled and no additional syntax is needed and difference is hardly notice-able.
+
+Importing them via `require()` will return a Promise that resolves to the exports.
+
+In webpack there are multiple ways to have async modules:
+
+- async externals
+- WebAssembly Modules in the new spec
+- ECMAScript Modules that are using Top-Level-Await
+
+### Externals
+
+Webpack 5 adds additional external types to cover more applications:
+
+`promise`: An expression that evaluates to a Promise. The external module is an async module and the resolved value is used as module exports.
+
+`import`: Native `import()` is used to load the specified request. The external module is an async module.
+
+`module`: Not implemented yet, but planned to load modules via `import x from "..."`.
+
+`script`: Loads a url via `<script>` tag and gets the exports from a global variable (and optionally properties of it). The external module is an async module.
+
+## Major Changes: New Node.js Ecosystem Features
+
+### Resolving
+
+The `exports` and `imports` field in package.json is now supported.
+
+Yarn PnP is supported natively.
+
+See more details in [package exports](/guides/package-exports/).
+
+## Major Changes: Development Experience
+
+### Improved target
+
+Webpack 5 allows to pass a list of targets and also support versions of target.
+
+Examples: `target: "node14"` `target: ["web", "es2020"]`
+
+This enables us to provide webpack all the information it needs to determine:
+
+- chunk loading mechanism, and
+- supported syntax like arrow functions
+
+### Stats
+
+The Stats test format has been improved regarding readability and verbosity. The defaults have been improved to be less verbose and also suitable for large builds.
+
+- Chunk relations are hidden by default now. This can be toggled with `stats.chunkRelations`.
+- Stats differentiate between `files` and `auxiliaryFiles` now.
+- Stats hide module and chunk ids by default now. This can be toggled with `stats.ids`.
+- The list of all modules is sorted by distance to entrypoint now. This can be changed with `stats.modulesSort`.
+- The list of chunk modules is sorted by module name now. This can be changed with `stats.chunkModulesSort`.
+- The list of nested modules in concatenated modules is sorted topologically now. This can be changed with `stats.nestedModulesSort`.
+- Chunks and Assets show chunk id hints now.
+- Assets and modules will display in a tree instead of a list/table.
+- General information is shown in a summary at the end now. It shows webpack version, config name and warnings/errors count.
+- Hash is hidden by default now. This can be changed with `stats.hash`.
+- Timestamp of build is no longer shown by default. This can be enabled with `stats.builtAt`. It will show the timestamp in the summary.
+- Child compilations will no longer shown by default. They can be displayed with `stats.children`.
+
+### Progress
+
+A few improvements have been done to the `ProgressPlugin` which is used for `--progress` by the CLI, but can also be used manually as plugin.
+
+It used to only count the processed modules. Now it can count `entries` `dependencies` and `modules`.
+All of them are shown by default now.
+
+It used to display the currently processed module. This caused much stderr output and yielded a performance problem on some consoles.
+This is now disabled by default (`activeModules` option). This also reduces the amount of spam on the console.
+Now writing to stderr during building modules is throttled to 500ms.
+
+The profiling mode also got an upgrade and will display timings of nested progress messages.
+This makes it easier to figure out which plugin is causing performance problems.
+
+A newly added `percentBy`-option tells `ProgressPlugin` how to calculate progress percentage.
+
+```js
+new webpack.ProgressPlugin({ percentBy: 'entries' });
+```
+
+To make progress percentage more accurate `ProgressPlugin` caches the last known total modules count and reuses this value on the next build. The first build will warm the cache but the following builds will use and update this value.
+
+### Automatic unique naming
+
+In webpack 4 multiple webpack runtimes could conflict on the same HTML page, because they use the same global variable for chunk loading. To fix that it was needed to provide a custom name to the `output.jsonpFunction` configuration.
+
+Webpack 5 does automatically infer a unique name for the build from `package.json` `name` and uses this as default for `output.uniqueName`.
+
+This value is used to make all potential conflicting globals unique.
+
+**MIGRATION**: Remove `output.jsonpFunction` in favor of a unique name in your `package.json`.
+
+### Automatic public path
+
+Webpack 5 will determine the `output.publicPath` automatically when possible.
+
+### Typescript typings
+
+Webpack 5 generates typescript typings from source code and exposes them via the npm package.
+
+**MIGRATION**: Remove `@types/webpack`. Update references when names differ.
+
+## Major Changes: Optimization
+
+### Nested tree-shaking
+
+Webpack is now able to track access to nested properties of exports. This can improve Tree Shaking (Unused export elimination and export mangling) when reexporting namespace objects.
+
+**inner.js**
+
+```js
+export const a = 1;
+export const b = 2;
+```
+
+**module.js**
+
+```js
+export * as inner from './inner';
+// or import * as inner from './inner'; export { inner };
+```
+
+**user.js**
+
+```js
+import * as module from './module';
+
+console.log(module.inner.a);
+```
+
+In this example, the export `b` can be removed in production mode.
+
+### Inner-module tree-shaking
+
+Webpack 4 didn't analyze dependencies between exports and imports of a module. Webpack 5 has a new option `optimization.innerGraph`, which is enabled by default in production mode, that runs an analysis on symbols in a module to figure out dependencies from exports to imports.
+
+In a module like this:
+
+```js
+import { something } from './something';
+
+function usingSomething() {
+  return something;
+}
+
+export function test() {
+  return usingSomething();
+}
+```
+
+The inner graph algorithm will figure out that `something` is only used when the `test` export is used. This allows to flag more exports as unused and to omit more code from the bundle.
+
+When `"sideEffects": false` is set, this allows to omit even more modules. In this example `./something` will be omitted when the `test` export is unused.
+
+To get the information about unused exports `optimization.usedExports` is required. To remove side-effect-free modules `optimization.sideEffects` is required.
+
+The following symbols can be analysed:
+
+- function declarations
+- class declarations
+- `export default` with or variable declarations with
+  - function expressions
+  - class expressions
+  - sequence expressions
+  - `/*#__PURE__*/` expressions
+  - local variables
+  - imported bindings
+
+**FEEDBACK**: If you find something missing in this analysis, please report an issue and we consider adding it.
+
+Using `eval()` will bail-out this optimization for a module, because evaled code could reference any symbol in scope.
+
+This optimization is also known as Deep Scope Analysis.
+
+### CommonJs Tree Shaking
+
+Webpack used to opt-out from used exports analysing for CommonJs exports and `require()` calls.
+
+Webpack 5 adds support for some CommonJs constructs, allows to eliminate unused CommonJs exports and track referenced export names from `require()` calls.
+
+The following constructs are supported:
+
+- `exports|this|module.exports.xxx = ...`
+- `exports|this|module.exports = require("...")` (reexport)
+- `exports|this|module.exports.xxx = require("...").xxx` (reexport)
+- `Object.defineProperty(exports|this|module.exports, "xxx", ...)`
+- `require("abc").xxx`
+- `require("abc").xxx()`
+- importing from ESM
+- `require()` a ESM
+- flagged exportType (special handling for non-strict ESM import):
+  - `Object.defineProperty(exports|this|module.exports, "__esModule", { value: true|!0 })`
+  - `exports|this|module.exports.__esModule = true|!0`
+- It's planned to support more constructs in future
+
+When detecting not analysable code, webpack bails out and doesn't track export information at all for these modules (for performance reasons).
+
+### Side-Effect analysis
+
+The `"sideEffects"` flag in package.json allows to manually flag modules as side-effect-free, which allows to drop them when unused.
+
+Webpack 5 can also automatically flag modules as side-effect-free according to a static analysis of the source code.
+
+### Optimization per runtime
+
+Webpack 5 is now able (and does by default) to analyse and optimize modules per runtime (A runtime is often equal to an entrypoint).
+This allows to only exports in these entrypoints where they are really needed.
+Entrypoints doesn't affect each other (as long as using a runtime per entrypoint)
+
+### Module Concatenation
+
+Module Concatenation also works per runtime to allow different concatenation for each runtime.
+
+Module Concatenation has become a first class citizen and any module and dependency is now allowed to implement it.
+Initially webpack 5 already added support for ExternalModules and json modules, more will likely ship soonish.
+
+### General Tree Shaking improvements
+
+`export *` has been improved to track more info and do no longer flag the `default` export as used.
+
+`export *` will now show warnings when webpack is sure that there are conflicting exports.
+
+`import()` allows to manually tree shake the module via `/* webpackExports: ["abc", "default"] */` magic comment.
+
+### Development Production Similarity
+
+We try to find a good trade-off between build performance in development mode and avoiding production-only problems by improving the similarity between both modes.
+
+Webpack 5 enables the `sideEffects` optimization by default in both modes. In webpack 4 this optimization lead to some production-only errors because of an incorrect `"sideEffects"` flag in package.json. Enabling this optimization in development allows to find these problems faster and easier.
+
+In many cases development and production happen on different OS with different case-sensitivity of filesystem, so webpack 5 adds a few more warnings/errors when there is something weird casing-wise.
+
+### Improved Code Generation
+
+Webpack detects when ASI happens and generates shorter code when no semicolons are inserted. `Object(...)` -> `(0, ...)`
+
+Webpack merges multiple export getters into a single runtime function call: `r.d(x, "a", () => a); r.d(x, "b", () => b);` -> `r.d(x, {a: () => a, b: () => b});`
+
+There are additional options in `output.environment` now.
+They allows specifying which ECMAScript feature can be used for runtime code generated by webpack.
+
+One usually do not specify this option directly, but would use the `target` option instead.
+
+Webpack 4 used to only emit ES5 code.
+Webpack 5 can generate both ES5 and ES6/ES2015 code now.
+
+Supporting only modern browsers will generate shorter code using arrow functions and more spec-conform code using `const` declarations with TDZ for `export default`.
+
+### Improved `target` option
+
+In webpack 4 the `target` was a rough choice between `"web"` and `"node"` (and a few others).
+Webpack 5 gives you more options here.
+
+The `target` option now influences more things about the generated code than before:
+
+- method of chunk loading
+- format of chunks
+- method of wasm loading
+- method of chunk and wasm loading in workers
+- global object used
+- if publicPath should be determined automatically
+- ECMAScript features/syntax used in the generated code
+- `externals` enabled by default
+- Behavior of some Node.js compat layers (`global`, `__filename`, `__dirname`)
+- Resolving of modules (`browser` field, `exports` and `imports` conditions)
+- Some loaders might change behavior based on that
+
+For some of these things the choice between `"web"` and `"node"` is too rough and we need more information.
+Therefore we allow to specify the minimum version e.g. like `"node10.13"` and infer more properties about the target environment.
+
+It's now also allowed to combined multiple targets with an array and webpack will determine the minimum properties of all targets. Using an array is also useful when using targets that doesn't give full information like `"web"` or `"node"` (without version number). E. g. `["web", "es2020"]` combines these two partial targets.
+
+There is a target `"browserslist"` which will use browserslist data to determine properties of the environment.
+This target is also used by default when there is a browserslist config available in the project. When none such config is available, the `"web"` target will be used by default.
+
+Some combinations and features are not yet implemented and will result in errors. They are preparations for future features. Examples:
+
+- `["web", "node"]` will lead to an universal chunk loading method, which is not implemented yet
+- `["web", "node"]` + `output.module: true` will lead to a module chunk loading method, which is not implemented yet
+- `"web"` will lead to `http(s):` imports being treated as `module` externals, which are not implemented yet (Workaround: `externalsPresets: { web: false, webAsync: true }`, which will use `import()` instead).
+
+### SplitChunks and Module Sizes
+
+Modules now express size in a better way than a single number. There are different types of sizes now.
+
+The SplitChunksPlugin now knows how to handle these different sizes and uses them for `minSize` and `maxSize`.
+By default, only `javascript` size is handled, but you can now pass multiple values to manage them:
+
+```js
+module.exports = {
+  optimization: {
+    splitChunks: {
+      minSize: {
+        javascript: 30000,
+        webassembly: 50000,
+      },
+    },
+  },
+};
+```
+
+You can still use a single number for sizes. In this case webpack will automatically use the default size types.
+
+The `mini-css-extract-plugin` uses `css/mini-extra` as size type, and adds this size type to the default types automatically.
+
+## Major Changes: Performance
+
+### Persistent Caching
+
+There is now a filesystem cache. It's opt-in and can be enabled with the following configuration:
+
+```js
+module.exports = {
+  cache: {
+    // 1. Set cache type to filesystem
+    type: 'filesystem',
+
+    buildDependencies: {
+      // 2. Add your config as buildDependency to get cache invalidation on config change
+      config: [__filename],
+
+      // 3. If you have other things the build depends on you can add them here
+      // Note that webpack, loaders and all modules referenced from your config are automatically added
+    },
+  },
+};
+```
+
+Important notes:
+
+By default, webpack assumes that the `node_modules` directory, which webpack is inside of, is **only** modified by a package manager. Hashing and timestamping is skipped for `node_modules`.
+Instead, only the package name and version is used for performance reasons.
+Symlinks (i. e. `npm/yarn link`) are fine as long `resolve.symlinks: false` is not specified (avoid that anyway).
+Do not edit files in `node_modules` directly unless you opt-out of this optimization with `snapshot.managedPaths: []`.
+When using Yarn PnP webpack assumes that the yarn cache is immutable (which it usually is).
+You can opt-out of this optimization with `snapshot.immutablePaths: []`
+
+The cache will be stored into `node_modules/.cache/webpack` (when using node_modules) resp. `.yarn/.cache/webpack` (when using Yarn PnP) by default.
+You probably never have to delete it manually, when all plugins handle caching correctly.
+
+Many internal plugins will use the Persistent Cache too. Examples: `SourceMapDevToolPlugin` (to cache the SourceMap generation) or `ProgressPlugin` (to cache the number of modules)
+
+The Persistent Cache will automatically create multiple cache files depending on usage to optimize read and write access to and from the cache.
+
+By default timestamps will be used for snapshotting in development mode and file hashes in production mode.
+File hashes allow to use Persistent Caching on CI too.
+
+#### Compiler Idle and Close
+
+Compilers now need to be closed after being used. Compilers now enter and leave the idle state and have hooks for these states. Plugins may use these hooks to do unimportant work. (i. e. the Persistent cache slowly stores the cache to disk). On compiler close - All remaining work should be finished as fast as possible. A callback signals the closing as done.
+
+Plugins and their respective authors should expect that some users may forget to close the Compiler. So, all work should eventually be finishing while in idle too. Processes should be prevented from exiting when the work is being done.
+
+The `webpack()` façade automatically calls `close` when being passed a callback.
+
+**MIGRATION**: While using the Node.js API, make sure to call `Compiler.close` when done.
+
+### File Emitting
+
+Webpack used to always emit all output files during the first build but skipped writing unchanged files during incremental (watch) builds.
+It is assumed that nothing else changes output files while webpack is running.
+
+With Persistent Caching added a watch-like experience should be given even when restarting the webpack process, but it would be a too strong assumption to think that nothing else changes the output directory even when webpack is not running.
+
+So webpack will now check existing files in the output directory and compares their content with the output file in memory. It will only write the file when it has been changed.
+This is only done on the first build. Any incremental build will always write the file when a new asset has been generated in the running webpack process.
+
+We assume that webpack and plugins only generate new assets when content has been changed. Caching should be used to ensure that no new asset is generated when input is equal.
+Not following this advice will degrade performance.
+
+Files that are flagged as `[immutable]` (including a content hash), will never be written when a file with the same name already exists.
+We assume that the content hash will change when file content changes.
+This is true in general, but might not be always true during webpack or plugin development.
+
+## Major Changes: Long outstanding problems
+
+### Code Splitting for single-file-targets
+
+Targets that only allow to startup a single file (like node, WebWorker, electron main) now supports loading the dependent pieces required for bootstrapping automatically by the runtime.
+
+This allows using `optimization.splitChunks` for these targets with `chunks: "all"` and also `optimization.runtimeChunk`
+
+Note that with targets where chunk loading is async, this makes initial evaluation async too. This can be an issue when using `output.library`, since the exported value is a Promise now.
+
+### Updated Resolver
+
+`enhanced-resolve` was updated to v5. This has the following improvements:
+
+- The resolve tracks more dependencies, like missing files
+- aliasing may have multiple alternatives
+- aliasing to `false` is possible now
+- support for features like `exports` and `imports` fields
+- Increased performance
+
+### Chunks without JS
+
+Chunks that contain no JS code, will no longer generate a JS file.
+This allows to have chunks that contain only CSS.
+
+## Major Changes: Future
+
+### Experiments
+
+Not all features are stable from the beginning. In webpack 4 we added experimental features and noted in the changelog that they are experimental, but it was not always clear from the configuration that these features are experimental.
+
+In webpack 5 there is a new `experiments` config option which allows to enable experimental features. This makes it clear which ones are enabled/used.
+
+While webpack follows semantic versioning, it will make an exception for experimental features. Experimental features might contain breaking changes in minor webpack versions. When this happens we will add a clear note into the changelog. This will allow us to iterate faster for experimental features, while also allowing us to stay longer on a major version for stable features.
+
+The following experiments will ship with webpack 5:
+
+- Old WebAssembly support like in webpack 4 (`experiments.syncWebAssembly`)
+- New WebAssembly support according to the [updated spec](https://github.com/WebAssembly/esm-integration) (`experiments.asyncWebAssembly`)
+  - This makes a WebAssembly module an async module
+- [Top Level Await](https://github.com/tc39/proposal-top-level-await) Stage 3 proposal (`experiments.topLevelAwait`)
+  - Using `await` on top-level makes the module an async module
+- Emitting bundle as module (`experiments.outputModule`)
+  - This removed the wrapper IIFE from the bundle, enforces strict mode, lazy loads via `<script type="module">` and minimized in module mode
+
+Note that this also means WebAssembly support is now disabled by default.
+
+### Minimum Node.js Version
+
+The minimum supported Node.js version has increased from 6 to 10.13.0(LTS).
+
+**MIGRATION**: Upgrade to the latest Node.js version available.
+
+## Changes to the Configuration
+
+### Changes to the Structure
+
+- `entry: {}` allows an empty object now (to allow to use plugins to add entries)
+- `target` supports an array, versions and browserslist
+- `cache: Object` removed: Setting to a memory-cache object is no longer possible
+- `cache.type` added: It's now possible to choose between `"memory"` and `"filesystem"`
+- New configuration options for `cache.type = "filesystem"` added:
+  - `cache.cacheDirectory`
+  - `cache.name`
+  - `cache.version`
+  - `cache.store`
+  - `cache.hashAlgorithm`
+  - `cache.idleTimeout`
+  - `cache.idleTimeoutForInitialStore`
+  - `cache.buildDependencies`
+- `snapshot.resolveBuildDependencies` added
+- `snapshot.resolve` added
+- `snapshot.module` added
+- `snapshot.managedPaths` added
+- `snapshot.immutablePaths` added
+- `resolve.cache` added: Allows to disable/enable the safe resolve cache
+- `resolve.concord` removed
+- `resolve.moduleExtensions` removed
+- `resolve.alias` values can be arrays or `false` now
+- `resolve.restrictions` added: Allows to restrict potential resolve results
+- `resolve.fallback` added: Allow to alias requests that failed to resolve
+- `resolve.preferRelative` added: Allows to resolve modules requests are relative requests too
+- Automatic polyfills for native Node.js modules were removed
+  - `node.Buffer` removed
+  - `node.console` removed
+  - `node.process` removed
+  - `node.*` (Node.js native module) removed
+  - **MIGRATION**: `resolve.alias` and `ProvidePlugin`. Errors will give hints. (Refer to [node-libs-browser](https://github.com/webpack/node-libs-browser) for polyfills & mocks used in v4)
+- `output.filename` can now be a function
+- `output.assetModuleFilename` added
+- `output.jsonpScriptType` renamed to `output.scriptType`
+- `devtool` is more strict
+  - Format: `false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map`
+- `optimization.chunkIds: "deterministic"` added
+- `optimization.moduleIds: "deterministic"` added
+- `optimization.moduleIds: "hashed"` deprecated
+- `optimization.moduleIds: "total-size"` removed
+- Deprecated flags for module and chunk ids were removed
+  - `optimization.hashedModuleIds` removed
+  - `optimization.namedChunks` removed (`NamedChunksPlugin` too)
+  - `optimization.namedModules` removed (`NamedModulesPlugin` too)
+  - `optimization.occurrenceOrder` removed
+  - **MIGRATION**: Use `chunkIds` and `moduleIds`
+- `optimization.splitChunks` `test` no longer matches chunk name
+  - **MIGRATION**: Use a test function
+    `(module, { chunkGraph }) => chunkGraph.getModuleChunks(module).some(chunk => chunk.name === "name")`
+- `optimization.splitChunks` `minRemainingSize` was added
+- `optimization.splitChunks` `filename` can now be a function
+- `optimization.splitChunks` sizes can now be objects with a size per source type
+  - `minSize`
+  - `minRemainingSize`
+  - `maxSize`
+  - `maxAsyncSize`
+  - `maxInitialSize`
+- `optimization.splitChunks` `maxAsyncSize` and `maxInitialSize` added next to `maxSize`: allows to specify different max sizes for initial and async chunks
+- `optimization.splitChunks` `name: true` removed: Automatic names are no longer supported
+  - **MIGRATION**: Use the default. `chunkIds: "named"` will give your files useful names for debugging
+- `optimization.splitChunks.cacheGroups[].idHint` added: Gives a hint how the named chunk id should be chosen
+- `optimization.splitChunks` `automaticNamePrefix` removed
+  - **MIGRATION**: Use `idHint` instead
+- `optimization.splitChunks` `filename` is no longer restricted to initial chunks
+- `optimization.splitChunks` `usedExports` added to include used exports when comparing modules
+- `optimization.splitChunks.defaultSizeTypes` added: Specified the size types when using numbers for sizes
+- `optimization.mangleExports` added
+- `optimization.minimizer` `"..."` can be used to reference the defaults
+- `optimization.usedExports` `"global"` value added to allow to disable the analysis per runtime and instead do it globally (better performance)
+- `optimization.noEmitOnErrors` renamed to `optimization.emitOnErrors` and logic inverted
+- `optimization.realContentHash` added
+- `output.devtoolLineToLine` removed
+  - **MIGRATION**: No replacement
+- `output.chunkFilename: Function` is now allowed
+- `output.hotUpdateChunkFilename: Function` is now forbidden: It never worked anyway.
+- `output.hotUpdateMainFilename: Function` is now forbidden: It never worked anyway.
+- `output.importFunctionName: string` specifies the name used as replacement for `import()` to allow polyfilling for non-supported environments
+- `output.charset` added: setting it to false omit the `charset` property on script tags
+- `output.hotUpdateFunction` renamed to `output.hotUpdateGlobal`
+- `output.jsonpFunction` renamed to `output.chunkLoadingGlobal`
+- `output.chunkCallbackFunction` renamed to `output.chunkLoadingGlobal`
+- `output.chunkLoading` added
+- `output.enabledChunkLoadingTypes` added
+- `output.chunkFormat` added
+- `module.rules` `resolve` and `parser` will merge in a different way (objects are deeply merged, array may include `"..."` to reference to prev value)
+- `module.rules` `parser.worker` added: Allows to configure the worker supported
+- `module.rules` `query` and `loaders` were removed
+- `module.rules` `options` passing a string is deprecated
+  - **MIGRATION**: Pass an options object instead, open an issue on the loader when this is not supported
+- `module.rules` `mimetype` added: allows to match a mimetype of a DataURI
+- `module.rules` `descriptionData` added: allows to match a data from package.json
+- `module.defaultRules` `"..."` can be used to reference the defaults
+- `stats.chunkRootModules` added: Show root modules for chunks
+- `stats.orphanModules` added: Show modules which are not emitted
+- `stats.runtime` added: Show runtime modules
+- `stats.chunkRelations` added: Show parent/children/sibling chunks
+- `stats.errorStack` added: Show webpack-internal stack trace of errors
+- `stats.preset` added: select a preset
+- `stats.relatedAssets` added: show assets that are related to other assets (e.g. SourceMaps)
+- `stats.warningsFilter` deprecated in favor of `ignoreWarnings`
+- `BannerPlugin.banner` signature changed
+  - `data.basename` removed
+  - `data.query` removed
+  - **MIGRATION**: extract from `filename`
+- `SourceMapDevToolPlugin` `lineToLine` removed
+  - **MIGRATION**: No replacement
+- `[hash]` as hash for the full compilation is now deprecated
+  - **MIGRATION**: Use `[fullhash]` instead or better use another hash option
+- `[modulehash]` is deprecated
+  - **MIGRATION**: Use `[hash]` instead
+- `[moduleid]` is deprecated
+  - **MIGRATION**: Use `[id]` instead
+- `[filebase]` removed
+  - **MIGRATION**: Use `[base]` instead
+- New placeholders for file-based templates (i. e. SourceMapDevToolPlugin)
+  - `[name]`
+  - `[base]`
+  - `[path]`
+  - `[ext]`
+- `externals` when passing a function, it has now a different signature `({ context, request }, callback)`
+  - **MIGRATION**: Change signature
+- `externalsPresets` added
+- `experiments` added (see Experiments section above)
+- `watchOptions.followSymlinks` added
+- `watchOptions.ignored` can now be a RegExp
+- `webpack.util.serialization` is now exposed.
+
+### Changes to the Defaults
+
+- `target` is now `"browserslist"` by default when a browserslist config is available
+- `module.unsafeCache` is now only enabled for `node_modules` by default
+- `optimization.moduleIds` defaults to `deterministic` in production mode, instead of `size`
+- `optimization.chunkIds` defaults to `deterministic` in production mode, instead of `total-size`
+- `optimization.nodeEnv` defaults to `false` in `none` mode
+- `optimization.splitChunks.minSize` defaults to `20k` in production
+- `optimization.splitChunks.enforceSizeThreshold` defaults to `50k` in production
+- `optimization.splitChunks` `minRemainingSize` defaults to `minSize`
+  - This will lead to less splitted chunks created in cases where the remaining part would be too small
+- `optimization.splitChunks` `maxAsyncRequests` and `maxInitialRequests` defaults was been increased to 30
+- `optimization.splitChunks.cacheGroups.vendors` has be renamed to `optimization.splitChunks.cacheGroups.defaultVendors`
+- `optimization.splitChunks.cacheGroups.defaultVendors.reuseExistingChunk` now defaults to `true`
+- `optimization.minimizer` target default uses `compress.passes: 2` in terser options now
+- `resolve(Loader).cache` defaults to `true` when `cache` is used
+- `resolve(Loader).cacheWithContext` defaults to `false`
+- `resolveLoader.extensions` remove `.json`
+- `node.global` `node.__filename` and `node.__dirname` defaults to `false` in node-`target`s
+- `stats.errorStack` defaults to `false`
+
+## Loader related Changes
+
+### `this.getOptions`
+
+This new API should simplify the usage for options in loaders.
+It allows to pass a JSON schema for validation.
+See [PR](https://github.com/webpack/webpack/pull/10017) for details
+
+### `this.exec`
+
+This has been removed from loader context
+
+**MIGRATION**: This can be implemented in the loader itself
+
+### `this.getResolve`
+
+`getResolve(options)` in the loader API will merge options in a different way, see `module.rules` `resolve`.
+
+As webpack 5 differs between different issuing dependencies so it might make sense to pass a `dependencyType` as option (e.g. `"esm"`, `"commonjs"`, or others).
+
+## Major Internal Changes
+
+?> This section might need a bit more refinement
+
+The following changes are only relevant for plugin authors:
+
+### New plugin order
+
+Plugins in webpack 5 are now applies **before** the configuration defaults has been applied.
+This allows plugins to apply their own defaults, or act as configuration presets.
+
+But this is also a breaking change as plugins can't rely on configuration values to be set when they are applied.
+
+**MIGRATION**: Access configuration only in plugin hooks. Or best avoid accessing configuration at all and take options via constructor.
+
+### Runtime Modules
+
+A large part of the runtime code was moved into the so-called "runtime modules". These special modules are in-charge of adding runtime code. They can be added into any chunk, but are currently always added to the runtime chunk. "Runtime Requirements" control which runtime modules (or core runtime parts) are added to the bundle. This ensures that only runtime code that is used is added to the bundle. In the future, runtime modules could also be added to an on-demand-loaded chunk, to load runtime code when needed.
+
+In most cases, the core runtime allows to inline the entry module instead of calling it with `__webpack_require__`. If there is no other module in the bundle, no `__webpack_require__` is needed at all. This combines well with Module Concatenation where multiple modules are concatenated into a single module.
+
+In the best case, no runtime code is needed at all.
+
+**MIGRATION**: If you are injecting runtime code into the webpack runtime in a plugin, consider using RuntimeModules instead.
+
+### Serialization
+
+A serialization mechanism was added to allow serialization of complex objects in webpack. It has an opt-in semantic, so classes that should be serialized need to be explicitly flagged (and their serialization implemented). This has been done for most Modules, all Dependencies and some Errors.
+
+**MIGRATION**: When using custom Modules or Dependencies, it is recommended to make them serializable to benefit from persistent caching.
+
+### Plugins for Caching
+
+A `Cache` class with a plugin interface has been added. This class can be used to write and read to the cache. Depending on the configuration, different plugins can add functionality to the cache. The `MemoryCachePlugin` adds in-memory caching. The `FileCachePlugin` adds persistent (file-system) caching.
+
+The `FileCachePlugin` uses the serialization mechanism to persist and restore cached items to/from the disk.
+
+### Hook Object Frozen
+
+Classes with `hooks` have their `hooks` object frozen, so adding custom hooks is no longer possible this way.
+
+**MIGRATION**: The recommended way to add custom hooks is using a WeakMap and a static `getXXXHooks(XXX)` (i. e. `getCompilationHook(compilation)`) method. Internal classes use the same mechanism used for custom hooks.
+
+### Tapable Upgrade
+
+The compat layer for webpack 3 plugins has been removed. It had already been deprecated for webpack 4.
+
+Some less used tapable APIs were removed or deprecated.
+
+**MIGRATION**: Use the new tapable API.
+
+### Staged Hooks
+
+For several steps in the sealing process, there had been multiple hooks for different stages. i. e. `optimizeDependenciesBasic` `optimizeDependencies` and `optimizeDependenciesAdvanced`. These have been removed in favor of a single hook which can be used with a `stage` option. See `OptimizationStages` for possible stage values.
+
+**MIGRATION**: Hook into the remaining hook instead. You may add a `stage` option.
+
+### Main/Chunk/ModuleTemplate deprecation
+
+Bundle templating has been refactored. MainTemplate/ChunkTemplate/ModuleTemplate were deprecated and the JavascriptModulesPlugin takes care of JS templating now.
+
+Before that refactoring, JS output was handled by Main/ChunkTemplate while another output (i. e. WASM, CSS) was handled by plugins. This looks like JS is first class, while another output is second class. The refactoring changes that and all output is handled by their plugins.
+
+It's still possible to hook into parts of the templating. The hooks are in JavascriptModulesPlugin instead of Main/ChunkTemplate now. (Yes plugins can have hooks too. I call them attached hooks.)
+
+There is a compat-layer, so Main/Chunk/ModuleTemplate still exist, but only delegate tap calls to the new hook locations.
+
+**MIGRATION**: Follow the advice in the deprecation messages. Mostly pointing to hooks at different locations.
+
+### Entry point descriptor
+
+If an object is passed as entry point the value might be a string, array of strings or a descriptor:
+
+```js
+module.exports = {
+  entry: {
+    catalog: {
+      import: './catalog.js',
+    },
+  },
+};
+```
+
+Descriptor syntax might be used to pass additional options to an entry point.
+
+#### Entry point output filename
+
+By default, the output filename for the entry chunk is extracted from `output.filename` but you can specify a custom output filename for a specific entry:
+
+```js
+module.exports = {
+  entry: {
+    about: { import: './about.js', filename: 'pages/[name][ext]' },
+  },
+};
+```
+
+#### Entry point dependency
+
+By default, every entry chunk stores all the modules that it uses. With `dependOn`-option you can share the modules from one entry chunk to another:
+
+```js
+module.exports = {
+  entry: {
+    app: { import: './app.js', dependOn: 'react-vendors' },
+    'react-vendors': ['react', 'react-dom', 'prop-types'],
+  },
+};
+```
+
+The app chunk will not contain the modules that `react-vendors` has.
+
+#### Entry point library
+
+The entry descriptor allows to pass a different `library` option for each entrypoint.
+
+```js
+module.exports = {
+  entry: {
+    commonjs: {
+      import: './lib.js',
+      library: {
+        type: 'commonjs-module',
+      },
+    },
+    amd: {
+      import: './lib.js',
+      library: {
+        type: 'amd',
+      },
+    },
+  },
+};
+```
+
+#### Entry point runtime
+
+The entry descriptor allows to specify a `runtime` per entry.
+When specified a chunk with this name is created which contains only the runtime code for the entry.
+When multiple entries specify the same `runtime`, that chunk will contain a common runtime for all these entry.
+This means they could be used together on the same HTML page.
+
+```js
+module.exports = {
+  entry: {
+    app: {
+      import: './app.js',
+      runtime: 'app-runtime',
+    },
+  },
+};
+```
+
+#### Entry point chunk loading
+
+The entry descriptor allows to specify a `chunkLoading` per entry.
+The runtime for this entry will use this to load chunks.
+
+```js
+module.exports = {
+  entry: {
+    app: {
+      import: './app.js',
+    },
+    worker: {
+      import: './worker.js',
+      chunkLoading: 'importScripts',
+    },
+  },
+};
+```
+
+### Order and IDs
+
+Webpack used to order modules and chunks in the Compilation phase, in a specific way, to assign IDs in incremental order. This is no longer the case. The order will no longer be used for id generation, instead, the full control of ID generation is in the plugin.
+
+Hooks to optimize the order of module and chunks have been removed.
+
+**MIGRATION**: You cannot rely on the order of modules and chunks in the compilation phase no more.
+
+### Arrays to Sets
+
+- Compilation.modules is now a Set
+- Compilation.chunks is now a Set
+- Chunk.files is now a Set
+
+There is a compat-layer which prints deprecation warnings.
+
+**MIGRATION**: Use Set methods instead of Array methods.
+
+### Compilation.fileSystemInfo
+
+This new class can be used to access information about the filesystem in a cached way. Currently, it allows asking for both file and directory timestamps. Information about timestamps is transferred from the watcher if possible, otherwise determined by filesystem access.
+
+In the future, asking for file content hashes will be added and modules will be able to check validity with file contents instead of file hashes.
+
+**MIGRATION**: Instead of using `file/contextTimestamps` use the `compilation.fileSystemInfo` API instead.
+
+Timestamping for directories is possible now, which allows serialization of ContextModules.
+
+`Compiler.modifiedFiles` has been added (next to `Compiler.removedFiles`) to make it easier to reference the changed files.
+
+### Filesystems
+
+Next to `compiler.inputFileSystem` and `compiler.outputFileSystem` there is a new `compiler.intermediateFileSystem` for all fs actions that are not considered as input or output, like writing records, cache or profiling output.
+
+The filesystems have now the `fs` interface and do no longer demand additional methods like `join` or `mkdirp`. But if they have methods like `join` or `dirname` they are used.
+
+### Hot Module Replacement
+
+HMR runtime has been refactored to Runtime Modules. `HotUpdateChunkTemplate` has been merged into `ChunkTemplate`. ChunkTemplates and plugins should also handle `HotUpdateChunk`s now.
+
+The javascript part of HMR runtime has been separated from the core HMR runtime. Other module types can now also handle HMR in their own way. In the future, this will allow i. e. HMR for the mini-css-extract-plugin or for WASM modules.
+
+**MIGRATION**: As this is a newly introduced functionality, there is nothing to migrate.
+
+`import.meta.webpackHot` exposes the same API as `module.hot`. This is also usable from strict ESM modules (.mjs, type: "module" in package.json) which do not have access to `module`.
+
+### Work Queues
+
+Webpack used to handle module processing by functions calling functions, and a `semaphore` which limits parallelism. The `Compilation.semaphore` has been removed and async queues now handle work queuing and processing. Each step has a separate queue:
+
+- `Compilation.factorizeQueue`: calling the module factory for a group of dependencies.
+- `Compilation.addModuleQueue`: adding the module to the compilation queue (may restore module from cache).
+- `Compilation.buildQueue`: building the module if necessary (may stores module to cache).
+- `Compilation.rebuildQueue`: building a module again if manually triggered.
+- `Compilation.processDependenciesQueue`: processing dependencies of a module.
+
+These queues have some hooks to watch and intercept job processing.
+
+In the future, multiple compilers may work together and job orchestration can be done by intercepting these queues.
+
+**MIGRATION**: As this is a newly introduced functionality, there is nothing to migrate.
+
+### Logging
+
+Webpack internals includes some logging now.
+`stats.logging` and `infrastructureLogging` options can be used to enabled these messages.
+
+### Module and Chunk Graph
+
+Webpack used to store a resolved module in the dependency, and store the contained modules in the chunk. This is no longer the case. All information about how modules are connected in the module graph are now stored in a ModuleGraph class. All information about how modules are connected with chunks are now stored in the ChunkGraph class. The information which depends on i. e. the chunk graph, is also stored in the related class.
+
+That means the following information about modules has been moved:
+
+- Module connections -> ModuleGraph
+- Module issuer -> ModuleGraph
+- Module optimization bailout -> ModuleGraph (TODO: check if it should ChunkGraph instead)
+- Module usedExports -> ModuleGraph
+- Module providedExports -> ModuleGraph
+- Module pre order index -> ModuleGraph
+- Module post order index -> ModuleGraph
+- Module depth -> ModuleGraph
+- Module profile -> ModuleGraph
+- Module id -> ChunkGraph
+- Module hash -> ChunkGraph
+- Module runtime requirements -> ChunkGraph
+- Module is in chunk -> ChunkGraph
+- Module is entry in chunk -> ChunkGraph
+- Module is runtime module in chunk -> ChunkGraph
+- Chunk runtime requirements -> ChunkGraph
+
+Webpack used to disconnect modules from the graph when restored from the cache. This is no longer necessary. A Module stores no info about the graph and can technically be used in multiple graphs. This makes caching easier.
+
+There is a compat-layer for most of these changes, which prints a deprecation warning when used.
+
+**MIGRATION**: Use the new APIs on ModuleGraph and ChunkGraph
+
+### Init Fragments
+
+`DependenciesBlockVariables` has been removed in favor of InitFragments. `DependencyTemplates` can now add `InitFragments` to inject code to the top of the module's source. `InitFragments` allows deduplication.
+
+**MIGRATION**: Use `InitFragments` instead of inserting something at a negative index into the source.
+
+### Module Source Types
+
+Modules now have to define which source types they support via `Module.getSourceTypes()`. Depending on that, different plugins call `source()` with these types. i. e. for source type `javascript` the `JavascriptModulesPlugin` embeds the source code into the bundle. Source type `webassembly` will make the `WebAssemblyModulesPlugin` emit a wasm file. Custom source types are also supported, i. e. the mini-css-extract-plugin will probably use the source type `stylesheet` to embed the source code into a css file.
+
+There is no relationship between module type and source type. i. e. module type `json` also uses source type `javascript` and module type `webassembly/experimental` uses source types `javascript` and `webassembly`.
+
+**MIGRATION**: Custom modules need to implement these new interface methods.
+
+### Plugins for Stats
+
+Stats `preset`, `default`, `json` and `toString` are now baked in by a plugin system. Converted the current Stats into plugins.
+
+**MIGRATION**: Instead of replacing the whole Stats functionality, you can now customize it. Extra information can now be added to the stats json instead of writing a separate file.
+
+### New Watching
+
+The watcher used by webpack was refactored. It was previously using `chokidar` and the native dependency `fsevents` (only on macOS). Now it's only based on native Node.js `fs`. This means there is no native dependency left in webpack.
+
+It also captures more information about filesystem while watching. It now captures mtimes and watches event times, as well as information about missing files. For this, the `WatchFileSystem` API changed a little bit. While on it we also converted Arrays to Sets and Objects to Maps.
+
+### SizeOnlySource after emit
+
+Webpack now replaces the Sources in `Compilation.assets` with `SizeOnlySource` variants to reduce memory usage.
+
+### Emitting assets multiple times
+
+The warning `Multiple assets emit different content to the same filename` has been made an error.
+
+### ExportsInfo
+
+The way how information about exports of modules is stored has been refactored. The ModuleGraph now features an `ExportsInfo` for each `Module`, which stores information per export. It also stores information about unknown exports and if the module is used in a side-effect-only way.
+
+For each export the following information is stored:
+
+- Is the export used? yes, no, not statically known, not determined. (see also `optimization.usedExports`)
+- Is the export provided? yes, no, not statically known, not determined. (see also `optimization.providedExports`)
+- Can be export name be renamed? yes, no, not determined.
+- The new name, if the export has been renamed. (see also `optimization.mangleExports`)
+- Nested ExportsInfo, if the export is an object with information attached itself
+  - Used for reexporting namespace objects: `import * as X from "..."; export { X };`
+  - Used for representing structure in JSON modules
+
+### Code Generation Phase
+
+The Compilation features Code Generation as separate compilation phase now. It no longer runs hidden in `Module.source()` or `Module.getRuntimeRequirements()`.
+
+This should make the flow much cleaner. It also allows to report progress for this phase and makes Code Generation more visible when profiling.
+
+**MIGRATION**: `Module.source()` and `Module.getRuntimeRequirements()` are deprecated now. Use `Module.codeGeneration()` instead.
+
+### DependencyReference
+
+Webpack used to have a single method and type to represent references of dependencies (`Compilation.getDependencyReference` returning a `DependencyReference`).
+This type used to include all information about this reference like the referenced Module, which exports have been imported, if it's a weak reference and also some ordering related information.
+
+Bundling all these information together makes getting the reference expensive and it's also called often (every time somebody needs one piece of information).
+
+In webpack 5 this part of the codebase was refactored and the method has been split up.
+
+- The referenced module can be read from the ModuleGraphConnection
+- The imported export names can be get via `Dependency.getReferencedExports()`
+- There is a `weak` flag on the `Dependency` class
+- Ordering is only relevant to `HarmonyImportDependencies` and can be get via `sourceOrder` property
+
+### Presentational Dependencies
+
+There is now a new type of dependency in `NormalModules`: Presentational Dependencies
+
+These dependencies are only used during the Code Generation phase but are not used during Module Graph building.
+So they can never have referenced modules or influence exports/imports.
+
+These dependencies are cheaper to process and webpack uses them when possible
+
+### Deprecated loaders
+
+- [`null-loader`](https://github.com/webpack-contrib/null-loader)
+
+  It will be deprecated. Use
+
+  ```js
+  module.exports = {
+    resolve: {
+      alias: {
+        xyz$: false,
+      },
+    },
+  };
+  ```
+
+  or use an absolute path
+
+  ```js
+  module.exports = {
+    resolve: {
+      alias: {
+        [path.resolve(__dirname, '....')]: false,
+      },
+    },
+  };
+  ```
+
+## Minor Changes
+
+- `Compiler.name`: When generating a compiler name with absolute paths, make sure to separate them with `|` or `!` on both parts of the name.
+  - Using space as a separator is now deprecated. (Paths could contain spaces)
+  - Hint: `|` is replaced with space in Stats string output.
+- `SystemPlugin` is now disabled by default.
+  - **MIGRATION**: Avoid using it as the spec has been removed. You can re-enable it with `Rule.parser.system: true`
+- `ModuleConcatenationPlugin`: concatenation is no longer prevented by `DependencyVariables` as they have been removed
+  - This means it can now concatenate in cases of `module`, `global`, `process` or the ProvidePlugin
+- `Stats.presetToOptions` removed
+  - **MIGRATION**: Use `compilation.createStatsOptions` instead
+- `SingleEntryPlugin` and `SingleEntryDependency` removed
+  - **MIGRATION**: use `EntryPlugin` and `EntryDependency`
+- Chunks can now have multiple entry modules
+- `ExtendedAPIPlugin` removed
+  - **MIGRATION**: No longer needed, `__webpack_hash__` and `__webpack_chunkname__` can always be used and runtime code is injected where needed.
+- `ProgressPlugin` no longer uses tapable context for `reportProgress`
+  - **MIGRATION**: Use `ProgressPlugin.getReporter(compiler)` instead
+- `ProvidePlugin` is now re-enabled for `.mjs` files
+- `Stats` json `errors` and `warnings` no longer contain strings but objects with information splitted into properties.
+  - **MIGRATION**: Access the information on the properties. i. e. `message`
+- `Compilation.hooks.normalModuleLoader` is deprecated
+  - **MIGRATION**: Use `NormalModule.getCompilationHooks(compilation).loader` instead
+- Changed hooks in `NormalModuleFactory` from waterfall to bailing, changed and renamed hooks that return waterfall functions
+- Removed `compilationParams.compilationDependencies`
+  - Plugins can add dependencies to the compilation by adding to `compilation.file/context/missingDependencies`
+  - Compat layer will delegate `compilationDependencies.add` to `fileDependencies.add`
+- `stats.assetsByChunkName[x]` is now always an array
+- `__webpack_get_script_filename__` function added to get the filename of a script file
+- `"sideEffects"` in package.json will be handled by `glob-to-regex` instead of `micromatch`
+  - This may have changed semantics in edge-cases
+- `checkContext` was removed from `IgnorePlugin`
+- New `__webpack_exports_info__` API allows export usage introspection
+- SourceMapDevToolPlugin applies to non-chunk assets too now
+- EnvironmentPlugin shows an error now when referenced env variable is missing and has no fallback
+- Remove `serve` property from schema
+
+## Other Minor Changes
+
+- removed builtin directory and replaced builtins with runtime modules
+- Removed deprecated features
+  - BannerPlugin now only support one argument that can be an object, string or function
+- removed `CachePlugin`
+- `Chunk.entryModule` is deprecated, use ChunkGraph instead
+- `Chunk.hasEntryModule` is deprecated
+- `Chunk.addModule` is deprecated
+- `Chunk.removeModule` is deprecated
+- `Chunk.getNumberOfModules` is deprecated
+- `Chunk.modulesIterable` is deprecated
+- `Chunk.compareTo` is deprecated
+- `Chunk.containsModule` is deprecated
+- `Chunk.getModules` is deprecated
+- `Chunk.remove` is deprecated
+- `Chunk.moveModule` is deprecated
+- `Chunk.integrate` is deprecated
+- `Chunk.canBeIntegrated` is deprecated
+- `Chunk.isEmpty` is deprecated
+- `Chunk.modulesSize` is deprecated
+- `Chunk.size` is deprecated
+- `Chunk.integratedSize` is deprecated
+- `Chunk.getChunkModuleMaps` is deprecated
+- `Chunk.hasModuleInGraph` is deprecated
+- `Chunk.updateHash` signature changed
+- `Chunk.getChildIdsByOrders` signature changed (TODO: consider moving to `ChunkGraph`)
+- `Chunk.getChildIdsByOrdersMap` signature changed (TODO: consider moving to `ChunkGraph`)
+- `Chunk.getChunkModuleMaps` removed
+- `Chunk.setModules` removed
+- deprecated Chunk methods removed
+- `ChunkGraph` added
+- `ChunkGroup.setParents` removed
+- `ChunkGroup.containsModule` removed
+- `Compilation.cache` was removed in favor of `Compilation.getCache()`
+- `ChunkGroup.remove` no longer disconnected the group from block
+- `ChunkGroup.compareTo` signature changed
+- `ChunkGroup.getChildrenByOrders` signature changed
+- `ChunkGroup` index and index renamed to pre/post order index
+  - old getter is deprecated
+- `ChunkTemplate.hooks.modules` signature changed
+- `ChunkTemplate.hooks.render` signature changed
+- `ChunkTemplate.updateHashForChunk` signature changed
+- `Compilation.hooks.optimizeChunkOrder` removed
+- `Compilation.hooks.optimizeModuleOrder` removed
+- `Compilation.hooks.advancedOptimizeModuleOrder` removed
+- `Compilation.hooks.optimizeDependenciesBasic` removed
+- `Compilation.hooks.optimizeDependenciesAdvanced` removed
+- `Compilation.hooks.optimizeModulesBasic` removed
+- `Compilation.hooks.optimizeModulesAdvanced` removed
+- `Compilation.hooks.optimizeChunksBasic` removed
+- `Compilation.hooks.optimizeChunksAdvanced` removed
+- `Compilation.hooks.optimizeChunkModulesBasic` removed
+- `Compilation.hooks.optimizeChunkModulesAdvanced` removed
+- `Compilation.hooks.optimizeExtractedChunksBasic` removed
+- `Compilation.hooks.optimizeExtractedChunks` removed
+- `Compilation.hooks.optimizeExtractedChunksAdvanced` removed
+- `Compilation.hooks.afterOptimizeExtractedChunks` removed
+- `Compilation.hooks.stillValidModule` added
+- `Compilation.hooks.statsPreset` added
+- `Compilation.hooks.statsNormalize` added
+- `Compilation.hooks.statsFactory` added
+- `Compilation.hooks.statsPrinter` added
+- `Compilation.fileDependencies`, `Compilation.contextDependencies` and `Compilation.missingDependencies` are now LazySets
+- `Compilation.entries` removed
+  - **MIGRATION**: Use `Compilation.entryDependencies` instead
+- `Compilation._preparedEntrypoints` removed
+- `dependencyTemplates` is now a `DependencyTemplates` class instead of a raw `Map`
+- `Compilation.fileTimestamps` and `contextTimestamps` removed
+  - **MIGRATION**: Use `Compilation.fileSystemInfo` instead
+- `Compilation.waitForBuildingFinished` removed
+  - **MIGRATION**: Use the new queues
+- `Compilation.addModuleDependencies` removed
+- `Compilation.prefetch` removed
+- `Compilation.hooks.beforeHash` is now called after the hashes of modules are created
+  - **MIGRATION**: Use `Compilation.hooks.beforeModuleHash` instead
+- `Compilation.applyModuleIds` removed
+- `Compilation.applyChunkIds` removed
+- `Compiler.root` added, which points to the root compiler
+  - it can be used to cache data in WeakMaps instead of statically scoped
+- `Compiler.hooks.afterDone` added
+- `Source.emitted` is no longer set by the Compiler
+  - **MIGRATION**: Check `Compilation.emittedAssets` instead
+- `Compiler/Compilation.compilerPath` added: It's a unique name of the compiler in the compiler tree. (Unique to the root compiler scope)
+- `Module.needRebuild` deprecated
+  - **MIGRATION**: use `Module.needBuild` instead
+- `Dependency.getReference` signature changed
+- `Dependency.getExports` signature changed
+- `Dependency.getWarnings` signature changed
+- `Dependency.getErrors` signature changed
+- `Dependency.updateHash` signature changed
+- `Dependency.module` removed
+- There is now a base class for `DependencyTemplate`
+- `MultiEntryDependency` removed
+- `EntryDependency` added
+- `EntryModuleNotFoundError` removed
+- `SingleEntryPlugin` removed
+- `EntryPlugin` added
+- `Generator.getTypes` added
+- `Generator.getSize` added
+- `Generator.generate` signature changed
+- `HotModuleReplacementPlugin.getParserHooks` added
+- `Parser` was moved to `JavascriptParser`
+- `ParserHelpers` was moved to `JavascriptParserHelpers`
+- `MainTemplate.hooks.moduleObj` removed
+- `MainTemplate.hooks.currentHash` removed
+- `MainTemplate.hooks.addModule` removed
+- `MainTemplate.hooks.requireEnsure` removed
+- `MainTemplate.hooks.globalHashPaths` removed
+- `MainTemplate.hooks.globalHash` removed
+- `MainTemplate.hooks.hotBootstrap` removed
+- `MainTemplate.hooks` some signatures changed
+- `Module.hash` deprecated
+- `Module.renderedHash` deprecated
+- `Module.reasons` removed
+- `Module.id` deprecated
+- `Module.index` deprecated
+- `Module.index2` deprecated
+- `Module.depth` deprecated
+- `Module.issuer` deprecated
+- `Module.profile` removed
+- `Module.prefetched` removed
+- `Module.built` removed
+- `Module.used` removed
+  - **MIGRATION**: Use `Module.getUsedExports` instead
+- Module.usedExports deprecated
+  - **MIGRATION**: Use `Module.getUsedExports` instead
+- `Module.optimizationBailout` deprecated
+- `Module.exportsArgument` removed
+- `Module.optional` deprecated
+- `Module.disconnect` removed
+- `Module.unseal` removed
+- `Module.setChunks` removed
+- `Module.addChunk` deprecated
+- `Module.removeChunk` deprecated
+- `Module.isInChunk` deprecated
+- `Module.isEntryModule` deprecated
+- `Module.getChunks` deprecated
+- `Module.getNumberOfChunks` deprecated
+- `Module.chunksIterable` deprecated
+- `Module.hasEqualsChunks` removed
+- `Module.useSourceMap` moved to `NormalModule`
+- `Module.addReason` removed
+- `Module.removeReason` removed
+- `Module.rewriteChunkInReasons` removed
+- `Module.isUsed` removed
+  - **MIGRATION**: Use `isModuleUsed`, `isExportUsed` and `getUsedName` instead
+- `Module.updateHash` signature changed
+- `Module.sortItems` removed
+- `Module.unbuild` removed
+  - **MIGRATION**: Use `invalidateBuild` instead
+- `Module.getSourceTypes` added
+- `Module.getRuntimeRequirements` added
+- `Module.size` signature changed
+- `ModuleFilenameHelpers.createFilename` signature changed
+- `ModuleProfile` class added with more data
+- `ModuleReason` removed
+- `ModuleTemplate.hooks` signatures changed
+- `ModuleTemplate.render` signature changed
+- `Compiler.dependencies` removed
+  - **MIGRATION**: Use `MultiCompiler.setDependencies` instead
+- `MultiModule` removed
+- `MultiModuleFactory` removed
+- `NormalModuleFactory.fileDependencies`, `NormalModuleFactory.contextDependencies` and `NormalModuleFactory.missingDependencies` are now LazySets
+- `RuntimeTemplate` methods now take `runtimeRequirements` arguments
+- `serve` property is removed
+- `Stats.jsonToString` removed
+- `Stats.filterWarnings` removed
+- `Stats.getChildOptions` removed
+- `Stats` helper methods removed
+- `Stats.toJson` signature changed (second argument removed)
+- `ExternalModule.external` removed
+- `HarmonyInitDependency` removed
+- `Dependency.getInitFragments` deprecated
+  - **MIGRATION**: Use `apply` `initFragments` instead
+- DependencyReference now takes a function to a module instead of a Module
+- HarmonyImportSpecifierDependency.redirectedId removed
+  - **MIGRATION**: Use `setId` instead
+- acorn 5 -> 8
+- Testing
+  - HotTestCases now runs for multiple targets `async-node` `node` `web` `webworker`
+  - TestCases now also runs for filesystem caching with `store: "instant"` and `store: "pack"`
+  - TestCases now also runs for deterministic module ids
+- Tooling added to order the imports (checked in CI)
+- Chunk name mapping in runtime no longer contains entries when chunk name equals chunk id
+- add `resolvedModuleId` `resolvedModuleIdentifier` and `resolvedModule` to reasons in Stats which point to the module before optimizations like scope hoisting
+- show `resolvedModule` in Stats toString output
+- loader-runner was upgraded: https://github.com/webpack/loader-runner/releases/tag/v3.0.0
+- `file/context/missingDependencies` in `Compilation` are no longer sorted for performance reasons
+  - Do not rely on the order
+- webpack-sources was upgraded to version 2: https://github.com/webpack/webpack-sources/releases/tag/v2.0.1
+- webpack-command support was removed
+- Use schema-utils@2 for schema validation
+- `Compiler.assetEmitted` has an improved second argument with more information
+- BannerPlugin omits trailing whitespace
+- removed `minChunkSize` option from `LimitChunkCountPlugin`
+- reorganize from javascript related files into sub-directory
+  - `webpack.JavascriptModulesPlugin` -> `webpack.javascript.JavascriptModulesPlugin`
+- Logger.getChildLogger added
+- change the default of entryOnly of the DllPlugin to true
+- remove special request shortening logic and use single relative paths for readable module names
+- allow webpack:// urls in SourceMaps to provided paths relative to webpack root context
+- add API to generate and process CLI arguments targeting webpack configuration
+- add `__system_context__` as context from System.js when using System.js as libraryTarget
+- add bigint support for the DefinePlugin
+- add bigint support for basic evaluations like maths
+- remove ability to modify the compilation hash after the hash has been created
+- remove HotModuleReplacementPlugin multiStep mode
+- `assetInfo` from `emitAsset` will now merge when nested objects or arrays are used
+- `[query]` is now a valid placeholder when for paths based on a `filename` like assets
+- add `Compilation.deleteAsset` to correctly delete an assets and non-shared related assets
+- expose `require("webpack-sources")` as `require("webpack").sources`
+- terser 5
+- Webpack can be written with a capital W when at the start of a sentence

--- a/pages/blog/posts/2020-12-08-roadmap-2021.md
+++ b/pages/blog/posts/2020-12-08-roadmap-2021.md
@@ -1,0 +1,237 @@
+---
+layout: post
+date: 2020-12-08T00:00:00Z
+authors:
+  - sokra
+category: Roadmap
+image: /assets/blog/cover-2.svg
+description: A look ahead at the Webpack roadmap for 2021, focusing on ESM support, treating CSS and HTML as first-class citizens, and further stabilizing webpack 5.
+---
+
+# Roadmap 2021
+
+It has been nearly 2 months since webpack 5 was officially released. Due to the sponsoring situation, we couldn't devote as much time to webpack as we would like to. Speaking only for myself (@sokra), I enjoyed the little break and have worked on a few side projects. Ironically, while I was using webpack 5 and all its bleeding-edge features (asset modules, worker support, persistent caching), I discovered a few more bugs in webpack 5 that people are likely to run into when upgrading their projects to webpack 5, which led to a lot of work going into bug fixing. Here is a little summary:
+
+## What happened so far?
+
+A few more things have been exposed from webpack, both typings-wise and runtime-wise. A few low-handling performance improvements have been made. Code without semicolons used to generate some invalid/incorrect code in some cases, which has been corrected. The combination of side-effect-free code + concatenated modules + reexports has led to some edge cases, which have been fixed (at least the known ones).
+
+But one bug reported by a user has led to the need for a completely new internal feature. You can skip it and go to the next chapter if you find webpack internals boring or too complex.
+
+To trigger the bug we need three ingredients:
+
+- Since webpack 5 the optimization in `production` mode will run the used exports analysis (Tree Shaking) against each runtime (which is often identical to the entrypoints), which means webpack can optimize each runtime (resp. entrypoint) individually.
+- A custom `optimization.splitChunks` configuration allows to forcefully merge modules into a single chunk. This is done by passing the `name` option. E.g. `{ test: /node_modules/, name: "vendors" }` merges modules from `node_modules` into a single chunk. While this is not recommended in general, it's possible and probably makes sense in some cases. The whole thing is about trade-offs anyway and choosing to merge all vendors into a single chunk can be good for long term caching this chunk for repeated visits or between multiple entrypoints.
+- When exports of a side-effect-free module are not used, the whole module is omitted from the module graph and the `import`-statement generates no runtime code at all.
+
+A problem happens in an edge case where modules from two entrypoints are merged into a single chunk and they reference a side-effect-free module which is not in the shared chunk since only one of the entrypoints uses exports from the side-effect-free module. Modules in the shared chunk are used by both entrypoint, thus they need to include the exports that are used by any of the entrypoints.
+That means it will generate code referencing the side-effect-free module that is not available at runtime for the other entrypoint in the aforementioned edge case, which leads to an `undefined is not a function` or `cannot read property 'call' of undefined` error at runtime.
+
+A potential fix would be to include the side-effect-free module in all entrypoints, but as this module isn't really needed, that would be a waste of bundle size.
+So we went another route, which required the development of a new feature: `runtime-dependent code generation`.
+This allows to generate code which behaves differently depending on which runtime it executes.
+
+To put it another way, we are wrapping some generated code in `if`-blocks, so they only execute in one runtime.
+In this example, this would affect the `import`-statement which references the side-effect-free module.
+The import is only executed for one of the entrypoints.
+This avoids to include unnecessary modules, and it also avoids executing unnecessary code even if it would be available.
+So even if you are merging all code into a single chunk, only the code that is really used is executed.
+
+So far for the excurse, I hope it wasn't that boring...
+
+## Roadmap 2021
+
+So assuming we can sort out our sponsoring situation, the following is planned for 2021:
+
+### Further stabilizing
+
+Our top-priority stays stabilizing webpack 5.
+So far the situation looks pretty good.
+Most critical bugs reported in the last time, affect some edge cases.
+So I guess webpack 5 should work for the general cases.
+But handling edge cases is (and should stay) one of webpack strength, so we want to continue to work hard fixing these.
+We think that many many webpack users need custom things for their build and that's something webpack offers via configurability and its rich plugin system.
+
+### EcmaScript Modules
+
+EcmaScript Modules (ESM) are slowly gaining wide-spread adoption.
+On authoring side they are already the de facto standard to write code.
+On browser support it also looks pretty ok (except for IE11 and a few older mobile browsers).
+Browsers are still a bit lacking in supporting ESM for WebWorkers.
+
+One can also generate bundles that run in a `type=module` script tag, but that has few benefits currently.
+
+There are multiple areas in webpack where ESM support can be improved:
+
+#### ESM as chunk loading mechanism
+
+When targeting the web webpack loads chunks via `script` tags.
+When targeting node.js webpack loads chunks via `require` or `fs` + `vm`.
+When targeting WebWorkers webpack loads chunk via `importScripts`.
+
+In a not-so-far future, all these environments support ESM and more importantly the dynamic `import()` function.
+So a chunk loading mechanism based on `import()` can unify all these environments, while even needing less runtime code.
+
+#### Self-executed chunks
+
+Currently on-demand-loaded chunks in webpack are always containers for module and never execute module code directly.
+When writing `import("./module")` in modules, this will compile to something like `__webpack_load_chunk__("chunk-containing-module.js").then(() => __webpack_require__("./module"))`.
+There are many cases where this can't be changed (e.g. when loading multiple chunks or loading CSS too), but there are some cases where webpack could generate a chunk that directly executes the contained module.
+This could lead to less generated code and would avoid the function wrapping in the chunk.
+
+Currently I'm not yet sure if this is worth it, but it's at least worth looking into that.
+
+#### ESM exports
+
+Currently it's not possible to generate ESM exports for a bundle via `output.library.type: "module"`.
+This can be useful when integrating webpack bundles into ESM loading environments or inline scripts.
+
+T> For webpack 4 there is actually a plugin, but native support would be preferable.
+
+#### ESM externals (import)
+
+Webpack allows to define `externals` which are modules that are not bundled but exist at runtime.
+There are many types of externals ranging from globals over CommonJs/AMD/System to loading from classic script tag.
+Even `import()` (`type: "import"`) can be used to load an external, but `import` (`type: "module"`) can't be used yet.
+
+Interestingly even while `type: "module"` isn't supported yet, webpack already uses it as default when writing e.g. `import x from "https://example.com/module.js"`.
+The default has been choosing to seamlessly add support for ESM externals without introducing a breaking change.
+
+Absolute URLs in `import`s can make sense e.g. when using external services that offer their API as ESM: `import { event } from "https://analytics.company.com/api/v1.js"` (`import("https://analytics.company.com/api/v1.js")` might make more sense to gracefully handle errors when depending on this external service, but errors could also be caught higher in module graph).
+
+As usual the `externals` configuration allows to map any module name to externals:
+
+```js
+export default {
+  externalsType: 'module',
+  externals: {
+    analytics: 'https://analytics.company.com/api/v1.js',
+    svelte: 'https://jspm.dev/svelte@3',
+    react: 'https://cdn.skypack.dev/preact@10',
+    'react-dom': 'https://esm.sh/[react,react-dom]/react-dom',
+  },
+};
+```
+
+W> Using multiple different ESM CDNs will not work. This is only an example.
+
+#### ESM library
+
+When ESM exports and import are supported people might think bundling a library makes sense, and that's probably true in some cases, but in many cases natively bundling will result in worse results.
+The biggest problem is the `"sideEffects": false` flag. It affects modules on per file base to skip whole modules. When concatenating multiple side-effect-free modules it's no longer possible to skip the individual modules, which leads to worse optimization when not all exports of the library are used.
+
+When the output should be a library that will be processed by a bundler later, this needs to be considered.
+
+I could think of a special mode, which does not apply chunking and instead, emit the raw (processed) modules connected via ESM imports and exports (or also CommonJS `require`).
+So this means loaders, module graph, and asset optimizations run, but no chunk graph is created and each module in the module graph is emitted as a separate file.
+
+#### Strict mode warnings
+
+When generating an ESM bundle, all contained code will be forced to strict mode.
+For many modules, this isn't an issue, but there are a few older packages that might have trouble with the different semantic.
+We want to show warnings for these cases.
+
+### More first-class citizen
+
+Webpack 4 and 5 did a lot of work to support non-JS module types, and webpack 5 already supports some module types by default: JS (ESM/CJS/AMD), JSON, WebAssembly, Asset.
+Since webpack 5 one of our long term goals is to become a web-app optimizer, with the goal of supporting everything the browser supports.
+So technically a vanilla web app should work out-of-the-box with webpack, but being optimized on the go.
+
+The initial webpack 5 release already did some major steps in this direction: `new Worker` is supported natively. `new URL(...)` is supported natively (assets).
+
+WebAssembly and JSON is already supported, even while the proposals are not finished yet.
+
+But two resource types are still missing for the complete story: HTML and CSS.
+
+#### CSS as modules
+
+Currently webpack supports CSS via `css-loader`, `style-loader` or `mini-css-extract-plugin`.
+This is working pretty well, but I think we can do more by supporting CSS as a native module type in webpack.
+
+A major benefit would be the developer experience: The `mini-css-extract-plugin` configuration is not the easiest and getting rid of it would simplify a lot for the developer.
+That doesn't mean you can add additional customization on top of that.
+I see many developers not using raw CSS, but using preprocessors on top of that (with native CSS support this would look like that: `{ test: /\.sass$/, type: "stylesheet", use: "sass-loader" }`).
+
+As of [State of CSS 2020](https://2020.stateofcss.com/en-US/technologies/css-in-js/) CSS Modules is a popular way of writing modular CSS and it being a native module type in webpack allows to benefit from module graph optimization like Tree Shaking (Used Exports Optimization and Side-Effects optimization). When using CSS Modules this means the resulting CSS will only contain CSS rules that are referenced from the application (as one is used to from JS Tree Shaking).
+
+There are some potential CSS Modules specific optimizations which are possible with the global knowledge of the application webpack has: CSS rules can be split into smaller rules to avoid repeating common properties. This can result in a much smaller payload as the output CSS contains fewer repeated properties (Atomic CSS).
+
+But there is a big "BUT" here: There is work towards a different "CSS Modules" proposal in the WebComponents community, which is planned to become natively supported by browsers.
+At least that's the goal of the proposal.
+Sadly this proposal is different from what's currently used in the Frontend ecosystem but uses similar syntax.
+Usually, webpack would align with proposals, so that's something to consider here.
+We have to check whether it's possible to avoid potential conflicts.
+
+#### HTML as entrypoint
+
+Following Parcels example, we also want to support HTML natively as entrypoints.
+Supporting that would be inline with the goal as web app optimizer, as web apps usually start with an HTML document.
+It is also a huge developer experience improvement for beginners as many things can be inferred from the HTML.
+
+Being in control of the generated HTML does also allow to optimize more aggressively by default.
+Currently, we prevent renaming or splitting initial chunks by default, as this requires additional infrastructure for the HTML generation.
+
+HTML entrypoints also benefit from CSS as modules and Asset modules, as these resources can be referenced from HTML too (e.g. `<link rel=stylesheet />`, `<img src="..." />`, `<link rel=icon />`).
+
+#### HTML modules
+
+There is also a proposal about native support of importing HTML in browsers, that's something we will follow, especially as there is a huge overlap with HTML entrypoints.
+
+### SourceMap performance
+
+Using (full) SourceMaps with webpack is currently quite expensive with webpack, as performance for SourceMap processing isn't the best.
+This is something we want to look into for webpack, but also for terser, which is used by webpack as minimizer by default.
+
+### `exports`/`imports` package.json field
+
+Node.js 14 has added support for the `exports` field in package.json to allow to define entrypoints of a package.
+Webpack 5 followed this, and even added additional conditions like `production/development`.
+
+Shortly after that Node.js made further additions to that, e.g. they also added an `imports` field for private imports.
+
+That's something we also want to add.
+
+### Improve CommonJS analysis
+
+While ESM is the future, there are still a lot of CommonJS packages in npm and in use.
+Webpack 5 added analysis for CommonJS modules to allow Tree Shaking for most of these modules.
+
+But we can do more. While many exporting patterns are supported, only a few importing patterns are supported.
+We want to add support for more patterns to allow more optimizations for CommonJS modules too.
+
+### Hot Module Replacement for Module Federation
+
+Webpack 5 added a new feature called "Module Federation" which allows integrating multiple builds together at runtime.
+Currently, Hot Module Replacement (HMR) supports only a single build at a time and updates can't bubble between builds.
+We want to improve here and allow HMR updates to bubble between different builds, which would improve developing federation applications.
+
+### Hinting system
+
+Currently, webpack displays warnings and errors to the user.
+During the build, there are quite a few cases where we could tell the user something, like potential footguns or optimization opportunities, but they don't fit into warnings or errors and we don't want to spam the output with all this information.
+So we want to add another category: Hints.
+We want to collect all hints during builds (plugins could also emit some), but only display a limited number of them in the output (by default only one).
+This should lead to some kind of "Did you know" experience for the user.
+
+### Multi-Threading
+
+While Persistent Caching makes cached build "blazing" fast, initial builds without Persistent Cache have still a bit of room for improvement.
+Javascript execution in Node.js is single-threaded by default, but recent additions allow to use `worker_threads`, which is an API similar to WebWorkers.
+
+This can be used distribute work across all CPUs. There has already been some preparations in webpack 5 for that: e.g. serializing of internal data structures is possible and the work queues support plugins. But some parts of that are still unclear and require experimentation.
+
+This is in our voting list for a while, but not many have voted on that. Is this really something people need?
+
+### WebAssembly
+
+Currently, WebAssembly is experimental and not enabled by default.
+Once the proposal reaches Stage 4 we can enable it by default.
+
+This might also lead to a wider adoption of WebAssembly in the ecosystem.
+I think we might see more in this field in 2021.
+
+## Disclaimer
+
+This list is not set in stone.
+The web ecosystem changes so fast that we probably end up implementing totally different things, that we might not even aware of at this time.
+We do not even know how much time we can invest in webpack, considering our current sponsoring situation.

--- a/pages/blog/posts/2026-02-03-webpack-5-105.md
+++ b/pages/blog/posts/2026-02-03-webpack-5-105.md
@@ -1,0 +1,232 @@
+---
+layout: post
+date: 2026-02-03T00:00:00Z
+authors:
+  - bjohansebas
+category: Release
+image: /assets/blog/cover-3.svg
+description: Webpack 5.105 brings CVE fixes, native tsconfig.json alias resolution without plugins, automatic module resolution for Web Workers, and cleaner ESM output.
+---
+
+# Webpack 5.105
+
+Webpack 5.105 brings several improvements, both in code generation and bug fixes.
+
+- [Two Low-Severity CVEs Fixed in Webpack](#two-low-severity-cves-fixed-in-webpack)
+- [`tsconfig.json` Alias Resolution Without Requiring plugins](#tsconfigjson-alias-resolution-without-requiring-plugins)
+- [Automatic Module Resolution for Web Workers](#automatic-module-resolution-for-web-workers)
+- [Support Import Specifier Guard](#support-import-specifier-guard)
+- [Support `import.defer()` for Context Module](#support-importdefer-for-context-module)
+- [Preserving Custom `import.meta` Properties](#preserving-custom-importmeta-properties)
+- [Better Control of Source Maps in `devtool`](#better-control-of-source-maps-in-devtool)
+- [Cleaner ESM output for Node.js and modern builds](#cleaner-esm-output-for-nodejs-and-modern-builds)
+- [Other Improvements and Bug Fixes](#other-improvements-and-bug-fixes)
+
+---
+
+## Two Low-Severity CVEs Fixed in Webpack
+
+Two new low-severity CVEs in Webpack have been fixed and published.
+By default, you are safe; these issues only affect users of the experimental
+[`experiments.buildHttp`](/configuration/experiments/#experimentsbuildhttp) option.
+
+### Affected CVEs:
+
+#### CVE-2025-68157
+
+- For more details, see the advisory: [GHSA-38r7-794h-5758](https://github.com/webpack/webpack/security/advisories/GHSA-38r7-794h-5758)
+- Affected versions: `>=5.49.0 <5.104.0`
+
+#### CVE-2025-68458
+
+- For more details, see the advisory: [GHSA-8fgc-7cc6-rx7x](https://github.com/webpack/webpack/security/advisories/GHSA-8fgc-7cc6-rx7x)
+- Affected versions: `>=5.49.0 <5.104.1`
+
+Even though these are low-severity CVEs, it’s still a good idea to
+update if you use the affected versions.
+
+For more information on reporting security vulnerabilities,
+see the [Webpack Security Policy](https://github.com/webpack/webpack/security/policy)
+.
+
+## `tsconfig.json` Alias Resolution Without Requiring plugins
+
+Module resolution can be configured to read `compilerOptions.baseUrl` and `compilerOptions.paths` from `tsconfig.json` and apply those aliases when resolving imports. As a result, it is no longer necessary to install and configure the external `tsconfig-paths-webpack-plugin` just to make TypeScript path aliases work during bundling.
+
+In the webpack configuration, the `resolve.tsconfig` option is used to specify which tsconfig file should be used as the source (which is also useful in monorepos or setups with multiple tsconfig files):
+
+```js
+// webpack.config.js
+module.exports = {
+  resolve: {
+    tsconfig: './tsconfig.json', // Can be `false` (disabled), `true` (use the default tsconfig.json), a path to a `tsconfig.json` file, or an object with configFile and references options.
+  },
+};
+```
+
+Example of aliases in tsconfig.json:
+
+```json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
+}
+```
+
+And then in the code:
+
+```ts
+import Button from '@/components/Button';
+```
+
+This way, `@/components/Button` can be resolved according to the rules defined in `tsconfig.json`, avoiding the need to duplicate aliases in `resolve.alias` and reducing discrepancies between what TypeScript understands and what the bundler resolves.
+
+## Automatic Module Resolution for Web Workers
+
+When importing a package specifically to be used in a Web Worker in Webpack, module resolution can prioritize files like `index.worker.js` over `index.js` when using [conditional exports](https://nodejs.org/api/packages.html#conditional-exports) defined in the `exports` field of `package.json`.
+
+This means that if you define conditions such as `"worker"` in your package's exports, Webpack will automatically select the appropriate version, like `index.worker.js`, whenever the package is imported inside a worker context. There’s no need to modify the `resolve.conditionNames` option or make additional Webpack configuration changes; you just need to specify the conditions correctly in `package.json`.
+
+For example, in `package.json`:
+
+```json
+{
+  "name": "foo",
+  "exports": {
+    ".": {
+      "worker": "./index.worker.js",
+      "default": "./index.js"
+    }
+  }
+}
+```
+
+Now, when importing the `foo` package inside a Worker, Webpack will automatically choose the `index.worker.js` file according to the export conditions:
+
+{/_ eslint-disable _/}
+
+```js
+// This import is inside a Worker context, so Webpack uses index.worker.js
+const worker = new Worker(new URL('foo', import.meta.url), {
+  type: 'module',
+});
+```
+
+{/_ eslint-enable _/}
+
+## Support Import Specifier Guard
+
+Support for import specifier guards has been added, an improvement that helps the bundler better understand a common pattern checking whether an export exists before using it. Previously, even if the code was correctly guarded by an if, the access could be interpreted as unconditional and result in warnings like “export … was not found”.
+
+With this change, those checks are recognized as a signal that the access is conditional, and the analysis is adjusted accordingly. In practice, this makes it possible to write code that is more compatible across different versions of the same library, where an export may or may not exist, without unnecessary noise during compilation.
+
+```js
+import * as React from 'react';
+
+if (React.useId) {
+  // create guard for `React` => userId: ["", "useId"].
+  React.useId; // React -> "useId" is in guard.
+  React; //  React -> "" is in guard.
+}
+```
+
+## Support `import.defer()` for Context Module
+
+Webpack now supports `import.defer()` even when the import is a context module (that is, when the import path is built dynamically and webpack needs to include a set of possible files). In practice, this makes it much easier to defer the loading of a module selected at runtime, even when that module comes from a dynamic expression pointing to a directory. This enables patterns like “choose between a.js or b.js and load it only when needed”, with webpack generating the appropriate context so that import.defer() works correctly.
+
+{/_ eslint-disable _/}
+
+```text
+const file = Math.random() > 0.5 ? "a.js" : "b.js";
+import.defer("./dir/" + file);
+```
+
+{/_ eslint-enabled _/}
+
+## Preserving Custom `import.meta` Properties
+
+Webpack now preserves custom `import.meta` properties during bundling when [`output.module`](/configuration/output/#outputmodule) is enabled. Previously, Webpack would remove any unknown `import.meta` properties (such as `import.meta.customProp`), causing the loss of contextual or tool-specific information in the build.
+
+With this change, any non-standard property you add to `import.meta` will remain intact in the generated code, allowing the use of custom meta-information or additional signals in modern applications.
+
+```js
+if (!import.meta.UNKNOWN_PROPERTY) {
+  // runtime assignment
+  import.meta.UNKNOWN_PROPERTY = 'HELLO';
+}
+```
+
+If `output.module` is not enabled, Webpack will continue to remove unknown properties unless you explicitly indicate otherwise. To preserve them manually, you can configure [`module.parser.javascript.importMeta`](/configuration/module/#moduleparserjavascriptimportmeta) as 'preserve-unknown' in your `webpack.config.js`:
+
+```js
+// webpack.config.js
+module.exports = {
+  module: {
+    parser: {
+      javascript: {
+        importMeta: 'preserve-unknown',
+      },
+    },
+  },
+};
+```
+
+This way, even without `output.module: true`, any custom import.meta property, such as `import.meta.customProp`, will be preserved in the build.
+
+## Better Control of Source Maps in `devtool`
+
+Webpack now allows the `devtool` option to accept both a **string** and an array of objects for advanced configurations.
+
+Each object in the array can include:
+
+- `type`: which can be `"all"`, `"css"`, or `"javascript"`.
+- `use`: where you define the type of source map to generate.
+
+This enables specifying different types of source maps for different resources in your project. For example:
+
+```js
+// webpack.config.js
+module.exports = {
+  target: ['web', 'node'],
+  experiments: {
+    css: true,
+  },
+  devtool: [
+    {
+      type: 'javascript',
+      use: 'source-map',
+    },
+    {
+      type: 'css',
+      use: 'inline-source-map',
+    },
+  ],
+};
+```
+
+In this example, standard source maps are applied to all modules, and inline source maps are used specifically for CSS files.
+
+This new option is especially useful if you are using Webpack’s [experimental CSS compilation feature](/configuration/experiments/#experimentscss), as it gives you greater control over the debugging process and improves integration with external tools.
+
+It’s worth noting that the classic string syntax, like `devtool: "source-map"`, remains fully valid and supported.
+
+## Cleaner ESM Output for Node.js and Modern Builds
+
+This improvement in Webpack optimizes the handling and representation of Node.js native modules (such as `fs`, `path`, or `crypto`) during bundling, especially when using the [`output.module`](/configuration/output/#outputmodule) option in the configuration. When `output.module: true` is enabled, Webpack now generates imports of native modules using ES module syntax `import ... from "module"` instead of CommonJS `require("module")`, regardless of whether the code will run in a web or Node.js environment.
+
+## Other Improvements and Bug Fixes
+
+- **Webpack-dev-server** has released a new version to update dependencies that had reported transitive vulnerabilities, so updating is recommended. Additionally, the option to close the error overlay by pressing the ESC key has been added, and several bugs have been fixed. Check the [release for more information](https://github.com/webpack/webpack-dev-server/releases/tag/v5.2.3).
+- **Webpack-bundle-analyzer** has received important improvements and fixes for the user experience. Visual issues with tooltips in dark mode have been resolved, and the analysis of bundles using IIFE has been made more robust, preventing errors. Additionally, support for Zstandard compression has been added, available only on Node.js 22.15 or higher. Check the [changelog for more information](https://github.com/webpack/webpack-bundle-analyzer/blob/main/CHANGELOG.md)
+- **Mini-css-extract-plugin** introduces new features and bug fixes. Among the main changes, the plugin now respects the `output.cssFilename` and `output.cssChunkFilename` options, allowing more precise control over the names of the generated CSS files. Additionally, a bug was fixed that prevented the generation of the `contentHash` for a chunk when the CSS module set had zero size, thus avoiding unnecessary hashes in those cases. Check the [release for more information](https://github.com/webpack/mini-css-extract-plugin/releases/tag/v2.10.0)
+
+Several bug fixes have been resolved since version [5.104](https://github.com/webpack/webpack/releases/tag/v5.104.0). Check the [changelog](https://github.com/webpack/webpack/blob/main/CHANGELOG.md) for more details
+
+## Thanks
+
+A big thank you to all our contributors and [sponsors](https://github.com/webpack/webpack?tab=readme-ov-file#sponsoring)
+who made Webpack 5.105 possible. Your support, whether through code contributions, documentation, or financial sponsorship, helps keep Webpack evolving and improving for everyone.

--- a/pages/blog/posts/2026-02-04-roadmap-2026.md
+++ b/pages/blog/posts/2026-02-04-roadmap-2026.md
@@ -1,0 +1,165 @@
+---
+layout: post
+date: 2026-02-04T00:00:00Z
+authors:
+  - evenstensberg
+  - bjohansebas
+  - UlisesGascon
+category: Roadmap
+image: /assets/blog/cover-4.svg
+description: The Webpack 2026 Roadmap explores native CSS Modules support, a new universal target, lazy barrel optimization, and dropping the need for TypeScript loaders.
+---
+
+# Roadmap 2026
+
+Hello from the webpack Technical Steering Committee member [Even](http://x.com/evenstensberg)!
+
+The different contributors in the organization continue to work on ensuring that **webpack remains a solid and reliable tool** for building web applications. While many new tools have emerged, webpack continues to be a **stable and well-supported choice**.
+
+## Here’s what we’re excited about for 2026
+
+In 2026, our focus goes beyond maintaining existing features. We’re investing in improvements that make webpack easier to use and maintain, while also pushing forward ideas that prepare the project for modern runtimes, evolving development patterns, and the long-term health of the ecosystem.
+
+Below, we’ll walk through the main areas we’re actively working on and the ideas we plan to develop throughout the year.
+
+### [webpack#14893](https://github.com/webpack/webpack/issues/14893) - Support for CSS Modules without the need for plugins
+
+There is currently an [`experimental.css`](/configuration/experiments/#experimentscss) option, which enables **native CSS support** without the need to add plugins to your configuration, as was previously required with plugins like [`mini-css-extract-plugin`](/plugins/mini-css-extract-plugin).
+
+The development is already quite advanced, with the possibility of finishing the inclusion into webpack core around **February/March**. After that, the support would remain _experimental_ for a while to gather bug reports, but in **webpack 6** it will no longer be experimental and **plugins for this task will no longer be necessary**.
+
+You can follow the discussion about [experimental CSS support](https://github.com/webpack/webpack/issues/14893)
+to stay updated and contribute ideas.
+
+### [webpack#6525](https://github.com/webpack/webpack/issues/6525) - A universal target to make your code compatible across runtimes
+
+The idea is to add a new target called **universal**, which will compile your code so it can run across **different runtimes**, including Node, the web, Bun, Deno, etc.
+Regardless of whether you use **CommonJS modules** in your application, webpack will be able to wrap them, and all the resulting code will be **pure ESM**, making it _runtime-agnostic_.
+
+There has already been significant progress toward this goal, but **ESM output is not fully finished yet**. Additional fixes and improvements are still required (see [webpack#17121](https://github.com/webpack/webpack/issues/17121)), along with **adding missing tests** and completing the _CommonJS wrapper functionality_.
+
+You can also join the discussion about [universal target](https://github.com/webpack/webpack/issues/6525) to share your ideas or follow updates on cross-runtime compatibility.
+
+### Support for building TypeScript without loaders
+
+Recently, in version [5.105](/blog/2026-02-03-webpack-5-105/) we included support for **resolving the paths defined in the TypeScript configuration**, eliminating the need to use a plugin ([tsconfig-paths-webpack-plugin](https://www.npmjs.com/package/tsconfig-paths-webpack-plugin)). Now we want to further expand TypeScript support by **removing the need to use a loader** (the most common one being _ts-loader_) to transpile TypeScript directly in webpack, which would also **reduce your project’s dependencies**.
+
+### [webpack#536](https://github.com/webpack/webpack/issues/536) - Import HTML files and use them as entry points without the need for plugins
+
+Currently, to import HTML files and use them as entry points, it’s necessary to use a plugin ([_html-webpack-plugin_](/plugins/html-webpack-plugin)). The idea is to **integrate that plugin into the core of webpack itself**, similar to how CSS Modules are being handled, and remove the need for a plugin for such a common task. Like CSS Modules, this would be introduced as an _experimental option_, so that in **webpack 6** you’ll be able to remove that dependency.
+
+You can follow the idea and its progress in the related issue ([#536](https://github.com/webpack/webpack/issues/536)).
+
+### Webpack Everywhere (Node, Deno, and Bun, Web)
+
+Node.js is still the **default runtime** for many projects, but times have changed and it’s no longer the only JavaScript runtime. New options like **Deno** and **Bun** have gained significant popularity, and webpack should work seamlessly across all of them.
+
+The goal is to build webpack so it can run **everywhere**: in Node.js, in web environments, and in alternative runtimes like Deno and Bun. Even when using modules traditionally tied to Node.js, such as `node:fs`, webpack will intelligently handle them, enabling code that depends on these modules to **run in the browser** or other environments where these modules don’t exist.
+
+To achieve this, we need to **reduce reliance on Node.js internals** and _Buffer usage_, move toward a **more runtime-agnostic architecture**, and expand test coverage.
+
+Currently, **Deno support is missing proper tests**, while **Bun still lacks required assets and corresponding tests**. In addition, this effort includes adding a **site playground** to validate and showcase webpack running across different environments.
+
+### Evaluating Lazy Barrel Optimization
+
+One interesting idea to explore is **lazy barrel optimization**, inspired by how _Rspack_ handles certain module patterns. In Rspack, _lazy barrel_ is an optimization that **skips building unused re-exported modules in side‑effect‑free barrel files until they’re actually needed**. This can significantly reduce build time, especially in **large codebases** with lots of grouped exports.
+
+Barrel files are modules that **re-export other modules** to create a convenient API surface. For example, a `components/index.js` that exports every component from a directory. While useful for organizing code, traditional bundlers often build _all_ the re-exported modules even if only one is used, which can hurt performance. With _lazy barrel optimization_ in Rspack, **only the modules actually referenced get built**, skipping the rest and improving overall build speed.
+
+Evaluating Rspack’s approach gives us an opportunity to see whether a **similar strategy could benefit webpack**, improving performance around commonly used barrel patterns without requiring developers to restructure their exports manually. It’s an example of looking outward at innovations in the ecosystem to inform possible future enhancements for webpack.
+
+### Simplifying Asset Minimization in Webpack
+
+Webpack currently relies on **multiple separate minimizer plugins**, such as `terser-webpack-plugin`, `css-minimizer-webpack-plugin`, `html-minimizer-webpack-plugin`, and `json-minimizer-webpack-plugin`. While each one works well on its own, **managing them individually adds extra configuration and maintenance overhead**.
+
+The idea is to **combine all of these into a single `minimizer-webpack-plugin`**, providing a more **unified and consistent minimization experience**. This would **simplify configuration**, reduce duplication, and make it easier to extend and maintain minimization logic across different asset types.
+
+### Streamlining Webpack’s Dev Experience
+
+Webpack’s **development and CLI tools** are being improved to enhance maintainability while also introducing **new features** for contributors and users alike.
+
+#### Dev Tooling
+
+Efforts in development tooling focus on **improving webpack’s internal development workflow** and making it easier to extend and maintain. This includes **merging webpack-dev-middleware and webpack-hot-middleware**, **extracting the overlay from dev-server**, and **consolidating overlay + WebSocket/EventSource logic for reuse**.
+
+Additionally, **plugin support** will be added to the dev-server, enabling more flexibility and reducing duplication. These improvements streamline development for contributors while keeping webpack **flexible and reliable** for users.
+
+#### CLI Improvements
+
+The CLI is being refined to **simplify maintenance** and **improve usability**. Work includes **consolidating packages**, **refactoring help and subcommand logic**, and **improving the overall developer experience** (see [webpack-cli#4619](https://github.com/webpack/webpack-cli/issues/4619)).
+
+These changes make it easier for contributors to maintain the CLI while also providing **practical enhancements** for developers working with webpack in their projects.
+
+You can follow the [webpack-cli improvements](https://github.com/webpack/webpack-cli/issues/4619) discussion to stay updated.
+
+### Accurate and Reliable Documentation
+
+The idea is to **enable automatic generation of all API and configuration documentation** directly from webpack’s **types and schemas**, ensuring the documentation **always matches the actual behavior** of the code (new api options, deprecations, types etc).
+
+This approach addresses long-standing problems with **incomplete, or inconsistent documentation** on the webpack website, and makes it easier to maintain. The goal is to provide developers with **accurate, reliable, and up-to-date references** that gives users a easy way to interact with webpack.
+
+### Community Outreach and Engagement
+
+Following improvements to documentation and active maintenance, another key focus is **building and strengthening the webpack community**. This year, the effort began with a **new blog launched for webpack 5.105**, and the idea is to continue expanding our outreach through **articles, conference talks, and other public channels**.
+
+By engaging the community, webpack can **grow adoption**, receive **valuable input**, and create stronger connections between the project and its users. Outreach efforts also help ensure that improvements, tutorials, and best practices reach a **wider audience**, making the ecosystem more vibrant and sustainable.
+
+### Multithreading API
+
+Webpack is exploring a **Multithreading API**, inspired by _thread-loader_, to bring **better parallel processing capabilities** into the core.
+
+The goal is to allow webpack to take advantage of **multi-core systems**, improving build performance for **large projects**. This effort is still in the **design and discussion phase**, aiming to create a solution that is **flexible, maintainable, and easy to use**.
+
+By integrating multithreading in a more formal way, webpack hopes to provide developers with **faster builds** while keeping the configuration and internal logic **clean and scalable**. This work reflects ongoing exploration rather than a finalized feature, and _thread-loader_ remains the current **community-supported solution** for parallelization.
+
+### Design and Visual Identity
+
+We want to **improve webpack’s overall visual identity** by creating **new design assets** for projects and swag. This includes things like **banners, clothing merch, water bottles, coffee cups, socks**, and other branded materials.
+
+Beyond making webpack look **more polished and recognizable**, these assets also open the door to **future merchandise sales**, where purchasing swag would directly help fund and support webpack’s ongoing development.
+
+### GSoC Mentorship
+
+A key focus is **mentoring students through the Google Summer of Code (GSoC) program**, a volunteer-driven effort with the goal of teaching them how to **effectively maintain open source projects**.
+
+Through hands-on guidance, students learn **workflows, best practices**, and how to approach maintaining a codebase. At the same time, this mentorship allows the project to **develop new features**, as students work on functionalities that are needed while being guided by experienced contributors.
+
+This experience equips them with the skills needed to become **future maintainers**, contributing not only to webpack but also to the **broader open source ecosystem**, which relies heavily on volunteers.
+
+By emphasizing **maintainability, knowledge transfer**, and **guided feature development**, GSoC mentorship helps secure **long-term sustainability** and cultivates the **next generation of contributors** for open source projects.
+
+### Donations and Sponsorships
+
+Open source projects like webpack are maintained primarily by **volunteers**, and there isn’t a full-time engineering team dedicated to the project.
+
+**Growing donations and sponsorships** is crucial because the more funding available, the more time the core contributors can dedicate to **maintaining and improving webpack**, despite having other responsibilities and personal lives.
+
+Support through donations not only helps **sustain ongoing maintenance** but also enables contributors to focus on **new features, bug fixes**, and **improving the ecosystem** overall. By contributing financially, the community directly helps ensure webpack remains **healthy and actively developed**.
+
+### Preparing for Webpack 6
+
+All the efforts covered in this blog, from enhancing runtime support (Node, Deno, Bun, and universal targets), improving documentation and developer tooling, mentoring new contributors through GSoC, to exploring multithreading and optimizations like lazy barrel, are paving the way toward **webpack 6**.
+
+#### Core and Loader Improvements
+
+To prepare for **webpack@6** and simplify internal logic, efforts include **moving loader-runner into core** to unify loader context handling. This helps reduce duplication, improves maintainability, and lays the groundwork for future enhancements.
+
+Additionally, **reducing internal TODOs across the codebase** ensures a **cleaner foundation** and makes it easier for contributors to work efficiently.
+
+#### Testing and Type Coverage
+
+**Improving test coverage** and **strengthening type coverage** are key priorities. By reducing the use of `any`, `unknown`, and other loose types, webpack becomes **more reliable** and easier to maintain. Strong types and thorough tests help **catch issues earlier** and improve confidence for contributors making changes.
+
+#### Benchmarks and Performance
+
+To measure progress and maintain **high performance standards**, webpack plans to **add more benchmarks**. Integrating these benchmarks into CI pipelines allows **comparisons across versions**, ensuring that optimizations continue to deliver **tangible improvements** for developers.
+
+## Final remarks
+
+I hope that you found this list useful and that you are **excited for 2026**, we are too! One of the most important parts of our work now, is to **get enough donations** to keep the project sustainable. We use our resources to **pay contributors** once they reach a certain threshold. In addition to that, we want to make sure that over time, the project has **some left-over resources** that we can save for when times are hard.
+
+This year we will try something new, which is to have **allocated sections** where **companies/individuals that contribute a significant amount** will have a spot to **showcase their product/project/promotion**.
+
+Thank you for the attention and for being interested in our roadmap for 2026. If you are curious about contributing to the organization either **financially** or otherwise, send us a private or public message in [Discord](https://discord.com/invite/webpack), reach us through [email](mailto:webpack-security@openjsf.org) or contact one of the [TSC members](https://github.com/webpack/webpack?tab=readme-ov-file#tsc-technical-steering-committee).
+
+~ webpack TSC 💙

--- a/pages/blog/posts/2026-04-08-webpack-5-106.md
+++ b/pages/blog/posts/2026-04-08-webpack-5-106.md
@@ -1,0 +1,325 @@
+---
+layout: post
+date: 2026-04-08T00:00:00Z
+authors:
+  - bjohansebas
+category: Release
+image: /assets/blog/cover-1.svg
+description: Webpack 5.106 introduces plugin validation hooks, built-in runtime style injection for CSS Modules, smarter tree shaking for CommonJS, and experimental oxc-parser.
+---
+
+# Webpack 5.106
+
+**Webpack 5.106 introduces plugin validation hooks, built-in runtime style injection for CSS Modules, smarter tree shaking for CommonJS destructuring, source-phase imports for WebAssembly modules, and an experimental integration with `oxc-parser` for faster JavaScript parsing.**
+
+Explore what's new in this release:
+
+- [**Plugin Validation with `compiler.hooks.validate`**](#plugin-validation-with-compilerhooksvalidate)
+- [**CSS Modules with Runtime Style Injection**](#css-modules-with-runtime-style-injection)
+- [**Better Tree Shaking for CommonJS Destructuring**](#better-tree-shaking-for-commonjs-destructuring)
+- [**Source Phase Imports for WebAssembly (Experimental)**](#source-phase-imports-for-webassembly-experimental)
+- [**Getting Started with `create-webpack-app`**](#getting-started-with-create-webpack-app)
+- [**Context Support for VirtualUrlPlugin**](#context-support-for-virtualurlplugin)
+- [**Experimental JavaScript Parsing with `oxc-parser`**](#experimental-javascript-parsing-with-oxc-parser)
+- [**Ecosystem Updates**](#ecosystem-updates)
+- [**Bug Fixes**](#bug-fixes)
+
+## Plugin Validation with `compiler.hooks.validate`
+
+Webpack adds a new top-level `validate` option and a [`compiler.hooks.validate`](/api/compiler-hooks/#validate) hook that standardize how schema validation works across webpack configuration, plugins, and loaders.
+
+Until now, there was no unified way for plugins to integrate schema validation into the webpack build lifecycle. Each plugin handled validation on its own. The new `compiler.hooks.validate` hook gives plugin authors a standard API to register their validation logic, and `compiler.validate(...)` to run it. This means all validation from webpack's core config to every plugin that adopts the hook is controlled by a single `validate` flag and follows the same patterns:
+
+```js
+module.exports = {
+  // Disable schema validation (webpack config, plugins, and loaders)
+  validate: false,
+};
+```
+
+The default value depends on the build mode:
+
+| Mode        | `experiments.futureDefaults` | Default `validate` |
+| ----------- | :--------------------------: | :----------------: |
+| development |           `false`            |       `true`       |
+| development |            `true`            |       `true`       |
+| production  |           `false`            |       `true`       |
+| production  |            `true`            |      `false`       |
+
+For plugin authors, integrating validation is straightforward. Register a tap on `compiler.hooks.validate`, and webpack takes care of the rest, including skipping validation entirely when the user sets `validate: false`:
+
+```js
+class MyPlugin {
+  constructor(options = {}) {
+    this.options = options;
+  }
+
+  apply(compiler) {
+    compiler.hooks.validate.tap('MyPlugin', () => {
+      compiler.validate(
+        () => require('./schema/MyPlugin.json'),
+        this.options,
+        { name: 'My Plugin', baseDataPath: 'options' },
+        options => require('./schema/MyPlugin.check')(options)
+      );
+    });
+
+    // ...normal plugin logic here...
+  }
+}
+
+module.exports = MyPlugin;
+```
+
+When `validate` is `true` and something is wrong, webpack throws a clear error at compile time.
+
+When `validate` is `false`, that check is skipped entirely. The build may still fail later with a less obvious error, so use this option with care.
+
+## CSS Modules with Runtime Style Injection
+
+Webpack now supports `exportType: "style"` for CSS Modules (when `experiments.css: true` is enabled), which allows CSS to be injected into the DOM as a `<style>` (`HTMLStyleElement`) directly from the webpack runtime. This covers the typical use case of `style-loader`, so it is no longer necessary to use `style-loader` to inject styles when using this mode.
+
+Additionally, the CSS Module exports are preserved (for example, the class name mapping in `*.module.css`).
+
+For CSP compatibility, when a nonce has been configured in the webpack runtime (`__webpack_require__.nc`), the `<style>` injected by this mode receives the same nonce via the `nonce` attribute (webpack reuses the nonce provided by the application; it does not generate one automatically).
+
+```js
+module.exports = {
+  experiments: { css: true },
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        type: 'css/module',
+        parser: {
+          exportType: 'style',
+        },
+      },
+    ],
+  },
+};
+```
+
+W> CSS support has matured significantly and is expected to be fully finalized in the next minor release, as planned in the roadmap. As part of this transition, `css-loader`, `style-loader`, and `mini-css-extract-plugin` are planned for deprecation.
+
+## Better Tree Shaking for CommonJS Destructuring
+
+Webpack can now statically analyze **destructuring assignments directly from CommonJS `require`** (and `module.require`) and treat only the destructured properties as "referenced exports", instead of conservatively assuming the whole `exports` object is used. This improves dead-code elimination in optimized builds and can reduce bundle size in codebases that still consume CommonJS modules.
+
+Consider a module that exports multiple functions, and a consumer that only destructures one of them:
+
+```js
+// math.js
+exports.add = (a, b) => a + b;
+exports.divide = (a, b) => a / b;
+exports.multiply = (a, b) => a * b;
+exports.subtract = (a, b) => a - b;
+```
+
+```js
+// app.js
+const { add } = require('./math');
+
+console.log(add(2, 3));
+```
+
+In previous versions, webpack treated `require("./math")` as referencing the entire exports object. All four functions were included in the bundle even though only `add` is used:
+
+```js
+// Bundled output (5.105 — simplified)
+const math = {
+  add: (a, b) => a + b,
+  subtract: (a, b) => a - b,
+  multiply: (a, b) => a * b,
+  divide: (a, b) => a / b,
+};
+```
+
+Starting with 5.106, webpack recognizes the destructuring pattern and marks only `add` as referenced. The unused exports are eliminated during optimization:
+
+```js
+// Bundled output (5.106 — simplified)
+const math_add = (a, b) => a + b;
+// subtract, multiply, divide - tree-shaken away
+```
+
+This also works with `module.require`:
+
+```js
+const { a, b } = module.require('./module');
+```
+
+## Source Phase Imports for WebAssembly (Experimental)
+
+Webpack now includes experimental support for TC39 [Source Phase Imports](https://github.com/tc39/proposal-source-phase-imports) when importing WebAssembly modules.
+
+The proposal is currently at **Stage 3** and introduces a way to import a module at the _source phase_ instead of immediately evaluating it. In practical terms for WebAssembly, this means you can obtain a compiled `WebAssembly.Module` first, and instantiate it later with your own imports.
+
+In webpack 5.106, this experimental support is focused on WebAssembly source imports under `experiments.sourceImport`. In the next minor release, the focus is expected to shift toward JavaScript support.
+
+Enable the feature with `experiments.sourceImport`:
+
+```js
+module.exports = {
+  experiments: {
+    asyncWebAssembly: true,
+    sourceImport: true,
+  },
+};
+```
+
+Then use either static or dynamic source-phase syntax:
+
+```text
+// Static form
+import source wasmModule from "./module.wasm";
+
+// Dynamic form
+const wasmModule2 = await import.source("./module.wasm");
+
+const instance = await WebAssembly.instantiate(wasmModule);
+```
+
+You can also see an end-to-end example in webpack's repository:
+[https://github.com/webpack/webpack/tree/main/examples/wasm-simple-source-phase](https://github.com/webpack/webpack/tree/main/examples/wasm-simple-source-phase)
+
+## Getting Started with `create-webpack-app`
+
+[`create-webpack-app`](https://www.npmjs.com/package/create-webpack-app) is now the recommended way to scaffold a new webpack project. Previously, this functionality lived inside `webpack-cli` as the `webpack init` command, but it has been extracted into its own standalone package with the release of webpack-cli 7.
+
+This means you can now create a new webpack project with a single command, without needing to install `webpack-cli` first:
+
+```bash
+npx create-webpack-app
+```
+
+The CLI walks you through an interactive setup where you choose the pieces that fit your project:
+
+```bash
+$ npx create-webpack-app
+
+? Which of the following JS solutions do you want to use? Typescript
+? Do you want to use webpack-dev-server? Yes
+? Do you want to simplify the creation of HTML files for your bundle? Yes
+? Do you want to add PWA support? No
+? Which of the following CSS solutions do you want to use? CSS only
+? Will you be using PostCSS in your project? Yes
+? Do you want to extract CSS for every file? Only for Production
+? Which package manager do you want to use? npm
+
+[create-webpack] ℹ️  Initializing a new Webpack project...
+[create-webpack] ✅ Project dependencies installed successfully!
+```
+
+The generated project includes a working `webpack.config.js`, dev server configuration, and the loader/plugin setup for the options you selected. From there, you can start developing immediately:
+
+```bash
+cd my-project
+npm start
+```
+
+This approach follows the same pattern popularized by tools like `create-react-app` and `create-vite`: a single `npx` command that gets you from zero to a working project without manual configuration.
+
+You can also use the `init` subcommand if you prefer the explicit form:
+
+```bash
+npx create-webpack-app init
+```
+
+Beyond project scaffolding, `create-webpack-app` can also generate the boilerplate for custom loaders and plugins:
+
+```bash
+npx create-webpack-app loader
+
+npx create-webpack-app plugin
+```
+
+## Context Support for VirtualUrlPlugin
+
+`VirtualUrlPlugin` (via `webpack.experiments.schemes.VirtualUrlPlugin`) now supports a `context` option that defines the **base directory used to resolve relative imports inside virtual modules**. This feature is currently **experimental**, as it is part of the `experiments.schemes` API.
+
+This makes virtual modules behave more like real files: code such as `import "./utils"` resolves consistently instead of falling back to `compiler.context` and potentially resolving incorrectly.
+
+`context` can be set per virtual module (inside the module definition) or as a plugin level default. It defaults to `"auto"`, which tries to infer the context from the virtual module id or path; otherwise it falls back to `compiler.context`. Conceptually, when you set `context` for a module, webpack treats that virtual module _as if it lived inside that directory_ for resolving relative paths.
+
+For example, if you define a virtual module id `virtual/table.js` with `context: path.join(__dirname, "src/components")`, then its internal `import "./utils"` is resolved as if the file were `src/components/table.js` importing `src/components/utils.js`.
+
+```js
+const path = require('node:path');
+const webpack = require('webpack');
+
+module.exports = {
+  plugins: [
+    new webpack.experiments.schemes.VirtualUrlPlugin(
+      {
+        'src/components/button.js': {
+          context: 'auto',
+          source() {
+            return "import { trim } from './utils'; export const button = trim('button ');";
+          },
+        },
+        'virtual/table.js': {
+          context: path.join(__dirname, 'src/components'),
+          source() {
+            return "import { trim } from './utils'; export const table = trim('table ');";
+          },
+        },
+      },
+      { context: 'auto' }
+    ),
+  ],
+};
+```
+
+## Experimental JavaScript Parsing with `oxc-parser`
+
+Webpack now includes an example demonstrating how to replace the default JavaScript parser with **`oxc-parser`**. This integration should be considered **purely experimental** and is **not recommended for production use**.
+
+Instead, it is intended for **development environments** or **benchmark branches**, allowing the community to experiment with alternative parsing strategies in real projects. This helps evaluate potential improvements in **parse time and build performance**, as well as identify possible **compatibility issues**.
+
+**Example**
+
+The following configuration limits the custom parser to `.js` files:
+
+```js
+'use strict';
+
+const oxcParse = require('./internals/oxc-parse');
+
+/** @type {import("webpack").Configuration} */
+module.exports = {
+  mode: 'production',
+  entry: './src/index.js',
+  module: {
+    rules: [
+      {
+        // Apply the custom parser only to JavaScript files
+        test: /\.js$/,
+        parser: {
+          parse: oxcParse,
+        },
+      },
+    ],
+  },
+};
+```
+
+You can find the full example in the webpack repository:
+[https://github.com/webpack/webpack/blob/main/examples/custom-javascript-parser/webpack.config.js](https://github.com/webpack/webpack/blob/main/examples/custom-javascript-parser/webpack.config.js)
+
+## Ecosystem Updates
+
+- **Webpack-cli** has released a new major version, [7.0.0](https://github.com/webpack/webpack-cli/releases/tag/webpack-cli%407.0.0). The minimum supported Node.js version is now `20.9.0`, and configuration files are loaded via dynamic `import()` by default, which enables native TypeScript configuration support through Node.js type stripping without needing external loaders.
+  The `--node-env` argument has been replaced by `--config-node-env`, and the deprecated programmatic API has been removed. Additionally, configuration freezing is now allowed, graceful shutdown has been improved when file system cache is enabled, and general performance improvements have been made. Check the [release for more information](https://github.com/webpack/webpack-cli/releases/tag/webpack-cli%407.0.0).
+- **Webpack-dev-middleware** has released a new major version, [8.0.0](https://github.com/webpack/webpack-dev-middleware/releases/tag/v8.0.0). The minimum supported Node.js version is now `20.9.0` and the minimum webpack version is `5.101.0`. The `getFilenameFromUrl` function is now asynchronous, immutable asset caching (`cacheImmutable`) is enabled by default, and a new `forwardError` option allows forwarding errors to the next middleware.
+  Support for plugin usage has also been added, and general performance improvements have been made. Check the [release for more information](https://github.com/webpack/webpack-dev-middleware/releases/tag/v8.0.0).
+- **Compression-webpack-plugin**, **html-minimizer-webpack-plugin**, **css-minimizer-webpack-plugin**, **image-minimizer-webpack-plugin**, and other plugins have released new major versions to align their minimum supported Node.js version to `20.9.0`, keeping consistency across the webpack ecosystem alongside the recent major releases of webpack-cli 7 and webpack-dev-middleware 8.
+
+## Bug Fixes
+
+Several bug fixes have been resolved since version [5.105](https://github.com/webpack/webpack/releases/tag/v5.105.0). Check the [changelog](https://github.com/webpack/webpack/blob/main/CHANGELOG.md) for all the details.
+
+## Thanks
+
+A big thank you to all our contributors and [sponsors](https://github.com/webpack/webpack?tab=readme-ov-file#sponsoring)
+who made Webpack 5.106 possible. Your support, whether through code contributions, documentation, or financial sponsorship, helps keep Webpack evolving and improving for everyone.

--- a/pages/blog/posts/2026-05-19-webpack-5-107.md
+++ b/pages/blog/posts/2026-05-19-webpack-5-107.md
@@ -1,0 +1,503 @@
+---
+layout: post
+date: 2026-05-19T00:00:00Z
+authors:
+  - bjohansebas
+category: Release
+image: /assets/blog/cover-2.svg
+description: Webpack 5.107 lands experimental HTML modules replacing html-loader, built-in TypeScript type stripping, and major improvements to the CSS pipeline.
+---
+
+# Webpack 5.107
+
+Webpack 5.107 is out. The headline of this release is the first step toward handling `.html` files natively in webpack core: importing an HTML file from JS now resolves its `<img src>`, `<link href>`, inline `<style>`, and `<script src>` references through the normal webpack pipeline, replacing the role `html-loader` has played for years. HTML entry points (the `html-webpack-plugin` part of the story) are not in 5.107 yet, they are planned for the next minor release.
+
+This release also lands experimental TypeScript support that leans on Node.js's built-in type-stripping, so simple TypeScript projects can compile without `ts-loader` or `swc-loader`.
+
+Both pieces are experimental and live behind opt-in flags, but the direction is clear: you should eventually be able to build a complete web app with zero extra loaders or plugins for HTML, CSS, and basic TypeScript.
+
+Alongside the experimental work, this release also continues maturing the built-in CSS pipeline, and ships a handful of improvements for tree shaking, deferred imports, and module resolution.
+
+Explore what's new:
+
+- [**HTML Modules (Experimental)**](#html-modules-experimental)
+  - [`experiments.html` Flag](#experimentshtml-flag)
+  - [Inline `<style>` Tags](#inline-style-tags)
+  - [Inline `<script>` Tags](#inline-script-tags)
+  - [`<script src>` and `<link rel="modulepreload">`](#script-src-and-link-relmodulepreload)
+  - [`webpackIgnore` Magic Comment](#webpackignore-magic-comment)
+- [**TypeScript Support (Experimental)**](#typescript-support-experimental)
+- [**CSS Improvements**](#css-improvements)
+  - [Scope Hoisting for CSS Modules](#scope-hoisting-for-css-modules)
+  - [Pure Mode for CSS Modules](#pure-mode-for-css-modules)
+  - [`@value` in URLs and `@import`](#value-in-urls-and-import)
+  - [Multiple Aliases via `exportsConvention`](#multiple-aliases-via-exportsconvention)
+  - [`linkInsert` Hook](#linkinsert-hook)
+  - [`orderModules` Hook](#ordermodules-hook)
+- [**JavaScript and ESM**](#javascript-and-esm)
+  - [Anonymous Default Export Naming](#anonymous-default-export-naming)
+  - [Preserving `defer` and `source` Phase on Externals](#preserving-defer-and-source-phase-on-externals)
+  - [`#__NO_SIDE_EFFECTS__` Annotation](#__no_side_effects__-annotation)
+- [**Resolver Updates**](#resolver-updates)
+- [**Bug Fixes**](#bug-fixes)
+
+## HTML Modules (Experimental)
+
+W> **This feature is experimental and partial.** Webpack 5.107 only implements the `html-loader` side of the story: importing an HTML file from JavaScript runs its tag references through the webpack pipeline. **HTML entry points** (using a `.html` file directly as `entry`, the `html-webpack-plugin` part) are **not supported yet** and are planned for the next minor release. The full story is tracked in issue [#536](https://github.com/webpack/webpack/issues/536).
+
+A real-world webpack setup that needs an HTML entry point has historically required at least two extra dependencies. The first is `html-webpack-plugin`, which generates or emits the HTML file and injects the right bundle URLs into it. The second is `html-loader`, which lets webpack walk through `<img src>`, `<link href>`, `<script src>`, and friends so those references go through the normal resolver and asset pipeline.
+
+Both of these have served the community well for a long time, but they live outside the core. Webpack 5.107 starts bringing the `html-loader` side of that work inward.
+
+### `experiments.html` Flag
+
+Everything else in this section sits behind a single opt-in flag. The new `experiments.html` option registers the `html` module type on `NormalModuleFactory` and turns on the HTML behaviors described below.
+
+```js
+// webpack.config.js
+module.exports = {
+  experiments: {
+    html: true,
+  },
+};
+```
+
+You then import the HTML file from JavaScript. The default export is the processed HTML as a string, with all asset references resolved through webpack:
+
+```js
+// src/index.js
+import page from './page.html';
+
+document.documentElement.innerHTML = page;
+```
+
+This is the same shape `html-loader` produces, so existing code that imports HTML should keep working. The pipeline does the work the loader used to do: tag references are resolved, hashed filenames are rewritten back into the HTML string, and the result lands in your JS bundle. Using an `.html` file directly as a webpack `entry` is **not** supported in 5.107.
+
+### Inline `<style>` Tags
+
+When webpack finds a `<style>` block inside an HTML module, it routes the CSS body through the same CSS pipeline you'd use for a `.css` file. The block is treated as a virtual CSS module with `exportType: "text"`, so any `url()` references and `@import` statements inside the style are resolved relative to the HTML file. Once processing finishes, the transformed CSS is written back into the original `<style>` tag in the emitted HTML string.
+
+```html
+<!-- src/page.html -->
+<!doctype html>
+<html>
+  <head>
+    <style>
+      @import './reset.css';
+
+      body {
+        background: url('./bg.png');
+      }
+    </style>
+  </head>
+  <body>
+    ...
+  </body>
+</html>
+```
+
+`<style type="text/css">` and `<style>` with no `type` attribute are processed. Anything with a non-CSS `type` is passed through untouched. This covers the inline-style behavior of `html-loader` without needing it in the pipeline.
+
+### Inline `<script>` Tags
+
+Inline `<script>` bodies are routed through the same entry pipeline that already handles `<script src>`. Each `<script>` body becomes its own webpack entry: classic inline scripts are bundled as CommonJS, and `<script type="module">` bodies are bundled as ESM. The tag in the emitted HTML is rewritten to `<script src="…">` pointing at the generated chunk, with the body cleared.
+
+```html
+<!-- src/page.html -->
+<!doctype html>
+<html>
+  <body>
+    <script type="module">
+      import { greet } from './lib.js';
+      greet('world');
+    </script>
+
+    <script>
+      console.log('classic inline script');
+    </script>
+  </body>
+</html>
+```
+
+The same behaviors that apply to external `<script src>` apply here too:
+
+- When `output.module` is enabled, classic inline `<script>` tags are auto-upgraded to `type="module"`, matching the auto-upgrade for `<script src>`.
+- `webpackIgnore` works on inline `<script>` tags as well, leaving the original body untouched.
+- Non-JS `type` values like `application/ld+json` and `importmap` pass through unchanged.
+
+### `<script src>` and `<link rel="modulepreload">`
+
+`<script src>` and `<link rel="modulepreload">` references inside an HTML module become real webpack entries, and the emitted chunk URL is rewritten back into the HTML string so hashed filenames stay correct.
+
+```html
+<!-- src/page.html -->
+<!doctype html>
+<html>
+  <head>
+    <link rel="modulepreload" href="./preloaded.js" />
+  </head>
+  <body>
+    <script src="./entry.js"></script>
+    <script src="./second.js"></script>
+  </body>
+</html>
+```
+
+A few behaviors are worth knowing about:
+
+- Multiple `<script src>` tags in the same page share a single runtime. Within each group (classic or `type="module"`), the leader holds the runtime and the rest declare `dependOn` on it.
+- `<link rel="modulepreload">` entries stay independent and are never imported by sibling scripts, so they preload without executing, exactly as the spec requires.
+- When `output.module` is enabled, classic `<script src>` tags are auto-upgraded to `<script type="module" src>` so the emitted ES-module chunks load in the right mode.
+- Non-JS script types like `application/ld+json` or `importmap`, as well as data URIs, flow through unchanged and are not bundled as JS.
+
+### `webpackIgnore` Magic Comment
+
+The familiar `webpackIgnore: true` magic comment now works inside HTML modules. Place an HTML comment with the directive right before a tag and webpack will leave that tag's URLs untouched in the output. This is exactly how `html-loader` handles the same case.
+
+```html
+<!-- webpackIgnore: true -->
+<img src="https://cdn.example.com/logo.png" />
+
+<!-- webpackIgnore: true -->
+<script src="/legacy/external.js"></script>
+```
+
+The comment value is parsed with the same context the JS and CSS parsers use, so non-boolean values raise an `UnsupportedFeatureWarning`.
+
+## TypeScript Support (Experimental)
+
+W> **This feature is experimental and depends on a recent Node.js.** It requires Node.js 22.6 or later for the stable `module.stripTypeScriptTypes` API. The transform handles only erasable TypeScript syntax (see limitations below). For anything else, keep using `ts-loader` or `swc-loader`.
+
+Webpack 5.107 adds first-class TypeScript support behind a new `experiments.typescript` flag. With it enabled, webpack compiles `.ts`, `.cts`, and `.mts` files directly through Node.js's built-in [`module.stripTypeScriptTypes`](https://nodejs.org/api/module.html#modulestriptypescripttypescode-options), no external loader required. The flag is also turned on automatically by [`experiments.futureDefaults`](/configuration/experiments/#experimentsfuturedefaults).
+
+```js
+// webpack.config.js
+export default {
+  experiments: {
+    typescript: true,
+  },
+  entry: './src/index.ts',
+};
+```
+
+Enabling the flag also wires up sensible defaults: rules for `.ts` / `.cts` / `.mts`, `.ts` added to extension resolution before `.js`, `extensionAlias` so `import "./foo.js"` also tries `./foo.ts`, `tsconfig.json` resolution, and the `"typescript"` conditional-exports key for monorepos that ship `.ts` sources.
+
+The transform only **erases types**: no type checking, no JSX / `.tsx`, and no non-erasable syntax (`enum`, `namespace`, parameter-property constructors, decorator metadata). These are the same constraints TypeScript enforces with [`erasableSyntaxOnly`](https://www.typescriptlang.org/tsconfig/#erasableSyntaxOnly). For type checking, pair the flag with `tsc --noEmit` or [`fork-ts-checker-webpack-plugin`](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin). For JSX or non-erasable syntax, keep using `ts-loader` or `swc-loader`.
+
+See [`examples/typescript`](https://github.com/webpack/webpack/tree/main/examples/typescript) for the built-in setup and [`examples/typescript-non-erasable`](https://github.com/webpack/webpack/tree/main/examples/typescript-non-erasable) for the `ts-loader` fallback.
+
+## CSS Improvements
+
+### Scope Hoisting for CSS Modules
+
+Module concatenation (also known as scope hoisting) used to be a JavaScript-only optimization. Even with `experiments.css` enabled, CSS Modules pulled into a concatenated bundle still produced separate runtime instances. Starting with 5.107, the same optimization applies to CSS Modules whose export type is `text`, `css-style-sheet`, `style`, or `link`. The result is lower runtime overhead and smaller output in CSS-heavy bundles.
+
+```js
+module.exports = {
+  experiments: { css: true },
+  optimization: {
+    concatenateModules: true,
+  },
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        type: 'css/module',
+        parser: {
+          exportType: 'css-style-sheet',
+        },
+      },
+    ],
+  },
+};
+```
+
+### Pure Mode for CSS Modules
+
+A new `pure` parser option for `css/module` and `css/auto` mirrors the strict pure mode of `postcss-modules-local-by-default`. When enabled, every selector must contain at least one local class or id; otherwise webpack raises a build error. The point is to catch accidentally global selectors in CSS Modules before they make it into production.
+
+```js
+module.exports = {
+  experiments: { css: true },
+  module: {
+    parser: {
+      'css/module': {
+        pure: true,
+      },
+    },
+  },
+};
+```
+
+Two comments offer opt-outs when you need them. The first suppresses the check for a single rule:
+
+```css
+/* cssmodules-pure-ignore */
+a {
+  /* suppressed only for this rule */
+  color: blue;
+}
+```
+
+The second, placed among the leading comments of a file before any rule, disables the check for the entire file:
+
+```css
+/* cssmodules-pure-no-check */
+/* disables pure mode for this file */
+
+a {
+  /* would normally fail under pure mode */
+  color: red;
+}
+```
+
+Nested rules inside a local-bearing ancestor count as pure-compliant, `&` resolves to the parent rule's purity, and `@keyframes` and `@counter-style` bodies are exempt.
+
+### `@value` in URLs and `@import`
+
+CSS Modules `@value` identifiers can now be used as the path argument to `@import` and inside `url()` references. This makes it easy to define shared paths and assets once and reuse them across stylesheets.
+
+```css
+@value path: "./other.module.css";
+@import path;
+
+@value bg: "./image.png";
+
+.a {
+  background: url(bg);
+}
+```
+
+Both quoted (`"./x"`, `'./x'`) and bare (`./x`) forms of the value work. Whichever form you write is unwrapped and resolved as a module request, so the asset flows through the normal webpack resolver and asset pipeline instead of being left as a literal identifier.
+
+### Multiple Aliases via `exportsConvention`
+
+The function form of `generator.exportsConvention` for CSS Modules now accepts `string[]` in addition to `string`. Returning an array exports the local class under every name in the array, matching `css-loader`'s behavior. This is handy when you want to expose multiple aliases for a single class, for example both the original name and an uppercase version.
+
+```js
+module.exports = {
+  experiments: { css: true },
+  module: {
+    generator: {
+      'css/module': {
+        exportsConvention: name => [name, name.toUpperCase()],
+      },
+    },
+  },
+};
+```
+
+```js
+// Usage in JS
+import styles from './button.module.css';
+
+console.log(styles.btn); // hashed class
+console.log(styles.BTN); // same hashed class, uppercase alias
+```
+
+### `linkInsert` Hook
+
+If you've ever wanted to control where webpack inserts a stylesheet `<link>` in the document, you now have a hook for it. `CssLoadingRuntimeModule.getCompilationHooks(compilation)` exposes a new `linkInsert` hook. It receives the default insertion source (`document.head.appendChild(link);`) and the chunk, and returns the JS used to attach the link.
+
+```js
+const webpack = require('webpack');
+
+class MyLinkInsertPlugin {
+  apply(compiler) {
+    compiler.hooks.thisCompilation.tap('MyLinkInsertPlugin', compilation => {
+      const hooks =
+        webpack.web.CssLoadingRuntimeModule.getCompilationHooks(compilation);
+
+      // Override the default `document.head.appendChild(link);`
+      hooks.linkInsert.tap(
+        'MyLinkInsertPlugin',
+        (source, chunk) =>
+          'link.setAttribute("data-injected", "true"); document.body.appendChild(link);'
+      );
+    });
+  }
+}
+
+module.exports = {
+  experiments: { css: true },
+  plugins: [new MyLinkInsertPlugin()],
+};
+```
+
+The hook is a `SyncWaterfallHook<[string, Chunk]>`. Return the default `source` to keep the original behavior, or return your own JS to override where (and how) the link is attached.
+
+### `orderModules` Hook
+
+When a chunk pulls in CSS from several files, webpack's default ordering is a topological sort of their import graph. That's the right call in most cases, but on real-world projects the import graph can be ambiguous enough to trigger the "Conflicting order between CSS …" warning, with no clean way out short of restructuring imports.
+
+A new `orderModules` hook on `CssModulesPlugin.getCompilationHooks(compilation)` gives plugin authors a deterministic escape hatch. It runs once per CSS source type (`CSS_IMPORT_TYPE` and `CSS_TYPE`) with the chunk's modules pre-sorted by full module name. Return an ordered `Module[]` to override the default, or return `undefined` to fall through to webpack's existing import-order topological sort.
+
+```js
+const webpack = require('webpack');
+
+class CssOrderByPathPlugin {
+  apply(compiler) {
+    compiler.hooks.thisCompilation.tap('CssOrderByPathPlugin', compilation => {
+      const hooks =
+        webpack.css.CssModulesPlugin.getCompilationHooks(compilation);
+
+      // Modules arrive pre-sorted by full module name; return as-is for
+      // a deterministic file-path order that side-steps the conflicting
+      // order warning.
+      hooks.orderModules.tap(
+        'CssOrderByPathPlugin',
+        (_chunk, modules) => modules
+      );
+    });
+  }
+}
+
+module.exports = {
+  experiments: { css: true },
+  plugins: [new CssOrderByPathPlugin()],
+};
+```
+
+The hook is a `SyncBailHook<[Chunk, Module[], Compilation], Module[] | undefined>`. The first tap to return a non-`undefined` value wins.
+
+## JavaScript and ESM
+
+### Anonymous Default Export Naming
+
+Webpack 5.106 introduced a fix-up that sets `.name` to `"default"` for anonymous default exports, matching the ES spec. It works correctly, but it injects unmangleable `Object.defineProperty` calls that inflate the bundle. For library consumers, who rarely rely on `.name === "default"`, that extra runtime helper is pure overhead.
+
+5.107 introduces a new option, `module.parser.javascript.anonymousDefaultExportName`, to control this behavior. It defaults to `true` for applications and `false` for libraries (when `output.library` is set). Apps stay spec-compliant by default; library authors stop paying for the extra runtime helper without having to know about it.
+
+```js
+// input
+export default function () {
+  /* ... */
+}
+
+// with `anonymousDefaultExportName: true` (default for apps)
+// the runtime sets .name = "default" matching native ESM behavior
+```
+
+You can override the default explicitly:
+
+```js
+module.exports = {
+  module: {
+    parser: {
+      javascript: {
+        anonymousDefaultExportName: false,
+      },
+    },
+  },
+};
+```
+
+### Preserving `defer` and `source` Phase on Externals
+
+Webpack now preserves the `defer` and `source` import phase keywords on external dependencies in ESM output, the same way import attributes are already preserved. Previously, the phase keyword was stripped from the emitted statement, so an `import defer * as ns from "x"` against an external lost its deferred semantics in the output.
+
+For static `module` externals, namespace defer imports and single-default source imports are now emitted as native phase syntax at the top of the bundle:
+
+```js
+// webpack.config.js
+module.exports = {
+  output: { module: true },
+  externalsType: 'module',
+  externals: { 'external-mod': 'external-mod' },
+};
+```
+
+```text
+// input
+import defer * as ns from "external-mod";
+import source v from "external-mod";
+
+// emitted output
+import defer * as ns from "external-mod";
+import source v from "external-mod";
+```
+
+For dynamic `import` externals, `import.defer("x")` and `import.source("x")` are emitted directly:
+
+```text
+// input
+const ns = await import.defer("external-mod");
+const src = await import.source("external-mod");
+
+// emitted output
+const ns = await import.defer("external-mod");
+const src = await import.source("external-mod");
+```
+
+One related improvement: the same external imported with two different phases (or attribute sets) no longer collapses into a single `ExternalModule`. Each combination produces its own emit, so neither phase is silently dropped.
+
+### `#__NO_SIDE_EFFECTS__` Annotation
+
+Webpack now supports the [`#__NO_SIDE_EFFECTS__`](https://github.com/javascript-compiler-hints/compiler-notations-spec/blob/main/no-side-effects-notation-spec.md#2-const-variable-declaration) annotation to mark functions as pure for better tree shaking. Calls to functions annotated this way can be eliminated from the bundle when their return value is unused, even if the function body is not statically analyzable as pure.
+
+{/_ eslint-disable _/}
+
+```js
+// utils.js
+/*#__NO_SIDE_EFFECTS__*/
+export function createLogger(prefix) {
+  return msg => console.log(`[${prefix}] ${msg}`);
+}
+
+export function realWork() {
+  // ...
+}
+```
+
+{/_ eslint-enable _/}
+
+```js
+// app.js
+import { createLogger, realWork } from './utils';
+
+// dropped, because `createLogger` is annotated and its result is unused
+const unused = createLogger('debug');
+
+realWork();
+```
+
+W> The annotation currently only takes effect **within the module where it is declared**. Cross-module propagation is planned for a future PR.
+
+## Resolver Updates
+
+Webpack now adds `"module-sync"` to the default `conditionNames` for resolver defaults, aligning with Node.js. Node.js exposes the `module-sync` community condition for synchronously-loadable ESM, and this change affects the ESM, CJS, AMD, worker, wasm, and build-dependency resolvers.
+
+Concretely, the resolver defaults now include `module-sync` right before `module` in the condition chain:
+
+```js
+// Before (5.106)
+conditionNames: ['require', 'module', '...']; // CJS deps
+conditionNames: ['import', 'module', '...']; // ESM deps
+
+// After (5.107)
+conditionNames: ['require', 'module-sync', 'module', '...'];
+conditionNames: ['import', 'module-sync', 'module', '...'];
+```
+
+This means packages that publish a `module-sync` export condition in their `package.json` will be picked up automatically without any additional configuration:
+
+```json
+{
+  "name": "my-package",
+  "exports": {
+    ".": {
+      "module-sync": "./esm/index.js",
+      "default": "./cjs/index.js"
+    }
+  }
+}
+```
+
+## Bug Fixes
+
+Several bug fixes have been resolved since version [5.106](https://github.com/webpack/webpack/releases/tag/v5.106.0). Check the [changelog](https://github.com/webpack/webpack/blob/main/CHANGELOG.md) for all the details.
+
+## Thanks
+
+A big thank you to all our contributors and [sponsors](https://github.com/webpack/webpack?tab=readme-ov-file#sponsoring)
+who made Webpack 5.107 possible. Your support, whether through code contributions, documentation, or financial sponsorship, helps keep Webpack evolving and improving for everyone.

--- a/scripts/data/blog.mjs
+++ b/scripts/data/blog.mjs
@@ -1,0 +1,50 @@
+// Builds the data file consumed by the Blog layout (`#theme/blog`)
+
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import matter from 'gray-matter';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const POSTS_DIR = join(ROOT, 'pages', 'blog', 'posts');
+const OUTPUT = join(ROOT, 'generated', 'blog.json');
+
+const toAuthors = data => {
+  const value = data.authors ?? data.author;
+  if (Array.isArray(value)) return value.map(String);
+  if (value == null) return [];
+  return [String(value)];
+};
+
+const titleFromBody = body => body.match(/^#\s+(.+)$/m)?.[1].trim() ?? null;
+
+const readPosts = async () => {
+  const entries = await readdir(POSTS_DIR);
+  const files = entries.filter(name => name.endsWith('.md'));
+
+  const posts = await Promise.all(
+    files.map(async file => {
+      const slug = file.replace(/\.md$/, '');
+      const { data, content } = matter(
+        await readFile(join(POSTS_DIR, file), 'utf8')
+      );
+
+      return {
+        slug,
+        title: titleFromBody(content) ?? slug,
+        authors: toAuthors(data),
+        date: new Date(data.date).toISOString(),
+        category: data.category ?? null,
+        image: data.image ?? null,
+        ...(data.description && { description: data.description }),
+      };
+    })
+  );
+
+  return posts.sort((a, b) => new Date(b.date) - new Date(a.date));
+};
+
+const posts = await readPosts();
+await mkdir(dirname(OUTPUT), { recursive: true });
+await writeFile(OUTPUT, `${JSON.stringify(posts, null, 2)}\n`);
+console.log(`[blog] wrote ${posts.length} posts to ${OUTPUT}`);

--- a/scripts/html/doc-kit.config.mjs
+++ b/scripts/html/doc-kit.config.mjs
@@ -73,6 +73,7 @@ export default {
 
       '#theme/Sidebar': join(ROOT, 'components/SideBar.jsx'),
       '#theme/sponsors': join(ROOT, 'generated/sponsors.json'),
+      '#theme/blog': join(ROOT, 'generated/blog.json'),
       '#theme/Layout': join(ROOT, 'components/Layout.jsx'),
       '#theme/Navigation': join(ROOT, 'components/NavBar.jsx'),
       '#theme/Footer': join(ROOT, 'components/Footer/index.jsx'),


### PR DESCRIPTION
**Summary**

**1. Data Pipeline (`scripts/data/blogs.mjs`)**
- Automatically adds missing `# H1` tags to prevent the Orama indexer from dropping blog pages.
- Converts descriptions to pure plain text. (need to be more clean)
- Sorts posts by dates descending and prepends an `Overview` link in the generated `site.json`.

**2. UI Components & Layout**
- **`BlogCard`:** Uses a Stretched Link to make the whole card clickable while safely supporting nested GitHub avatar links. Includes a Webpack diamond hover effect.
- **`BlogLayout`:** Wraps the blog grid inside `PartialArticle` to preserve the global Sidebar and Navbar.

**3. Navigation (`pages/site.mjs`)**
- **Sidebar Integration:** Hooks the generated `blogs/site.json` into the root sidebar config to enable correct navigation across `/blogs/*` paths.

**Related issue:** #101 