### PR TITLE
fix(theme): prevent empty Type Parameters heading and don't appear in callable interface

### DIFF
--- a/plugins/theme/partials/index.mjs
+++ b/plugins/theme/partials/index.mjs
@@ -209,18 +209,25 @@ export default ctx => {
         );
       }
 
-      if (model.typeParameters?.length) {
-        md.push(
-          heading(
-            options.headingLevel,
-            ReflectionKind.pluralString(ReflectionKind.TypeParameter)
-          )
-        );
-        md.push(
-          ctx.partials.typeParametersList(model.typeParameters, {
+      const signatures = callableSignatures(model);
+      const isCallable = signatures.length > 0;
+
+      if (!isCallable && model.typeParameters?.length) {
+        const typeParametersContent = ctx.partials.typeParametersList(
+          model.typeParameters,
+          {
             headingLevel: options.headingLevel,
-          })
+          }
         );
+        if (typeParametersContent) {
+          md.push(
+            heading(
+              options.headingLevel,
+              ReflectionKind.pluralString(ReflectionKind.TypeParameter)
+            )
+          );
+          md.push(typeParametersContent);
+        }
       }
 
       if (model.implementedTypes?.length) {


### PR DESCRIPTION
**Summary**

TypeDoc stores the function arguments of a Callable Interface inside the `typeParameters` property, that makes no sense as it should under `Call Signature` heading (if it has multiple signatures) not `Type Parameters` heading.

This PR solves that and prevent empty Type Parameters heading.

**Before:**

<img width="1056" height="489" alt="image" src="https://github.com/user-attachments/assets/264fc19a-dbee-4b1c-9690-a50e814d4161" />

<img width="1070" height="447" alt="image" src="https://github.com/user-attachments/assets/ebc8bbf9-ae71-458a-b324-8fed79cc0390" />

**After:**

<img width="1070" height="447" alt="image" src="https://github.com/user-attachments/assets/02f49007-51c4-4c92-a533-34d360a17439" />

<img width="1070" height="447" alt="image" src="https://github.com/user-attachments/assets/b06181f5-03c3-4fda-a2c9-6318c7d4aac2" />



