### PR TITLE
fix(blog): remove duplicate category label on post cards

### DIFF
--- a/components/Blog/PostCard/index.jsx
+++ b/components/Blog/PostCard/index.jsx
@@ -18,9 +18,6 @@ export default function PostCard({ post }) {
         tag={post.category}
         alt={post.title}
       />
-      {post.category && (
-        <span className={styles.category}>{post.category}</span>
-      )}
       <h3 className={styles.title}>{post.title}</h3>
       {post.description && <p className={styles.excerpt}>{post.description}</p>}
       <Byline

--- a/components/Blog/PostCard/index.module.css
+++ b/components/Blog/PostCard/index.module.css
@@ -18,16 +18,6 @@
   @apply shadow-md;
 }
 
-.category {
-  @apply mb-2
-    text-xs
-    font-bold
-    tracking-wide
-    uppercase
-    text-blue-600
-    dark:text-blue-400;
-}
-
 .title {
   @apply m-0
     mb-2


### PR DESCRIPTION
**Summary**

Fixes #217

Blog post cards on /blog were showing the category twice, once as a chip on the cover image and again as text below it. This removes the duplicate text label and keeps the chip on the cover.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

No, this is a small ui change.

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

Nothing, no docs update needed.

**Use of AI**

No