### PR TITLE
fix(theme): improve destructured parameters rendering and flatten lists

### DIFF
--- a/plugins/processor/index.mjs
+++ b/plugins/processor/index.mjs
@@ -52,7 +52,9 @@ export function load(app) {
             );
             param.name = `{ ${destructuredKeys.join(', ')} }`;
           } else if (param.type?.type === 'reference' && param.type.name) {
-            param.name = param.type.name;
+            const interfaceName = param.type.name;
+            param.name =
+              interfaceName[0].toLowerCase() + interfaceName.slice(1);
           } else {
             param.name = 'options';
           }

--- a/plugins/processor/index.mjs
+++ b/plugins/processor/index.mjs
@@ -37,6 +37,28 @@ export function load(app) {
       .getReflectionsByKind(ReflectionKind.Reference)
       .forEach(ref => context.project.removeReflection(ref));
 
+    // Destructured parameters are not supported by TypeDoc, so we rename them to
+    // a more generic name.
+    context.project
+      .getReflectionsByKind(ReflectionKind.Parameter)
+      .forEach(param => {
+        if (param.name.startsWith('__namedParameters')) {
+          if (
+            param.type?.type === 'reflection' &&
+            param.type.declaration?.children
+          ) {
+            const destructuredKeys = param.type.declaration.children.map(
+              child => child.name
+            );
+            param.name = `{ ${destructuredKeys.join(', ')} }`;
+          } else if (param.type?.type === 'reference' && param.type.name) {
+            param.name = param.type.name;
+          } else {
+            param.name = 'options';
+          }
+        }
+      });
+
     applyExportEqualsReflections(context.project);
     applySourceMetadata(context.project);
   });

--- a/plugins/theme/partials/index.mjs
+++ b/plugins/theme/partials/index.mjs
@@ -55,9 +55,7 @@ export default ctx => {
         stability,
         stability && '',
         model.parameters?.length &&
-          ctx.partials.parametersList(model.parameters, {
-            headingLevel: options.headingLevel,
-          }),
+          ctx.partials.parametersList(model.parameters),
         ctx.helpers.typedListItem({
           label: 'Returns',
           type: model.type ?? 'void',
@@ -301,7 +299,22 @@ export default ctx => {
 
     memberTitle: model =>
       getMemberTitle(model, { local: isTypePage(ctx.page.model) }),
-    parametersList: ctx.helpers.typedList,
+    parametersList(parameters) {
+      const flatList = [];
+
+      parameters.forEach(param => {
+        if (
+          param.type?.type === 'reflection' &&
+          param.type.declaration?.children
+        ) {
+          flatList.push(...param.type.declaration.children);
+        } else {
+          flatList.push(param);
+        }
+      });
+
+      return ctx.helpers.typedList(flatList);
+    },
     typeDeclarationList: ctx.helpers.typedList,
     propertiesTable: ctx.helpers.typedList,
 


### PR DESCRIPTION
**Summary**

Developers write functions with object params the TS compiler named that object with “__namedParameters”, so we have 2 scenarios:
 
- They wrote a destruct object.
- That’s interface.

**For destructed objects**, This update intercepts the AST to show the actual destructed keys'names for these parameters and flattens their properties in the documentation to match the project's flat list standard, as it doesn't create the **Attribute** table without be flat list.

**Before:**

<img width="999" height="411" alt="image" src="https://github.com/user-attachments/assets/10a75760-e743-40a8-b919-672cfed8efdf" />

**After:**

<img width="1048" height="538" alt="image" src="https://github.com/user-attachments/assets/9cefb122-6603-45de-aa5e-5559821c5f89" />

***

**For interface**, we just show its name.

**Before:**

<img width="1003" height="350" alt="image" src="https://github.com/user-attachments/assets/e1369668-7cff-4b08-bafc-c88d7ad612d6" />

**After:**


<img width="1003" height="350" alt="image" src="https://github.com/user-attachments/assets/248e1a9a-fb0b-4c51-b5cd-0a71763d84c2" />