### PR TITLE
fix(processor): resolve metadata extraction failure on Vercel

### DIFF
--- a/plugins/processor/source.mjs
+++ b/plugins/processor/source.mjs
@@ -678,6 +678,11 @@ const attachSourceMetadata = (reflection, sourceEntry, exportEntry) => {
   });
 };
 
+const getWebpackPath = () => {
+  const versions = JSON.parse(readFileSync('./versions.json'));
+  return versions ? `./.cache/webpack/${versions[0]}/lib` : `./webpack/lib`;
+};
+
 /**
  * Enrich declaration reflections with comments and source locations recovered
  * from webpack/lib. The declaration file remains authoritative for public API
@@ -686,11 +691,8 @@ const attachSourceMetadata = (reflection, sourceEntry, exportEntry) => {
  * @param {import('typedoc').ProjectReflection} project
  * @param {{ libDir?: string }} [options]
  */
-export const applySourceMetadata = (
-  project,
-  { libDir = './webpack/lib' } = {}
-) => {
-  const absoluteLibDir = resolve(libDir);
+export const applySourceMetadata = project => {
+  const absoluteLibDir = resolve(getWebpackPath());
   if (!existsSync(absoluteLibDir) || !statSync(absoluteLibDir).isDirectory()) {
     return;
   }


### PR DESCRIPTION
**Summary**

The `Edit this page` link works locally well, but in Vercel it doesn't. After debugging, I found in the file `plugins/processor/source.mjs` that:
```js
export const applySourceMetadata = (
  project,
  { libDir = './webpack/lib' } = {}
) => {
  const absoluteLibDir = resolve(libDir);
  if (!existsSync(absoluteLibDir) || !statSync(absoluteLibDir).isDirectory()) {
    return;
  }
...}
```
The `existsSync` function works well locally, as there is a `webpack` repo in the root path, but we don't have it in vercel.

This PR uses the cached repo instead of that one in the root path.