### PR TITLE
fix(a11y): resolve axe color-contrast and accessible-name failure

### DIFF
--- a/components/HomePage/ConfigSection/index.module.css
+++ b/components/HomePage/ConfigSection/index.module.css
@@ -34,7 +34,7 @@
     font-normal
     uppercase
     tracking-wider
-    text-blue-600
+    text-blue-700
     dark:text-blue-500
     lg:justify-start;
 }
@@ -80,7 +80,7 @@
   @apply mb-4
     text-base
     leading-relaxed
-    text-neutral-600
+    text-neutral-800
     dark:text-neutral-400;
 }
 
@@ -96,7 +96,7 @@
     gap-3
     text-sm
     font-medium
-    text-neutral-700
+    text-neutral-800
     dark:text-neutral-300;
 }
 

--- a/components/HomePage/FeaturesSection/index.module.css
+++ b/components/HomePage/FeaturesSection/index.module.css
@@ -105,6 +105,6 @@
   @apply m-0
     text-sm
     leading-relaxed
-    text-neutral-600
+    text-neutral-800
     dark:text-neutral-400;
 }

--- a/components/HomePage/HomeSponsorSection/index.module.css
+++ b/components/HomePage/HomeSponsorSection/index.module.css
@@ -64,7 +64,7 @@
     font-semibold
     uppercase
     tracking-widest
-    text-neutral-400
+    text-neutral-800
     dark:text-neutral-500;
 }
 

--- a/components/NavBar.jsx
+++ b/components/NavBar.jsx
@@ -29,10 +29,12 @@ export default ({ metadata }) => {
       <ThemeToggle
         onChange={setThemePreference}
         currentTheme={themePreference}
+        ariaLabel="Toggle color theme"
       />
       <a
         href="https://github.com/webpack/webpack"
         className={styles.ghIconWrapper}
+        aria-label="webpack on GitHub"
       >
         <GitHubIcon />
       </a>

--- a/components/SectionHeader/index.module.css
+++ b/components/SectionHeader/index.module.css
@@ -34,6 +34,6 @@
   @apply m-0
     text-base
     leading-relaxed
-    text-neutral-600
+    text-neutral-800
     dark:text-neutral-300;
 }

--- a/components/Sponsors/Card/index.module.css
+++ b/components/Sponsors/Card/index.module.css
@@ -64,7 +64,7 @@
 
 .amount {
   @apply text-xs
-    text-neutral-500
+    text-neutral-800
     dark:text-neutral-400;
 }
 
@@ -72,7 +72,7 @@
   @apply m-0
     text-sm
     leading-relaxed
-    text-neutral-600
+    text-neutral-800
     dark:text-neutral-300;
 }
 

--- a/components/Sponsors/Tier/index.module.css
+++ b/components/Sponsors/Tier/index.module.css
@@ -33,7 +33,7 @@
 .price {
   @apply ml-auto
     text-sm
-    text-neutral-500
+    text-neutral-800
     dark:text-neutral-400;
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
Fixes the visual  contrast of some text.

After
<img width="1612" height="351" alt="image" src="https://github.com/user-attachments/assets/ee21d297-bdbe-4ade-acff-9890950cb91a" />
