### PR TITLE
fix(home): stop config section resizing on tab switch

### DIFF
--- a/components/HomePage/ConfigSection/index.module.css
+++ b/components/HomePage/ConfigSection/index.module.css
@@ -59,7 +59,18 @@
     items-start
     gap-12
     lg:flex-row
-    lg:items-center;
+    lg:items-start;
+}
+
+.configGrid > * {
+  @apply w-full
+    min-w-0
+    lg:flex-1;
+}
+
+.configGrid code {
+  align-content: start;
+  min-height: 11lh;
 }
 
 .features {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
Just  wondering if  we could stop the  config section layout resizing on tab switch 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->
<img width="650" height="358" alt="image" src="https://github.com/user-attachments/assets/fb9a9880-20c0-4f14-8685-f7b7d91ad176" />


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
fix
<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**
no
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
no
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**
no
<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->