### PR TITLE
fix: `Support` -> `Sponsors`

### DIFF
--- a/pages/site.json
+++ b/pages/site.json
@@ -18,7 +18,7 @@
     },
     {
       "link": "/about/sponsors",
-      "text": "Support"
+      "text": "Sponsors"
     },
     {
       "link": "https://github.com/webpack/webpack/blob/main/CONTRIBUTING.md",


### PR DESCRIPTION
Looking towards the future, we don't want users to see a "Support" button and assume it's for general support inquiries, not supporting the project itself