### PR TITLE
fix(blog): rely on the source of data instead the props

### DIFF
--- a/layouts/Post/index.jsx
+++ b/layouts/Post/index.jsx
@@ -36,11 +36,10 @@ export default function PostLayout({
   readingTime,
   children,
 }) {
-  const { authors = [], date, category } = metadata;
-
   // `basename` is the slug (filename without extension), matching the listing.
   const index = posts.findIndex(post => post.slug === metadata.basename);
   const current = posts[index];
+  const { authors = [], date, category } = current;
   const next = index > 0 ? posts[index - 1] : undefined;
   const previous = index >= 0 ? posts[index + 1] : undefined;
 


### PR DESCRIPTION
**Summary**

As we rely on the string way in `authors` in `metadata` instead of array way, the `Byline` component didn't appear.
So, instead of using `metadata`, we use the source of truth the JSON `posts` that has the `authors` as array that the `Byline` needs.

**Before:** 

<img width="1360" height="752" alt="image" src="https://github.com/user-attachments/assets/2b8f7533-6ab5-47db-9e00-6720f55071d0" />


**After:**

<img width="1360" height="752" alt="image" src="https://github.com/user-attachments/assets/8302a8b6-d4c6-416b-b45a-d4e5de6147e3" />