### PR TITLE
chore(config): copy static assets using pathsToCopy

### DIFF
--- a/scripts/html/doc-kit.config.mjs
+++ b/scripts/html/doc-kit.config.mjs
@@ -88,4 +88,5 @@ export default {
       },
     },
   },
+  pathsToCopy: ['assets'],
 };

--- a/scripts/html/index.mjs
+++ b/scripts/html/index.mjs
@@ -1,13 +1,6 @@
 import { execFile } from 'node:child_process';
-import { readFile, cp } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { readFile } from 'node:fs/promises';
 import { promisify } from 'node:util';
-
-const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
-
-const ASSETS_SOURCE = join(ROOT, 'assets');
-const ASSETS_DESTINATION = join(ROOT, 'out/assets');
 
 const execFileAsync = promisify(execFile);
 
@@ -44,7 +37,3 @@ for (const version of versions) {
   await runDocKit(version);
 }
 await runDocKit();
-
-// copy assets folder to the out directory
-
-await cp(ASSETS_SOURCE, ASSETS_DESTINATION, { recursive: true });


### PR DESCRIPTION
**Summary**

Instead of manually copying assets, now `nodejs/doc-kit` has option in its config `pathsToCopy` after [PR](https://github.com/nodejs/doc-kit/pull/753).