### PR TITLE
feat(html): add sitemap generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:md:api": "node scripts/markdown/api/index.mjs && node scripts/markdown/api/configuration.mjs",
     "build:md:readmes": "node scripts/markdown/readmes.mjs",
     "build:md:governance": "node scripts/markdown/governance.mjs",
-    "build:html": "node scripts/html/index.mjs",
+    "build:html": "node scripts/html/index.mjs && node scripts/html/sitemap-index.mjs",
     "build:rss-feed": "node scripts/rss-feed/index.mjs",
     "build": "npm-run-all build:*",
     "lint": "npm-run-all \"lint:!(fix)\"",

--- a/scripts/html/doc-kit.config.mjs
+++ b/scripts/html/doc-kit.config.mjs
@@ -10,7 +10,7 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
 const VERSION = process.env.VERSION;
 const MAJOR_VERSION = VERSION ? `v${major(VERSION)}.x` : undefined;
-const URL_PATH = VERSION ? `/docs/api/${MAJOR_VERSION}` : '/';
+const URL_PATH = VERSION ? `/docs/api/${MAJOR_VERSION}` : '';
 
 const ORIGIN = process.env.VERCEL_URL
   ? `https://${process.env.VERCEL_URL}`
@@ -104,6 +104,10 @@ export default {
         read: createTailwindReader(),
       },
     },
+  },
+  sitemap: {
+    indexURL: '{baseURL}/',
+    pageURL: '{baseURL}{path}.html',
   },
 };
 

--- a/scripts/html/index.mjs
+++ b/scripts/html/index.mjs
@@ -16,6 +16,8 @@ const runDocKit = version =>
       'web',
       '-t',
       'orama-db',
+      '-t',
+      'sitemap',
       '--config-file',
       './scripts/html/doc-kit.config.mjs',
     ],

--- a/scripts/html/sitemap-index.mjs
+++ b/scripts/html/sitemap-index.mjs
@@ -1,0 +1,25 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { major } from 'semver';
+
+const versions = JSON.parse(await readFile('./versions.json', 'utf8'));
+
+const ORIGIN = process.env.VERCEL_URL
+  ? `https://${process.env.VERCEL_URL}`
+  : 'http://localhost:3000';
+
+const sitemaps = [
+  `${ORIGIN}/sitemap.xml`,
+  ...versions.map(
+    version => `${ORIGIN}/docs/api/v${major(version)}.x/sitemap.xml`
+  ),
+];
+
+const sitemapIndex = `<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${sitemaps
+  .map(url => `  <sitemap>\n    <loc>${url}</loc>\n  </sitemap>`)
+  .join('\n')}
+</sitemapindex>
+`;
+
+await writeFile('./out/sitemap-index.xml', sitemapIndex, 'utf8');


### PR DESCRIPTION
**Summary**

This PR enables the sitemap generator plugin in doc-kit and configures the page URLs to produce paths without double slashes.

Fixes #203 