### PR TITLE
feat(docs): restructure sidebar dropdowns and replace /docs STUB

### DIFF
--- a/pages/docs/index.md
+++ b/pages/docs/index.md
@@ -4,7 +4,7 @@ authors: moshams272
 
 # Documentation
 
-The documentation provides deep technical details on webpack's API, configuration, and ecosystem. Whether you are looking up core features or exploring community tools, you will find everything you need below.
+These pages provide technical details on webpack's API.
 
 - [Webpack](/docs/api/v5.x) — Explore the webpack's core configuration, CLI commands, and APIs.
 - [Loaders](/docs/loaders) — Discover third-party loaders to process CSS, TypeScript, images, and other file types.

--- a/pages/docs/index.md
+++ b/pages/docs/index.md
@@ -1,3 +1,23 @@
 # Documentation
 
-STUB
+The documentation provides deep technical details on webpack's API, configuration, and ecosystem. Whether you are looking up core features or exploring community tools, you will find everything you need below.
+
+### Main Packages
+
+Explore the core configuration, CLI commands, and Node.js API for the latest version of webpack. This is your definitive reference for webpack's built-in capabilities.
+
+[Explore the webpack API!](/docs/api/v5.x)
+
+### Third Party Packages
+
+#### Loaders
+
+Loaders allow webpack to process other types of files and convert them into valid modules. Discover the extensive ecosystem of third-party loaders for CSS, TypeScript, images, and more.
+
+[Discover community loaders!](/docs/loaders/coffee-loader)
+
+#### Plugins
+
+Plugins are the backbone of webpack's architecture. Browse community-maintained plugins that extend webpack's capabilities for build optimization, asset management, and environment injection.
+
+[Browse community plugins!](/docs/plugins/compression-webpack-plugin)

--- a/pages/docs/index.md
+++ b/pages/docs/index.md
@@ -1,3 +1,7 @@
+---
+authors: moshams272
+---
+
 # Documentation
 
 The documentation provides deep technical details on webpack's API, configuration, and ecosystem. Whether you are looking up core features or exploring community tools, you will find everything you need below.

--- a/pages/docs/index.md
+++ b/pages/docs/index.md
@@ -14,10 +14,10 @@ Explore the core configuration, CLI commands, and Node.js API for the latest ver
 
 Loaders allow webpack to process other types of files and convert them into valid modules. Discover the extensive ecosystem of third-party loaders for CSS, TypeScript, images, and more.
 
-[Discover community loaders!](/docs/loaders/coffee-loader)
+[Discover community loaders!](/docs/loaders)
 
 #### Plugins
 
 Plugins are the backbone of webpack's architecture. Browse community-maintained plugins that extend webpack's capabilities for build optimization, asset management, and environment injection.
 
-[Browse community plugins!](/docs/plugins/compression-webpack-plugin)
+[Browse community plugins!](/docs/plugins)

--- a/pages/docs/index.md
+++ b/pages/docs/index.md
@@ -6,22 +6,6 @@ authors: moshams272
 
 The documentation provides deep technical details on webpack's API, configuration, and ecosystem. Whether you are looking up core features or exploring community tools, you will find everything you need below.
 
-### Main Packages
-
-Explore the core configuration, CLI commands, and Node.js API for the latest version of webpack. This is your definitive reference for webpack's built-in capabilities.
-
-[Explore the webpack API!](/docs/api/v5.x)
-
-### Third Party Packages
-
-#### Loaders
-
-Loaders allow webpack to process other types of files and convert them into valid modules. Discover the extensive ecosystem of third-party loaders for CSS, TypeScript, images, and more.
-
-[Discover community loaders!](/docs/loaders)
-
-#### Plugins
-
-Plugins are the backbone of webpack's architecture. Browse community-maintained plugins that extend webpack's capabilities for build optimization, asset management, and environment injection.
-
-[Browse community plugins!](/docs/plugins)
+- [Webpack](/docs/api/v5.x) — Explore the webpack's core configuration, CLI commands, and APIs.
+- [Loaders](/docs/loaders) — Discover third-party loaders to process CSS, TypeScript, images, and other file types.
+- [Plugins](/docs/plugins) — Browse community plugins to extend webpack for build optimization, asset management, and more.

--- a/pages/site.mjs
+++ b/pages/site.mjs
@@ -35,8 +35,10 @@ export const sidebar = {
         },
       ],
     },
-    ...loaders.sidebar,
-    ...plugins.sidebar,
+    {
+      groupName: 'Third Party Packages',
+      items: [...loaders.sidebar, ...plugins.sidebar],
+    },
   ],
   guides: guides.sidebar,
 };

--- a/pages/site.mjs
+++ b/pages/site.mjs
@@ -33,11 +33,9 @@ export const sidebar = {
             link: `/docs/api/v${major(v)}.x`,
           })),
         },
+        ...loaders.sidebar,
+        ...plugins.sidebar,
       ],
-    },
-    {
-      groupName: 'Third Party Packages',
-      items: [...loaders.sidebar, ...plugins.sidebar],
     },
   ],
   guides: guides.sidebar,

--- a/scripts/markdown/readmes.mjs
+++ b/scripts/markdown/readmes.mjs
@@ -70,7 +70,7 @@ const processRepos = async (repos, { label, basePath, outputDir }) => {
   const siteJson = {
     sidebar: [
       {
-        groupName: label,
+        label: label,
         items: fetched.map(name => ({
           link: `${basePath}/${name}`,
           label: name.replace(/-(?:webpack-)?(?:loader|plugin)$/, ''),

--- a/scripts/markdown/readmes.mjs
+++ b/scripts/markdown/readmes.mjs
@@ -71,10 +71,16 @@ const processRepos = async (repos, { label, basePath, outputDir }) => {
     sidebar: [
       {
         label: label,
-        items: fetched.map(name => ({
-          link: `${basePath}/${name}`,
-          label: name.replace(/-(?:webpack-)?(?:loader|plugin)$/, ''),
-        })),
+        items: [
+          {
+            link: basePath,
+            label: 'Overview',
+          },
+          ...fetched.map(name => ({
+            link: `${basePath}/${name}`,
+            label: name.replace(/-(?:webpack-)?(?:loader|plugin)$/, ''),
+          })),
+        ],
       },
     ],
   };


### PR DESCRIPTION
**Summary**

This PR replaces the `STUB` marker in `pages/docs/index.md` and restructures the sidebar.

**Related issue:** #158 