### PR TITLE
test(theme): expand test fixtures to cover default TypeDoc reflections

### DIFF
--- a/tests/theme/fixtures/input.js
+++ b/tests/theme/fixtures/input.js
@@ -127,10 +127,10 @@ export class TypedListTest extends WebpackTest {
  */
 
 /**
- * Variable demonstrating declarationTitle formatting.
+ * A standalone constant demonstrating declarationTitle formatting and variable rendering.
  * @type {string}
  */
-export const declarationTitleTest = 'pass me';
+export const CONSTANT_AND_DECLARATION_TITLE_TEST = 'pass me';
 
 /**
  * Class demonstrating indexSignature rendering.
@@ -160,3 +160,59 @@ export class MemberGroupsTest {
    */
   init() {}
 }
+
+/**
+ * A simple enum demonstrating enum rendering.
+ * @enum {number}
+ */
+export const EnumTest = {
+  /** The first option */
+  ONE: 1,
+  /** The second option */
+  TWO: 2,
+};
+
+/**
+ * A standalone function demonstrating generics outside a class.
+ * @template T
+ * @param {T} value The input value
+ * @returns {T} The same value
+ */
+export function standAloneWithGenericsTest(value) {
+  return value;
+}
+
+/**
+ * Class demonstrating Getters and Setters (Accessors).
+ */
+export class AccessorTest {
+  /**
+   * Gets the current configuration name.
+   * @returns {string}
+   */
+  get configName() {
+    return '';
+  }
+
+  /**
+   * Sets the configuration name.
+   * @param {string} val The new name
+   */
+  set configName(val) {}
+}
+
+/**
+ * A namespace demonstrating nested members.
+ * @namespace
+ */
+export const WebpackUtils = {
+  /**
+   * Merges two configurations.
+   * @param {object} a First config
+   * @param {object} b Second config
+   * @returns {object} Merged config
+   */
+  merge(a, b) {
+    return Object.assign({}, a, b);
+  },
+};

--- a/tests/theme/theme.test.mjs
+++ b/tests/theme/theme.test.mjs
@@ -27,8 +27,8 @@ test('TypeDoc Theme - Edge Cases Fixture', async t => {
   const project = await app.convert();
   await app.generateOutputs(project);
 
-  const mdFiles = readdirSync(outputDir, { recursive: true }).filter(
-    f => f.endsWith('.md') && !f.endsWith('index.md')
+  const mdFiles = readdirSync(outputDir, { recursive: true }).filter(f =>
+    f.endsWith('.md')
   );
 
   if (mdFiles.length === 0) throw new Error('No markdown file generated');

--- a/tests/theme/theme.test.mjs.snapshot
+++ b/tests/theme/theme.test.mjs.snapshot
@@ -1,4 +1,36 @@
 exports[`TypeDoc Theme - Edge Cases Fixture 1`] = `
+# Class: \`webpack.js.org.AccessorTest\`
+
+Class demonstrating Getters and Setters (Accessors).
+
+## Constructors
+
+### \`new AccessorTest()\`
+
+* Returns: {AccessorTest}
+
+## Properties
+
+* \`configName\` {string} Gets the current configuration name.
+
+
+---
+
+# \`webpack.js.org.EnumTest\`
+
+## \`ONE\`
+
+* Type: {number}
+
+***
+
+## \`TWO\`
+
+* Type: {number}
+
+
+---
+
 # Class: \`webpack.js.org.ExamplesTest\`
 
 Class demonstrating the formatting of JSDoc example blocks.
@@ -209,6 +241,56 @@ Class demonstrating Webpack as a parent class.
 
 ---
 
+# \`webpack.js.org.WebpackUtils\`
+
+## \`merge(a, b)\`
+
+* \`a\` {object} First config
+* \`b\` {object} Second config
+* Returns: {object} Merged config
+
+Merges two configurations.
+
+
+---
+
+# \`webpack.js.org\`
+
+## Namespaces
+
+- [EnumTest](/EnumTest.md)
+- [WebpackUtils](/WebpackUtils.md)
+
+## Classes
+
+- [AccessorTest](/AccessorTest.md)
+- [ExamplesTest](/ExamplesTest.md)
+- [IndexSignatureTest](/IndexSignatureTest.md)
+- [MemberGroupsTest](/MemberGroupsTest.md)
+- [OverloadTest](/OverloadTest.md)
+- [StabilityTest](/StabilityTest.md)
+- [TypedListTest](/TypedListTest.md)
+- [WebpackInterface](/WebpackInterface.md)
+- [WebpackTest](/WebpackTest.md)
+
+## \`webpack.js.org.CONSTANT_AND_DECLARATION_TITLE_TEST\`
+
+* Type: {string}
+
+A standalone constant demonstrating declarationTitle formatting and variable rendering.
+
+***
+
+## \`webpack.js.org.standAloneWithGenericsTest(value)\`
+
+* \`value\` {T} The input value
+* Returns: {T} The same value
+
+A standalone function demonstrating generics outside a class.
+
+
+---
+
 # \`webpack\` Types
 
 These types are not exported by webpack, but they are available to TypeScript consumers.
@@ -247,6 +329,14 @@ Complex intersection type.
 * Type: {string | { advanced: boolean; timeout: number }}
 
 Complex union type.
+
+***
+
+## Type: \`EnumTest\`
+
+* Type: {number}
+
+A simple enum demonstrating enum rendering.
 
 ***
 


### PR DESCRIPTION
**Summary**

This PR expands the theme tests to cover common TypeDoc reflections (e.g., Enums, Namespaces, Accessors, Standalone Functions) that are handled by default TypeDoc partials and helpers. This **prevents poorly written overrides from passing the tests silently**, while actually breaking the generated Markdown in production.

**Note:** While `@enum` and `@namespace` are not currently used in the `webpack` source code, adding them to the tests ensures our documentation theme remains safe.

**Use of AI**

To investigate the important reflections in TypeDoc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded theme coverage for numeric enums, generic functions, constants, accessors, namespaces, and merge utilities.
  * Added snapshot validation for namespace index pages and generated `index.md` files.
  * Updated expected documentation output to include the newly supported declaration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->