### PR TITLE
test(theme): use raw string serializer for markdown snapshots

### DIFF
--- a/tests/theme/theme.test.mjs
+++ b/tests/theme/theme.test.mjs
@@ -41,5 +41,5 @@ test('TypeDoc Theme - Edge Cases Fixture', async t => {
 
   rmSync(outputDir, { recursive: true, force: true });
 
-  t.assert.snapshot(actualMarkdown);
+  t.assert.snapshot(actualMarkdown, { serializers: [val => val] });
 });

--- a/tests/theme/theme.test.mjs.snapshot
+++ b/tests/theme/theme.test.mjs.snapshot
@@ -1,3 +1,275 @@
 exports[`TypeDoc Theme - Edge Cases Fixture 1`] = `
-"# Class: \`webpack.js.org.ExamplesTest\`\\n\\nClass demonstrating the formatting of JSDoc example blocks.\\n\\n## Constructors\\n\\n### \`new ExamplesTest()\`\\n\\n* Returns: {ExamplesTest}\\n\\n## Methods\\n\\n### \`exampleMethod(name)\`\\n\\n* \`name\` {string} A simple string parameter\\n* Returns: {void} \\n\\nA sample method for the ExamplesTest class.\\n\`\`\`ts\\nexampleMethod('example-1');\\n\`\`\`\\n\\n\`\`\`ts\\nexampleMethod('example-2');\\n\`\`\`\\n\\n\\n---\\n\\n# Class: \`webpack.js.org.IndexSignatureTest\`\\n\\nClass demonstrating indexSignature rendering.\\n\\n## Constructors\\n\\n### \`new IndexSignatureTest()\`\\n\\n* Returns: {IndexSignatureTest}\\n\\n## Properties\\n\\n* \`dictionaryProperty\` {{ [key: string]: number }} An object property to trigger indexSignature.\\n\\n\\n---\\n\\n# Class: \`webpack.js.org.MemberGroupsTest\`\\n\\nClass demonstrating Implements and Constructor grouping.\\n\\n## Implements\\n\\n* {WebpackInterface}\\n\\n## Constructors\\n\\n### \`new MemberGroupsTest(data)\`\\n\\n* \`data\` {any} \\n* Returns: {MemberGroupsTest}\\n\\nThe constructor for MemberGroupsTest.\\n\\n## Lifecycle\\n\\n### \`init()\`\\n\\n* Returns: {void}\\n\\nA categorized method.\\n\\n\\n---\\n\\n# Class: \`webpack.js.org.OverloadTest\`\\n\\nClass demonstrating overload signatures.\\n\\n## Constructors\\n\\n### \`new OverloadTest()\`\\n\\n* Returns: {OverloadTest}\\n\\n## Methods\\n\\n### \`overloadMethod(name, count)\`\\n\\n#### Call Signature\\n\\n* \`name\` {string} A simple string parameter\\n* \`count\` {number} A simple number parameter\\n* Returns: {void} \\n\\nFirst overload signature.\\n\\n#### Call Signature\\n\\n* \`isEnabled\` {boolean} A simple boolean parameter\\n* Returns: {string} \\n\\nSecond overload signature.\\n\\n#### Call Signature\\n\\n* \`id\` {number} A simple string parameter\\n* \`isEnabled\` {boolean} A simple boolean parameter\\n* Returns: {void} \\n\\nThird overload signature.\\n\\n\\n---\\n\\n# Class: \`webpack.js.org.StabilityTest\`\\n\\nClass demonstrating stability for deprecated, experimental, and legacy APIs.\\n\\n## Constructors\\n\\n### \`new StabilityTest()\`\\n\\n* Returns: {StabilityTest}\\n\\n## Methods\\n\\n### \`deprecatedMethod()\`\\n\\n> Stability: 0 - Deprecated: Use the new API instead.\\n\\n* Returns: {void}\\n\\n***\\n\\n### \`experimentalMethod()\`\\n\\n> Stability: 1 - Experimental\\n\\n* Returns: {void}\\n\\n**\`Experimental\`**\\n\\n***\\n\\n### \`legacyMethod()\`\\n\\n> Stability: 3 - Legacy: This is a legacy Webpack v4 API.\\n\\n* Returns: {void}\\n\\n\\n---\\n\\n# Class: \`webpack.js.org.TypedListTest\`\\n\\nClass demonstrating properties and typed lists.\\n\\n* Extends: {WebpackTest}\\n\\n## Constructors\\n\\n### \`new TypedListTest()\`\\n\\n* Returns: {TypedListTest}\\n\\n## Properties\\n\\n* \`typedListProperty\` {string} A sample property for the TypedListTest class.\\n\\n## Methods\\n\\n### \`typedListMethod(name, count)\`\\n\\n* \`name\` {string} The name of the instance\\n* \`count\` {number} The count of items\\n* Returns: {boolean} A boolean indicating success\\n\\nA sample method for the TypedListTest class.\\n\\n\\n---\\n\\n# Class: \`webpack.js.org.WebpackInterface\`\\n\\n**\`Interface\`**\\n\\nInterface demonstrating Webpack as an interface.\\n\\n## Constructors\\n\\n### \`new WebpackInterface()\`\\n\\n* Returns: {WebpackInterface}\\n\\n\\n---\\n\\n# Class: \`webpack.js.org.WebpackTest\`\\n\\nClass demonstrating Webpack as a parent class.\\n\\n## Constructors\\n\\n### \`new WebpackTest()\`\\n\\n* Returns: {WebpackTest}\\n\\n\\n---\\n\\n# \`webpack\` Types\\n\\nThese types are not exported by webpack, but they are available to TypeScript consumers.\\n\\n## Type: \`ComplexArrayType\`\\n\\n* Type: {{ age: number; name: string }[]}\\n\\nComplex array type.\\n\\n### Type Declaration\\n\\n* \`age\` {number}\\n* \`name\` {string}\\n\\n***\\n\\n## Type: \`ComplexIntersectionType\`\\n\\n* Type: {{ id: string } & { metadata: object }}\\n\\nComplex intersection type.\\n\\n### Type Declaration\\n\\n* \`id\` {string}\\n\\n### Type Declaration\\n\\n* \`metadata\` {object}\\n\\n***\\n\\n## Type: \`ComplexUnionType\`\\n\\n* Type: {string | { advanced: boolean; timeout: number }}\\n\\nComplex union type.\\n\\n***\\n\\n## Type: \`SimpleArrayType\`\\n\\n* Type: {string[]}\\n\\nSimple array type.\\n\\n***\\n\\n## Type: \`SimpleIntersectionType\`\\n\\n* Type: {number & string}\\n\\nSimple intersection type.\\n\\n***\\n\\n## Type: \`SimpleUnionType\`\\n\\n* Type: {string | number}\\n\\nSimple union type.\\n"
+# Class: \`webpack.js.org.ExamplesTest\`
+
+Class demonstrating the formatting of JSDoc example blocks.
+
+## Constructors
+
+### \`new ExamplesTest()\`
+
+* Returns: {ExamplesTest}
+
+## Methods
+
+### \`exampleMethod(name)\`
+
+* \`name\` {string} A simple string parameter
+* Returns: {void} 
+
+A sample method for the ExamplesTest class.
+\`\`\`ts
+exampleMethod('example-1');
+\`\`\`
+
+\`\`\`ts
+exampleMethod('example-2');
+\`\`\`
+
+
+---
+
+# Class: \`webpack.js.org.IndexSignatureTest\`
+
+Class demonstrating indexSignature rendering.
+
+## Constructors
+
+### \`new IndexSignatureTest()\`
+
+* Returns: {IndexSignatureTest}
+
+## Properties
+
+* \`dictionaryProperty\` {{ [key: string]: number }} An object property to trigger indexSignature.
+
+
+---
+
+# Class: \`webpack.js.org.MemberGroupsTest\`
+
+Class demonstrating Implements and Constructor grouping.
+
+## Implements
+
+* {WebpackInterface}
+
+## Constructors
+
+### \`new MemberGroupsTest(data)\`
+
+* \`data\` {any} 
+* Returns: {MemberGroupsTest}
+
+The constructor for MemberGroupsTest.
+
+## Lifecycle
+
+### \`init()\`
+
+* Returns: {void}
+
+A categorized method.
+
+
+---
+
+# Class: \`webpack.js.org.OverloadTest\`
+
+Class demonstrating overload signatures.
+
+## Constructors
+
+### \`new OverloadTest()\`
+
+* Returns: {OverloadTest}
+
+## Methods
+
+### \`overloadMethod(name, count)\`
+
+#### Call Signature
+
+* \`name\` {string} A simple string parameter
+* \`count\` {number} A simple number parameter
+* Returns: {void} 
+
+First overload signature.
+
+#### Call Signature
+
+* \`isEnabled\` {boolean} A simple boolean parameter
+* Returns: {string} 
+
+Second overload signature.
+
+#### Call Signature
+
+* \`id\` {number} A simple string parameter
+* \`isEnabled\` {boolean} A simple boolean parameter
+* Returns: {void} 
+
+Third overload signature.
+
+
+---
+
+# Class: \`webpack.js.org.StabilityTest\`
+
+Class demonstrating stability for deprecated, experimental, and legacy APIs.
+
+## Constructors
+
+### \`new StabilityTest()\`
+
+* Returns: {StabilityTest}
+
+## Methods
+
+### \`deprecatedMethod()\`
+
+> Stability: 0 - Deprecated: Use the new API instead.
+
+* Returns: {void}
+
+***
+
+### \`experimentalMethod()\`
+
+> Stability: 1 - Experimental
+
+* Returns: {void}
+
+**\`Experimental\`**
+
+***
+
+### \`legacyMethod()\`
+
+> Stability: 3 - Legacy: This is a legacy Webpack v4 API.
+
+* Returns: {void}
+
+
+---
+
+# Class: \`webpack.js.org.TypedListTest\`
+
+Class demonstrating properties and typed lists.
+
+* Extends: {WebpackTest}
+
+## Constructors
+
+### \`new TypedListTest()\`
+
+* Returns: {TypedListTest}
+
+## Properties
+
+* \`typedListProperty\` {string} A sample property for the TypedListTest class.
+
+## Methods
+
+### \`typedListMethod(name, count)\`
+
+* \`name\` {string} The name of the instance
+* \`count\` {number} The count of items
+* Returns: {boolean} A boolean indicating success
+
+A sample method for the TypedListTest class.
+
+
+---
+
+# Class: \`webpack.js.org.WebpackInterface\`
+
+**\`Interface\`**
+
+Interface demonstrating Webpack as an interface.
+
+## Constructors
+
+### \`new WebpackInterface()\`
+
+* Returns: {WebpackInterface}
+
+
+---
+
+# Class: \`webpack.js.org.WebpackTest\`
+
+Class demonstrating Webpack as a parent class.
+
+## Constructors
+
+### \`new WebpackTest()\`
+
+* Returns: {WebpackTest}
+
+
+---
+
+# \`webpack\` Types
+
+These types are not exported by webpack, but they are available to TypeScript consumers.
+
+## Type: \`ComplexArrayType\`
+
+* Type: {{ age: number; name: string }[]}
+
+Complex array type.
+
+### Type Declaration
+
+* \`age\` {number}
+* \`name\` {string}
+
+***
+
+## Type: \`ComplexIntersectionType\`
+
+* Type: {{ id: string } & { metadata: object }}
+
+Complex intersection type.
+
+### Type Declaration
+
+* \`id\` {string}
+
+### Type Declaration
+
+* \`metadata\` {object}
+
+***
+
+## Type: \`ComplexUnionType\`
+
+* Type: {string | { advanced: boolean; timeout: number }}
+
+Complex union type.
+
+***
+
+## Type: \`SimpleArrayType\`
+
+* Type: {string[]}
+
+Simple array type.
+
+***
+
+## Type: \`SimpleIntersectionType\`
+
+* Type: {number & string}
+
+Simple intersection type.
+
+***
+
+## Type: \`SimpleUnionType\`
+
+* Type: {string | number}
+
+Simple union type.
+
 `;


### PR DESCRIPTION
**Summary**

Improves Developer Experience (DX) by making generated markdown snapshots human-readable.

**Details**

By default, the `node:test` snapshot serializes strings by escaping `\n`. Because of this, the entire markdown output is compressed into a single line. When a snapshot test fails, the resulting line-diff is big and hard to read, looking like this:

<img width="1847" height="1000" alt="image" src="https://github.com/user-attachments/assets/64c0244d-debe-47ef-98be-0e0ed1f89123" />

By overriding the default serializer with `(val) => val`, we prevent this escaping behavior. The snapshots are now saved as raw multi-line strings. Now, when a test fails, the diff correctly highlights only the specific lines that changed, looking like this:

<img width="1847" height="1000" alt="image" src="https://github.com/user-attachments/assets/f31603b4-725c-4857-842e-4523982299c6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated snapshot comparisons to use consistent Markdown serialization.
  * Reformatted expected documentation output for improved readability while preserving the documented content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->