### PR TITLE
fix(theme): resolve TS type prefixes

### DIFF
--- a/plugins/theme/partials/types.mjs
+++ b/plugins/theme/partials/types.mjs
@@ -35,10 +35,10 @@ const resolve = type => {
       return resolve(type.elementType ?? type.objectType);
 
     case 'query':
-      return resolve(type.queryType);
+      return `typeof ${resolve(type.queryType)}`;
 
     case 'typeOperator':
-      return resolve(type.target);
+      return `${type.operator} ${resolve(type.target)}`;
 
     case 'conditional':
       return `${resolve(type.trueType)}|${resolve(type.falseType)}`;


### PR DESCRIPTION
**Summary**

Support `query` & `typeOperator` prefixs.

**Note:** This PR **blocked** by `nodejs/doc-kit`'s [PR](https://github.com/nodejs/doc-kit/pull/883)

**Before:**
<img width="612" height="272" alt="image" src="https://github.com/user-attachments/assets/d5d38fd9-c6ed-4221-a83c-28023930d4d3" />

**After:**
<img width="612" height="285" alt="image" src="https://github.com/user-attachments/assets/ef4bdc0a-f55e-4029-9819-7d2530f46a07" />
